### PR TITLE
Fixed item quantity bug in shirts.xml.json

### DIFF
--- a/data/irregular/oliveira2000/shirts_2007-05-15/shirts.xml.json
+++ b/data/irregular/oliveira2000/shirts_2007-05-15/shirts.xml.json
@@ -482,7 +482,7 @@
         },
         {
             "type": "general",
-            "copies": 1,
+            "copies": 15,
             "allowed_rotations": [
                 {
                     "start": 0.0,

--- a/data/irregular_raw/oliveira2000/shirts_2007-05-15/shirts.xml
+++ b/data/irregular_raw/oliveira2000/shirts_2007-05-15/shirts.xml
@@ -41,7 +41,7 @@
 				</orientation>
 				<component idPolygon="polygon4" type="0" xOffset="0" yOffset="0" />
 			</piece>
-			<piece id="piece4" quantity="1">
+			<piece id="piece4" quantity="15">
 				<orientation>
 					<enumeration angle="0" />
 					<enumeration angle="180" />


### PR DESCRIPTION
Fixed a bug with the quantity of one of the items in the shirts benchmark instance. 
It is supposed to have 99 items in total.

Before:
```
Instance
--------
Objective:                    OpenDimensionX
Number of item types:         8
Number of items:              85
Number of bin types:          1
```

After:
```
Instance
--------
Objective:                    OpenDimensionX
Number of item types:         8
Number of items:              99
Number of bin types:          1
```