### PR TITLE
irregular: keep rigid-shifted bin when LP anchor throws on FP precision

### DIFF
--- a/src/irregular/linear_programming.cpp
+++ b/src/irregular/linear_programming.cpp
@@ -642,17 +642,21 @@ LinearProgrammingAnchorOutput packingsolver::irregular::linear_programming_ancho
         const SolutionBin& solution_bin = initial_solution.bin(bin_pos);
         Solution initial_solution_cur(instance);
         initial_solution_cur.append(initial_solution, bin_pos, 1);
-        Solution new_solution_cur = ::linear_programming_anchor(
-                instance,
-                initial_solution_cur,
-                x_weight,
-                y_weight,
-                parameters,
-                icd);
-        solution.append(
-                new_solution_cur,
-                0,
-                solution_bin.copies);
+        // Contingency: LP anchor occasionally throws on FP-precision violations
+        // (value just below -1e-6 tolerance). Keep the rigid-shifted bin instead
+        // of crashing the whole process.
+        try {
+            Solution new_solution_cur = ::linear_programming_anchor(
+                    instance,
+                    initial_solution_cur,
+                    x_weight,
+                    y_weight,
+                    parameters,
+                    icd);
+            solution.append(new_solution_cur, 0, solution_bin.copies);
+        } catch (const std::exception&) {
+            solution.append(initial_solution, bin_pos, solution_bin.copies);
+        }
     }
     //initial_solution.format(std::cout, 1);
     //solution.format(std::cout, 1);


### PR DESCRIPTION
linear_programming_anchor() iterates per-bin and calls find_best_edge_separator for verification. On dense layouts the LP solver returns positions whose post-verification value is just below the -1e-6 tolerance (e.g. -1e-5), causing a std::logic_error that aborts the entire process.

Wrap the per-bin call in a try/catch: on failure, fall back to the rigid-shifted bin produced by compute_shifted_solution() (already a valid feasible solution). Other bins still receive full LP polish.

No behavior change on success path. No tolerance/threshold changes.