### PR TITLE
Add missing comma in rectangle::Instance.write method

### DIFF
--- a/src/rectangle/instance.cpp
+++ b/src/rectangle/instance.cpp
@@ -415,6 +415,6 @@ void Instance::write(
     }
     f_parameters << "NAME,VALUE" << std::endl
         << "objective," << objective() << std::endl
-        << "unloading_constraint" << unloading_constraint() << std::endl;
+        << "unloading_constraint," << unloading_constraint() << std::endl;
 
 }


### PR DESCRIPTION
Add missing comma in the rectangle::Instance.write method.