### PR TITLE
Harden thread/async robustness in optimize and formatters

### DIFF
--- a/include/packingsolver/algorithms/common.hpp
+++ b/include/packingsolver/algorithms/common.hpp
@@ -12,11 +12,42 @@
 #include <cstdint>
 #include <set>
 #include <iomanip>
+#include <thread>
+#include <vector>
 
 namespace packingsolver
 {
 
 const double PSTOL = 1 + 1e-9;
+
+/**
+ * RAII guard that joins a vector of threads on scope exit.
+ *
+ * The 'optimize' functions create a set of worker threads and then join them
+ * explicitly in a loop.  If an exception is thrown (e.g. 'std::bad_alloc' from
+ * a container operation, or a failure while spawning a thread) after some
+ * threads have already been created but before the explicit join loop runs,
+ * the 'std::vector<std::thread>' would be destroyed while still holding
+ * joinable threads, which calls 'std::terminate()'.
+ *
+ * Declaring a 'ThreadJoinGuard' right after the thread vector guarantees that
+ * any still-joinable thread is joined during stack unwinding.  On the normal
+ * path the explicit join loop has already joined every thread, so the guard's
+ * destructor is a no-op and behavior is unchanged.
+ */
+struct ThreadJoinGuard
+{
+    std::vector<std::thread>& threads;
+
+    ThreadJoinGuard(std::vector<std::thread>& threads): threads(threads) { }
+
+    ~ThreadJoinGuard()
+    {
+        for (std::thread& thread: threads)
+            if (thread.joinable())
+                thread.join();
+    }
+};
 
 using Seed = int64_t;
 using Counter = int64_t;

--- a/src/box/algorithm_formatter.cpp
+++ b/src/box/algorithm_formatter.cpp
@@ -233,14 +233,15 @@ void AlgorithmFormatter::update_solution(
         const Solution& solution,
         const std::string& s)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
     output_.time = parameters_.timer.elapsed_time();
     int new_best = output_.solution_pool.add(solution);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (new_best == 1) {
         print(s);
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (instance_.objective() == Objective::BinPacking) {
@@ -254,45 +255,68 @@ void AlgorithmFormatter::update_solution(
             }
         }
 
+        // Take a snapshot of the output so the (potentially heavy, file-I/O
+        // performing) callback can run outside the critical section.
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    // Invoke the callback outside the lock so that file I/O performed by it
+    // does not serialize the worker threads.
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::update_knapsack_bound(
         Profit profit)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (profit < output_.knapsack_bound) {
         output_.knapsack_bound = profit;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
             end_ = true;
         }
+
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::update_bin_packing_bound(
         BinPos number_of_bins)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (number_of_bins > output_.bin_packing_bound) {
         output_.bin_packing_bound = number_of_bins;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (output_.solution_pool.best().full()
                 && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
             end_ = true;
         }
+
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::end()

--- a/src/box/optimize.cpp
+++ b/src/box/optimize.cpp
@@ -89,6 +89,7 @@ void optimize_tree_search(
     }
 
     std::vector<std::thread> threads;
+    ThreadJoinGuard thread_join_guard(threads);
     std::forward_list<std::exception_ptr> exception_ptr_list;
     for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
         if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
@@ -177,6 +178,7 @@ void optimize_tree_search_maximal_spaces(
     }
 
     std::vector<std::thread> threads;
+    ThreadJoinGuard thread_join_guard(threads);
     std::forward_list<std::exception_ptr> exception_ptr_list;
     for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
         if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
@@ -620,6 +622,7 @@ packingsolver::box::Output packingsolver::box::optimize(
 
     // Run selected algorithms.
     std::vector<std::thread> threads;
+    ThreadJoinGuard thread_join_guard(threads);
     std::forward_list<std::exception_ptr> exception_ptr_list;
     // Tree search.
     if (use_tree_search) {

--- a/src/boxstacks/algorithm_formatter.cpp
+++ b/src/boxstacks/algorithm_formatter.cpp
@@ -233,14 +233,15 @@ void AlgorithmFormatter::update_solution(
         const Solution& solution,
         const std::string& s)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
     output_.time = parameters_.timer.elapsed_time();
     int new_best = output_.solution_pool.add(solution);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (new_best == 1) {
         print(s);
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (instance_.objective() == Objective::BinPacking) {
@@ -254,8 +255,17 @@ void AlgorithmFormatter::update_solution(
             }
         }
 
+        // Take a snapshot of the output so the (potentially heavy, file-I/O
+        // performing) callback can run outside the critical section.
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    // Invoke the callback outside the lock so that file I/O performed by it
+    // does not serialize the worker threads.
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::end()

--- a/src/boxstacks/optimize.cpp
+++ b/src/boxstacks/optimize.cpp
@@ -171,6 +171,7 @@ packingsolver::boxstacks::Output packingsolver::boxstacks::optimize(
             }
 
             std::vector<std::thread> threads;
+            ThreadJoinGuard thread_join_guard(threads);
             std::forward_list<std::exception_ptr> exception_ptr_list;
             for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
                 ibs_parameters_list[i].new_solution_callback

--- a/src/irregular/algorithm_formatter.cpp
+++ b/src/irregular/algorithm_formatter.cpp
@@ -248,14 +248,15 @@ void AlgorithmFormatter::update_solution(
         const Solution& solution,
         const std::string& s)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
     output_.time = parameters_.timer.elapsed_time();
     int new_best = output_.solution_pool.add(solution);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (new_best == 1) {
         print(s);
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (instance_.objective() == Objective::Knapsack) {
@@ -273,64 +274,94 @@ void AlgorithmFormatter::update_solution(
             }
         }
 
+        // Take a snapshot of the output so the (potentially heavy, file-I/O
+        // performing) callback can run outside the critical section.
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    // Invoke the callback outside the lock so that file I/O performed by it
+    // does not serialize the worker threads.
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::update_knapsack_bound(
         Profit profit)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (profit < output_.knapsack_bound) {
         output_.knapsack_bound = profit;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
             end_ = true;
         }
+
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::update_bin_packing_bound(
         BinPos number_of_bins)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (number_of_bins > output_.bin_packing_bound) {
         output_.bin_packing_bound = number_of_bins;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (output_.solution_pool.best().full()
                 && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
             end_ = true;
         }
+
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
         Profit cost)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (cost > output_.variable_sized_bin_packing_bound) {
         output_.variable_sized_bin_packing_bound = cost;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (output_.solution_pool.best().full()
                 && output_.variable_sized_bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
             end_ = true;
         }
+
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::end()

--- a/src/irregular/optimize.cpp
+++ b/src/irregular/optimize.cpp
@@ -340,6 +340,7 @@ void optimize_tree_search(
     }
 
     std::vector<std::thread> threads;
+    ThreadJoinGuard thread_join_guard(threads);
     std::forward_list<std::exception_ptr> exception_ptr_list;
     for (Counter i = 0; i < (Counter)branching_scheme_parameters_list.size(); ++i) {
         std::function<void(const Solution&, const std::string&)> new_solution_callback;
@@ -945,6 +946,7 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
 
     // Run selected algorithms.
     std::vector<std::thread> threads;
+    ThreadJoinGuard thread_join_guard(threads);
     std::forward_list<std::exception_ptr> exception_ptr_list;
     // Tree search.
     if (use_tree_search) {

--- a/src/onedimensional/algorithm_formatter.cpp
+++ b/src/onedimensional/algorithm_formatter.cpp
@@ -197,14 +197,15 @@ void AlgorithmFormatter::update_solution(
         const Solution& solution,
         const std::string& s)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
     output_.time = parameters_.timer.elapsed_time();
     int new_best = output_.solution_pool.add(solution);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (new_best == 1) {
         print(s);
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (instance_.objective() == Objective::Knapsack) {
@@ -226,64 +227,95 @@ void AlgorithmFormatter::update_solution(
                 end_ = true;
             }
         }
+
+        // Take a snapshot of the output so the (potentially heavy, file-I/O
+        // performing) callback can run outside the critical section.
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    // Invoke the callback outside the lock so that file I/O performed by it
+    // does not serialize the worker threads.
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::update_knapsack_bound(
         Profit profit)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (profit < output_.knapsack_bound) {
         output_.knapsack_bound = profit;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
             end_ = true;
         }
+
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::update_bin_packing_bound(
         BinPos number_of_bins)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (number_of_bins > output_.bin_packing_bound) {
         output_.bin_packing_bound = number_of_bins;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (output_.solution_pool.best().full()
                 && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
             end_ = true;
         }
+
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
         Profit cost)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (cost > output_.variable_sized_bin_packing_bound) {
         output_.variable_sized_bin_packing_bound = cost;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (output_.solution_pool.best().full()
                 && equal(output_.variable_sized_bin_packing_bound, output_.solution_pool.best().cost())) {
             end_ = true;
         }
+
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::end()

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -138,6 +138,7 @@ void optimize_tree_search(
     }
 
     std::vector<std::thread> threads;
+    ThreadJoinGuard thread_join_guard(threads);
     std::forward_list<std::exception_ptr> exception_ptr_list;
     for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
         if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
@@ -582,6 +583,7 @@ packingsolver::onedimensional::Output packingsolver::onedimensional::optimize(
 
     // Run selected algorithms.
     std::vector<std::thread> threads;
+    ThreadJoinGuard thread_join_guard(threads);
     std::forward_list<std::exception_ptr> exception_ptr_list;
     // Tree search.
     if (use_tree_search) {

--- a/src/rectangle/algorithm_formatter.cpp
+++ b/src/rectangle/algorithm_formatter.cpp
@@ -233,14 +233,15 @@ void AlgorithmFormatter::update_solution(
         const Solution& solution,
         const std::string& s)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
     output_.time = parameters_.timer.elapsed_time();
     int new_best = output_.solution_pool.add(solution);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (new_best == 1) {
         print(s);
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (instance_.objective() == Objective::Knapsack) {
@@ -258,45 +259,68 @@ void AlgorithmFormatter::update_solution(
             }
         }
 
+        // Take a snapshot of the output so the (potentially heavy, file-I/O
+        // performing) callback can run outside the critical section.
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    // Invoke the callback outside the lock so that file I/O performed by it
+    // does not serialize the worker threads.
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::update_knapsack_bound(
         Profit profit)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (profit < output_.knapsack_bound) {
         output_.knapsack_bound = profit;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
             end_ = true;
         }
+
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::update_bin_packing_bound(
         BinPos number_of_bins)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (number_of_bins > output_.bin_packing_bound) {
         output_.bin_packing_bound = number_of_bins;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (output_.solution_pool.best().full()
                 && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
             end_ = true;
         }
+
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::end()

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -110,6 +110,7 @@ void optimize_tree_search(
     }
 
     std::vector<std::thread> threads;
+    ThreadJoinGuard thread_join_guard(threads);
     std::forward_list<std::exception_ptr> exception_ptr_list;
     for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
         if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
@@ -591,6 +592,7 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
 
     // Run selected algorithms.
     std::vector<std::thread> threads;
+    ThreadJoinGuard thread_join_guard(threads);
     std::forward_list<std::exception_ptr> exception_ptr_list;
     // Tree search.
     if (use_tree_search) {

--- a/src/rectangleguillotine/algorithm_formatter.cpp
+++ b/src/rectangleguillotine/algorithm_formatter.cpp
@@ -236,14 +236,15 @@ void AlgorithmFormatter::update_solution(
         const Solution& solution,
         const std::string& s)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
     output_.time = parameters_.timer.elapsed_time();
     int new_best = output_.solution_pool.add(solution);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (new_best == 1) {
         print(s);
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (instance_.objective() == Objective::BinPacking) {
@@ -257,64 +258,94 @@ void AlgorithmFormatter::update_solution(
             }
         }
 
+        // Take a snapshot of the output so the (potentially heavy, file-I/O
+        // performing) callback can run outside the critical section.
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    // Invoke the callback outside the lock so that file I/O performed by it
+    // does not serialize the worker threads.
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::update_knapsack_bound(
         Profit profit)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (profit < output_.knapsack_bound) {
         output_.knapsack_bound = profit;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
             end_ = true;
         }
+
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::update_bin_packing_bound(
         BinPos number_of_bins)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (number_of_bins > output_.bin_packing_bound) {
         output_.bin_packing_bound = number_of_bins;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (output_.solution_pool.best().full()
                 && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
             end_ = true;
         }
+
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
         Profit cost)
 {
-    mutex_.lock();
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool callback = false;
+    packingsolver::Output<Instance, Solution> output_snapshot(instance_);
     if (cost > output_.variable_sized_bin_packing_bound) {
         output_.variable_sized_bin_packing_bound = cost;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
-        parameters_.new_solution_callback(output_);
 
         // Check optimality.
         if (output_.solution_pool.best().full()
                 && equal(output_.variable_sized_bin_packing_bound, output_.solution_pool.best().cost())) {
             end_ = true;
         }
+
+        output_snapshot = output_;
+        callback = true;
     }
-    mutex_.unlock();
+    lock.unlock();
+
+    if (callback)
+        parameters_.new_solution_callback(output_snapshot);
 }
 
 void AlgorithmFormatter::end()

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -123,6 +123,7 @@ void optimize_tree_search(
     }
 
     std::vector<std::thread> threads;
+    ThreadJoinGuard thread_join_guard(threads);
     std::forward_list<std::exception_ptr> exception_ptr_list;
     for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
         if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
@@ -625,6 +626,7 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
 
     // Run selected algorithms.
     std::vector<std::thread> threads;
+    ThreadJoinGuard thread_join_guard(threads);
     std::forward_list<std::exception_ptr> exception_ptr_list;
     // Tree search.
     if (use_tree_search) {


### PR DESCRIPTION
Hardens thread and async handling across the optimize entry points and algorithm formatters (box, boxstacks, irregular, onedimensional, rectangle, rectangleguillotine) to avoid races and lost results under concurrency.