### PR TITLE
Rename branching_scheme* to tree_search* and add tree_search() functions

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -9,8 +9,8 @@ target_sources(PackingSolver_box PRIVATE
     optimize.cpp
     post_process.cpp
     block.cpp
-    branching_scheme.cpp
-    branching_scheme_maximal_spaces.cpp)
+    tree_search.cpp
+    tree_search_maximal_spaces.cpp)
 target_include_directories(PackingSolver_box PUBLIC
     ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(PackingSolver_box PRIVATE

--- a/src/box/optimize.cpp
+++ b/src/box/optimize.cpp
@@ -2,14 +2,12 @@
 
 #include "packingsolver/box/algorithm_formatter.hpp"
 #include "packingsolver/box/instance_builder.hpp"
-#include "box/branching_scheme.hpp"
-#include "box/branching_scheme_maximal_spaces.hpp"
+#include "box/tree_search.hpp"
+#include "box/tree_search_maximal_spaces.hpp"
 #include "algorithms/dichotomic_search.hpp"
 #include "algorithms/sequential_value_correction.hpp"
 #include "algorithms/column_generation.hpp"
 
-#include "treesearchsolver/iterative_beam_search_2.hpp"
-#include "treesearchsolver/iterative_beam_search.hpp"
 
 #include <thread>
 
@@ -19,217 +17,7 @@ using namespace packingsolver::box;
 namespace
 {
 
-void optimize_tree_search(
-        const Instance& instance,
-        const OptimizeParameters& parameters,
-        AlgorithmFormatter& algorithm_formatter)
-{
-    std::vector<GuideId> guides;
-    if (!parameters.tree_search_guides.empty()) {
-        guides = parameters.tree_search_guides;
-    } else if (instance.objective() == Objective::Knapsack) {
-        guides = {4, 5};
-    } else {
-        guides = {0, 1};
-    }
-    //guides = {4};
 
-    std::vector<Direction> directions;
-    if (instance.objective() == Objective::OpenDimensionX) {
-        directions = {Direction::X};
-    } else if (instance.objective() == Objective::OpenDimensionY) {
-        directions = {Direction::Y};
-    } else if (instance.objective() == Objective::OpenDimensionZ) {
-        directions = {Direction::Z};
-    } else if (instance.number_of_bin_types() == 1) {
-        directions = {Direction::X, Direction::Y, Direction::Z};
-    } else {
-        directions = {Direction::Any};
-    }
-    //directions = {Direction::Z};
-
-    std::vector<double> growth_factors = {1.5};
-    if (guides.size() * directions.size() * 2 <= 4)
-        growth_factors = {1.33, 1.5};
-    if (parameters.optimization_mode != OptimizationMode::Anytime)
-        growth_factors = {1.5};
-
-    std::vector<BranchingScheme> branching_schemes;
-    std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
-    std::vector<box::Output> outputs;
-    for (double growth_factor: growth_factors) {
-        for (GuideId guide_id: guides) {
-            for (Direction direction: directions) {
-                //std::cout << growth_factor << " " << guide_id << " " << direction << std::endl;
-                BranchingScheme::Parameters branching_scheme_parameters;
-                branching_scheme_parameters.guide_id = guide_id;
-                branching_scheme_parameters.direction = direction;
-                branching_schemes.push_back(BranchingScheme(instance, branching_scheme_parameters));
-                treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
-                ibs_parameters.verbosity_level = 0;
-                ibs_parameters.timer = parameters.timer;
-                ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
-                ibs_parameters.growth_factor = growth_factor;
-                if (parameters.optimization_mode != OptimizationMode::Anytime) {
-                    ibs_parameters.minimum_size_of_the_queue = 1;
-                    ibs_parameters.growth_factor
-                        = parameters.not_anytime_tree_search_queue_size;
-                    ibs_parameters.maximum_size_of_the_queue
-                        = parameters.not_anytime_tree_search_queue_size;
-                }
-                if (!parameters.json_search_tree_path.empty()) {
-                    ibs_parameters.json_search_tree_path = parameters.json_search_tree_path
-                        + "_guide_" + std::to_string(branching_scheme_parameters.guide_id)
-                        + "_d_" + std::to_string((int)branching_scheme_parameters.direction);
-                }
-                ibs_parameters_list.push_back(ibs_parameters);
-                outputs.push_back(box::Output(instance));
-            }
-        }
-    }
-
-    std::vector<std::thread> threads;
-    std::forward_list<std::exception_ptr> exception_ptr_list;
-    for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
-        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
-            ibs_parameters_list[i].new_solution_callback
-                = [&algorithm_formatter, &branching_schemes, i](
-                        const treesearchsolver::Output<BranchingScheme>& tss_output)
-                {
-                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
-                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
-                    Solution solution = branching_schemes[i].to_solution(
-                            tssibs_output.solution_pool.best());
-                    std::stringstream ss;
-                    ss << "TS g " << branching_schemes[i].parameters().guide_id
-                        << " d " << branching_schemes[i].parameters().direction
-                        << " q " << tssibs_output.maximum_size_of_the_queue;
-                    algorithm_formatter.update_solution(solution, ss.str());
-
-                    if (tssibs_output.optimal) {
-                        if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
-                            algorithm_formatter.update_bin_packing_bound(
-                                    solution.number_of_bins());
-                        }
-                    }
-                };
-        } else {
-            ibs_parameters_list[i].new_solution_callback
-                = [&outputs, &branching_schemes, i](
-                        const treesearchsolver::Output<BranchingScheme>& tss_output)
-                {
-                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
-                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
-                    Solution solution = branching_schemes[i].to_solution(
-                            tssibs_output.solution_pool.best());
-                    outputs[i].solution_pool.add(solution);
-                };
-        }
-        if (parameters.optimization_mode != OptimizationMode::NotAnytimeSequential) {
-            exception_ptr_list.push_front(std::exception_ptr());
-            threads.push_back(std::thread(
-                        wrapper<decltype(&treesearchsolver::iterative_beam_search_2<BranchingScheme>), treesearchsolver::iterative_beam_search_2<BranchingScheme>>,
-                        std::ref(exception_ptr_list.front()),
-                        std::ref(branching_schemes[i]),
-                        ibs_parameters_list[i]));
-        } else {
-            treesearchsolver::iterative_beam_search_2<BranchingScheme>(
-                    branching_schemes[i],
-                    ibs_parameters_list[i]);
-        }
-    }
-    for (Counter i = 0; i < (Counter)threads.size(); ++i)
-        threads[i].join();
-    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
-        if (exception_ptr)
-            std::rethrow_exception(exception_ptr);
-    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
-        for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
-            std::stringstream ss;
-            ss << "TS g " << branching_schemes[i].parameters().guide_id
-                << " d " << branching_schemes[i].parameters().direction;
-            algorithm_formatter.update_solution(outputs[i].solution_pool.best(), ss.str());
-        }
-    }
-}
-
-void optimize_tree_search_maximal_spaces(
-        const Instance& instance,
-        const OptimizeParameters& parameters,
-        AlgorithmFormatter& algorithm_formatter)
-{
-    MaxReachableLengths max_reachable_lengths = compute_max_reachable_lengths(instance);
-    std::vector<std::vector<Block>> all_blocks = compute_blocks(instance);
-
-    std::vector<BranchingSchemeMaximalSpaces> branching_schemes;
-    std::vector<treesearchsolver::IterativeBeamSearchParameters<BranchingSchemeMaximalSpaces>> ibs_parameters_list;
-    std::vector<box::Output> outputs;
-    {
-        BranchingSchemeMaximalSpaces::Parameters branching_scheme_parameters;
-        branching_schemes.push_back(BranchingSchemeMaximalSpaces(instance, all_blocks, max_reachable_lengths, branching_scheme_parameters));
-        treesearchsolver::IterativeBeamSearchParameters<BranchingSchemeMaximalSpaces> ibs_parameters;
-        ibs_parameters.verbosity_level = 0;
-        ibs_parameters.timer = parameters.timer;
-        ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
-        ibs_parameters.global_history = true;
-        ibs_parameters_list.push_back(ibs_parameters);
-        outputs.push_back(box::Output(instance));
-    }
-
-    std::vector<std::thread> threads;
-    std::forward_list<std::exception_ptr> exception_ptr_list;
-    for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
-        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
-            ibs_parameters_list[i].new_solution_callback
-                = [&algorithm_formatter, &branching_schemes, i](
-                        const treesearchsolver::Output<BranchingSchemeMaximalSpaces>& tss_output)
-                {
-                    const treesearchsolver::IterativeBeamSearchOutput<BranchingSchemeMaximalSpaces>& tssibs_output
-                        = static_cast<const treesearchsolver::IterativeBeamSearchOutput<BranchingSchemeMaximalSpaces>&>(tss_output);
-                    Solution solution = branching_schemes[i].to_solution(
-                            tssibs_output.solution_pool.best());
-                    std::stringstream ss;
-                    ss << "TSMS n " << tssibs_output.maximum_size_of_the_queue;
-                    algorithm_formatter.update_solution(solution, ss.str());
-                };
-        } else {
-            ibs_parameters_list[i].new_solution_callback
-                = [&outputs, &branching_schemes, i](
-                        const treesearchsolver::Output<BranchingSchemeMaximalSpaces>& tss_output)
-                {
-                    const treesearchsolver::IterativeBeamSearchOutput<BranchingSchemeMaximalSpaces>& tssibs_output
-                        = static_cast<const treesearchsolver::IterativeBeamSearchOutput<BranchingSchemeMaximalSpaces>&>(tss_output);
-                    Solution solution = branching_schemes[i].to_solution(
-                            tssibs_output.solution_pool.best());
-                    outputs[i].solution_pool.add(solution);
-                };
-        }
-        if (parameters.optimization_mode != OptimizationMode::NotAnytimeSequential) {
-            exception_ptr_list.push_front(std::exception_ptr());
-            threads.push_back(std::thread(
-                        wrapper<decltype(&treesearchsolver::iterative_beam_search<BranchingSchemeMaximalSpaces>), treesearchsolver::iterative_beam_search<BranchingSchemeMaximalSpaces>>,
-                        std::ref(exception_ptr_list.front()),
-                        std::ref(branching_schemes[i]),
-                        ibs_parameters_list[i]));
-        } else {
-            treesearchsolver::iterative_beam_search<BranchingSchemeMaximalSpaces>(
-                    branching_schemes[i],
-                    ibs_parameters_list[i]);
-        }
-    }
-    for (Counter i = 0; i < (Counter)threads.size(); ++i)
-        threads[i].join();
-    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
-        if (exception_ptr)
-            std::rethrow_exception(exception_ptr);
-    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
-        for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
-            std::stringstream ss;
-            ss << "TSMS";
-            algorithm_formatter.update_solution(outputs[i].solution_pool.best(), ss.str());
-        }
-    }
-}
 
 void optimize_sequential_single_knapsack(
         const Instance& instance,
@@ -446,6 +234,50 @@ void optimize_column_generation(
     cgslds_parameters.column_generation_parameters.solver_name
         = parameters.linear_programming_solver_name;
     columngenerationsolver::limited_discrepancy_search(cgs_model, cgslds_parameters);
+}
+
+void optimize_tree_search(
+        const Instance& instance,
+        const OptimizeParameters& parameters,
+        AlgorithmFormatter& algorithm_formatter)
+{
+    TreeSearchParameters ts_parameters;
+    ts_parameters.verbosity_level = 0;
+    ts_parameters.timer = parameters.timer;
+    ts_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    ts_parameters.guides = parameters.tree_search_guides;
+    ts_parameters.optimization_mode = parameters.optimization_mode;
+    ts_parameters.not_anytime_tree_search_queue_size = parameters.not_anytime_tree_search_queue_size;
+    ts_parameters.json_search_tree_path = parameters.json_search_tree_path;
+    ts_parameters.new_solution_callback = [&algorithm_formatter](
+            const packingsolver::Output<Instance, Solution>& ts_output)
+    {
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+        if (ts_output.bin_packing_bound > 0) {
+            algorithm_formatter.update_bin_packing_bound(
+                    ts_output.bin_packing_bound);
+        }
+    };
+    tree_search(instance, ts_parameters);
+}
+
+void optimize_tree_search_maximal_spaces(
+        const Instance& instance,
+        const OptimizeParameters& parameters,
+        AlgorithmFormatter& algorithm_formatter)
+{
+    TreeSearchMaximalSpacesParameters ts_ms_parameters;
+    ts_ms_parameters.verbosity_level = 0;
+    ts_ms_parameters.timer = parameters.timer;
+    ts_ms_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    ts_ms_parameters.optimization_mode = parameters.optimization_mode;
+    ts_ms_parameters.not_anytime_tree_search_queue_size = parameters.not_anytime_tree_search_queue_size;
+    ts_ms_parameters.new_solution_callback = [&algorithm_formatter](
+            const packingsolver::Output<Instance, Solution>& ts_output)
+    {
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+    };
+    tree_search_maximal_spaces(instance, ts_ms_parameters);
 }
 
 }

--- a/src/box/tree_search.cpp
+++ b/src/box/tree_search.cpp
@@ -1,5 +1,9 @@
-#include "box/branching_scheme.hpp"
+#include "box/tree_search.hpp"
 
+#include "packingsolver/box/algorithm_formatter.hpp"
+#include "treesearchsolver/iterative_beam_search_2.hpp"
+#include <thread>
+#include <sstream>
 #include <string>
 
 using namespace packingsolver;
@@ -913,4 +917,140 @@ std::ostream& packingsolver::box::operator<<(
         os << "  - " << uncovered_item << std::endl;
 
     return os;
+}
+
+const packingsolver::box::TreeSearchOutput packingsolver::box::tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters)
+{
+    TreeSearchOutput output(instance);
+    AlgorithmFormatter algorithm_formatter(instance, parameters, output);
+    algorithm_formatter.start();
+    algorithm_formatter.print_header();
+
+    std::vector<GuideId> guides;
+    if (!parameters.guides.empty()) {
+        guides = parameters.guides;
+    } else if (instance.objective() == Objective::Knapsack) {
+        guides = {4, 5};
+    } else {
+        guides = {0, 1};
+    }
+
+    std::vector<Direction> directions;
+    if (instance.objective() == Objective::OpenDimensionX) {
+        directions = {Direction::X};
+    } else if (instance.objective() == Objective::OpenDimensionY) {
+        directions = {Direction::Y};
+    } else if (instance.objective() == Objective::OpenDimensionZ) {
+        directions = {Direction::Z};
+    } else if (instance.number_of_bin_types() == 1) {
+        directions = {Direction::X, Direction::Y, Direction::Z};
+    } else {
+        directions = {Direction::Any};
+    }
+
+    std::vector<double> growth_factors = {1.5};
+    if (guides.size() * directions.size() * 2 <= 4)
+        growth_factors = {1.33, 1.5};
+    if (parameters.optimization_mode != OptimizationMode::Anytime)
+        growth_factors = {1.5};
+
+    std::vector<BranchingScheme> branching_schemes;
+    std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
+    std::vector<packingsolver::Output<Instance, Solution>> local_outputs;
+    for (double growth_factor: growth_factors) {
+        for (GuideId guide_id: guides) {
+            for (Direction direction: directions) {
+                BranchingScheme::Parameters branching_scheme_parameters;
+                branching_scheme_parameters.guide_id = guide_id;
+                branching_scheme_parameters.direction = direction;
+                branching_schemes.push_back(BranchingScheme(instance, branching_scheme_parameters));
+                treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
+                ibs_parameters.verbosity_level = 0;
+                ibs_parameters.timer = parameters.timer;
+                ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+                ibs_parameters.growth_factor = growth_factor;
+                if (parameters.optimization_mode != OptimizationMode::Anytime) {
+                    ibs_parameters.minimum_size_of_the_queue = 1;
+                    ibs_parameters.growth_factor = parameters.not_anytime_tree_search_queue_size;
+                    ibs_parameters.maximum_size_of_the_queue = parameters.not_anytime_tree_search_queue_size;
+                }
+                if (!parameters.json_search_tree_path.empty()) {
+                    ibs_parameters.json_search_tree_path = parameters.json_search_tree_path
+                        + "_guide_" + std::to_string(branching_scheme_parameters.guide_id)
+                        + "_d_" + std::to_string((int)branching_scheme_parameters.direction);
+                }
+                ibs_parameters_list.push_back(ibs_parameters);
+                local_outputs.push_back(packingsolver::Output<Instance, Solution>(instance));
+            }
+        }
+    }
+
+    std::vector<std::thread> threads;
+    std::forward_list<std::exception_ptr> exception_ptr_list;
+    for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
+        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
+            ibs_parameters_list[scheme_idx].new_solution_callback
+                = [&algorithm_formatter, &branching_schemes, scheme_idx](
+                        const treesearchsolver::Output<BranchingScheme>& tss_output)
+                {
+                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
+                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
+                    Solution solution = branching_schemes[scheme_idx].to_solution(
+                            tssibs_output.solution_pool.best());
+                    std::stringstream ss;
+                    ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
+                        << " d " << branching_schemes[scheme_idx].parameters().direction
+                        << " q " << tssibs_output.maximum_size_of_the_queue;
+                    algorithm_formatter.update_solution(solution, ss.str());
+                    if (tssibs_output.optimal
+                            && solution.instance().objective() == packingsolver::Objective::BinPacking) {
+                        algorithm_formatter.update_bin_packing_bound(
+                                solution.number_of_bins());
+                    }
+                };
+        } else {
+            ibs_parameters_list[scheme_idx].new_solution_callback
+                = [&local_outputs, &branching_schemes, scheme_idx](
+                        const treesearchsolver::Output<BranchingScheme>& tss_output)
+                {
+                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
+                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
+                    Solution solution = branching_schemes[scheme_idx].to_solution(
+                            tssibs_output.solution_pool.best());
+                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution);
+                };
+        }
+        if (parameters.optimization_mode != OptimizationMode::NotAnytimeSequential) {
+            exception_ptr_list.push_front(std::exception_ptr());
+            threads.push_back(std::thread(
+                        wrapper<decltype(&treesearchsolver::iterative_beam_search_2<BranchingScheme>), treesearchsolver::iterative_beam_search_2<BranchingScheme>>,
+                        std::ref(exception_ptr_list.front()),
+                        std::ref(branching_schemes[scheme_idx]),
+                        ibs_parameters_list[scheme_idx]));
+        } else {
+            treesearchsolver::iterative_beam_search_2<BranchingScheme>(
+                    branching_schemes[scheme_idx],
+                    ibs_parameters_list[scheme_idx]);
+        }
+    }
+    for (Counter thread_idx = 0; thread_idx < (Counter)threads.size(); ++thread_idx)
+        threads[thread_idx].join();
+    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
+        if (exception_ptr)
+            std::rethrow_exception(exception_ptr);
+    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
+        for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
+            std::stringstream ss;
+            ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
+                << " d " << branching_schemes[scheme_idx].parameters().direction;
+            algorithm_formatter.update_solution(
+                    local_outputs[(size_t)scheme_idx].solution_pool.best(),
+                    ss.str());
+        }
+    }
+
+    algorithm_formatter.end();
+    return output;
 }

--- a/src/box/tree_search.hpp
+++ b/src/box/tree_search.hpp
@@ -526,3 +526,32 @@ inline bool BranchingScheme::operator()(
 
 }
 }
+
+#include "packingsolver/box/solution.hpp"
+
+namespace packingsolver
+{
+namespace box
+{
+
+struct TreeSearchOutput: packingsolver::Output<Instance, Solution>
+{
+    TreeSearchOutput(const Instance& instance):
+        packingsolver::Output<Instance, Solution>(instance) { }
+};
+
+struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution>
+{
+    std::vector<GuideId> guides;
+
+    OptimizationMode optimization_mode = OptimizationMode::Anytime;
+
+    NodeId not_anytime_tree_search_queue_size = 1;
+};
+
+const TreeSearchOutput tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters = {});
+
+}
+}

--- a/src/box/tree_search_maximal_spaces.cpp
+++ b/src/box/tree_search_maximal_spaces.cpp
@@ -1,6 +1,10 @@
-#include "box/branching_scheme_maximal_spaces.hpp"
+#include "box/tree_search_maximal_spaces.hpp"
 
+#include "packingsolver/box/algorithm_formatter.hpp"
 #include "packingsolver/box/solution.hpp"
+#include "treesearchsolver/iterative_beam_search.hpp"
+#include <thread>
+#include <sstream>
 
 using namespace packingsolver;
 using namespace packingsolver::box;
@@ -826,4 +830,91 @@ void BranchingSchemeMaximalSpaces::cut_spaces(
         }
         // Do not increment i: the element swapped into position i must be checked.
     }
+}
+
+const packingsolver::box::TreeSearchMaximalSpacesOutput packingsolver::box::tree_search_maximal_spaces(
+        const Instance& instance,
+        const TreeSearchMaximalSpacesParameters& parameters)
+{
+    TreeSearchMaximalSpacesOutput output(instance);
+    AlgorithmFormatter algorithm_formatter(instance, parameters, output);
+    algorithm_formatter.start();
+    algorithm_formatter.print_header();
+
+    MaxReachableLengths max_reachable_lengths = compute_max_reachable_lengths(instance);
+    std::vector<std::vector<Block>> all_blocks = compute_blocks(instance);
+
+    std::vector<BranchingSchemeMaximalSpaces> branching_schemes;
+    std::vector<treesearchsolver::IterativeBeamSearchParameters<BranchingSchemeMaximalSpaces>> ibs_parameters_list;
+    std::vector<packingsolver::Output<Instance, Solution>> local_outputs;
+    {
+        BranchingSchemeMaximalSpaces::Parameters branching_scheme_parameters;
+        branching_schemes.push_back(BranchingSchemeMaximalSpaces(instance, all_blocks, max_reachable_lengths, branching_scheme_parameters));
+        treesearchsolver::IterativeBeamSearchParameters<BranchingSchemeMaximalSpaces> ibs_parameters;
+        ibs_parameters.verbosity_level = 0;
+        ibs_parameters.timer = parameters.timer;
+        ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+        ibs_parameters.global_history = true;
+        ibs_parameters_list.push_back(ibs_parameters);
+        local_outputs.push_back(packingsolver::Output<Instance, Solution>(instance));
+    }
+
+    std::vector<std::thread> threads;
+    std::forward_list<std::exception_ptr> exception_ptr_list;
+    for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
+        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
+            ibs_parameters_list[scheme_idx].new_solution_callback
+                = [&algorithm_formatter, &branching_schemes, scheme_idx](
+                        const treesearchsolver::Output<BranchingSchemeMaximalSpaces>& tss_output)
+                {
+                    const treesearchsolver::IterativeBeamSearchOutput<BranchingSchemeMaximalSpaces>& tssibs_output
+                        = static_cast<const treesearchsolver::IterativeBeamSearchOutput<BranchingSchemeMaximalSpaces>&>(tss_output);
+                    Solution solution = branching_schemes[scheme_idx].to_solution(
+                            tssibs_output.solution_pool.best());
+                    std::stringstream ss;
+                    ss << "TSMS n " << tssibs_output.maximum_size_of_the_queue;
+                    algorithm_formatter.update_solution(solution, ss.str());
+                };
+        } else {
+            ibs_parameters_list[scheme_idx].new_solution_callback
+                = [&local_outputs, &branching_schemes, scheme_idx](
+                        const treesearchsolver::Output<BranchingSchemeMaximalSpaces>& tss_output)
+                {
+                    const treesearchsolver::IterativeBeamSearchOutput<BranchingSchemeMaximalSpaces>& tssibs_output
+                        = static_cast<const treesearchsolver::IterativeBeamSearchOutput<BranchingSchemeMaximalSpaces>&>(tss_output);
+                    Solution solution = branching_schemes[scheme_idx].to_solution(
+                            tssibs_output.solution_pool.best());
+                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution);
+                };
+        }
+        if (parameters.optimization_mode != OptimizationMode::NotAnytimeSequential) {
+            exception_ptr_list.push_front(std::exception_ptr());
+            threads.push_back(std::thread(
+                        wrapper<decltype(&treesearchsolver::iterative_beam_search<BranchingSchemeMaximalSpaces>), treesearchsolver::iterative_beam_search<BranchingSchemeMaximalSpaces>>,
+                        std::ref(exception_ptr_list.front()),
+                        std::ref(branching_schemes[scheme_idx]),
+                        ibs_parameters_list[scheme_idx]));
+        } else {
+            treesearchsolver::iterative_beam_search<BranchingSchemeMaximalSpaces>(
+                    branching_schemes[scheme_idx],
+                    ibs_parameters_list[scheme_idx]);
+        }
+    }
+    for (Counter thread_idx = 0; thread_idx < (Counter)threads.size(); ++thread_idx)
+        threads[thread_idx].join();
+    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
+        if (exception_ptr)
+            std::rethrow_exception(exception_ptr);
+    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
+        for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
+            std::stringstream ss;
+            ss << "TSMS";
+            algorithm_formatter.update_solution(
+                    local_outputs[(size_t)scheme_idx].solution_pool.best(),
+                    ss.str());
+        }
+    }
+
+    algorithm_formatter.end();
+    return output;
 }

--- a/src/box/tree_search_maximal_spaces.hpp
+++ b/src/box/tree_search_maximal_spaces.hpp
@@ -632,3 +632,30 @@ inline bool BranchingSchemeMaximalSpaces::operator()(
 
 } // namespace box
 } // namespace packingsolver
+
+#include "packingsolver/box/solution.hpp"
+
+namespace packingsolver
+{
+namespace box
+{
+
+struct TreeSearchMaximalSpacesOutput: packingsolver::Output<Instance, Solution>
+{
+    TreeSearchMaximalSpacesOutput(const Instance& instance):
+        packingsolver::Output<Instance, Solution>(instance) { }
+};
+
+struct TreeSearchMaximalSpacesParameters: packingsolver::Parameters<Instance, Solution>
+{
+    OptimizationMode optimization_mode = OptimizationMode::Anytime;
+
+    NodeId not_anytime_tree_search_queue_size = 1;
+};
+
+const TreeSearchMaximalSpacesOutput tree_search_maximal_spaces(
+        const Instance& instance,
+        const TreeSearchMaximalSpacesParameters& parameters = {});
+
+}
+}

--- a/src/boxstacks/CMakeLists.txt
+++ b/src/boxstacks/CMakeLists.txt
@@ -9,7 +9,7 @@ target_sources(PackingSolver_boxstacks PRIVATE
     optimize.cpp
     post_process.cpp
     sequential_onedimensional_rectangle.cpp
-    branching_scheme.cpp)
+    tree_search.cpp)
 target_include_directories(PackingSolver_boxstacks PUBLIC
     ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(PackingSolver_boxstacks PRIVATE

--- a/src/boxstacks/optimize.cpp
+++ b/src/boxstacks/optimize.cpp
@@ -2,17 +2,40 @@
 
 #include "packingsolver/boxstacks/algorithm_formatter.hpp"
 #include "packingsolver/boxstacks/instance_builder.hpp"
-#include "boxstacks/branching_scheme.hpp"
+#include "boxstacks/tree_search.hpp"
 #include "boxstacks/sequential_onedimensional_rectangle.hpp"
 
 #include "algorithms/sequential_value_correction.hpp"
-
-#include "treesearchsolver/iterative_beam_search_2.hpp"
 
 #include <thread>
 
 using namespace packingsolver;
 using namespace packingsolver::boxstacks;
+
+namespace
+{
+
+void optimize_tree_search(
+        const Instance& instance,
+        const OptimizeParameters& parameters,
+        AlgorithmFormatter& algorithm_formatter,
+        ItemPos maximum_number_of_selected_items)
+{
+    TreeSearchParameters ts_parameters;
+    ts_parameters.verbosity_level = 0;
+    ts_parameters.timer = parameters.timer;
+    ts_parameters.optimization_mode = parameters.optimization_mode;
+    ts_parameters.not_anytime_tree_search_queue_size = parameters.not_anytime_tree_search_queue_size;
+    ts_parameters.maximum_number_of_selected_items = maximum_number_of_selected_items;
+    ts_parameters.new_solution_callback = [&algorithm_formatter](
+            const packingsolver::Output<Instance, Solution>& ts_output)
+    {
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+    };
+    tree_search(instance, ts_parameters);
+}
+
+}
 
 packingsolver::boxstacks::Output packingsolver::boxstacks::optimize(
         const Instance& instance,
@@ -116,99 +139,11 @@ packingsolver::boxstacks::Output packingsolver::boxstacks::optimize(
         if (run_boxstacks_branching_scheme) {
             auto bs_begin = std::chrono::steady_clock::now();
 
-            std::vector<GuideId> guides;
-            if (!parameters.tree_search_guides.empty()) {
-                guides = parameters.tree_search_guides;
-            } else if (instance.objective() == Objective::Knapsack) {
-                guides = {4, 5};
-            } else if (instance.objective() == Objective::BinPackingWithLeftovers) {
-                guides = {0, 1};
-            } else {
-                guides = {0, 2};
-            }
-            guides = {4};
-
-            std::vector<Direction> directions;
-            if (instance.objective() == Objective::OpenDimensionX) {
-                directions = {Direction::X};
-            } else if (instance.objective() == Objective::OpenDimensionY) {
-                directions = {Direction::Y};
-            } else if (instance.unloading_constraint() == rectangle::UnloadingConstraint::IncreasingX
-                    || instance.unloading_constraint() == rectangle::UnloadingConstraint::OnlyXMovements) {
-                directions = {Direction::X};
-            } else if (instance.unloading_constraint() == rectangle::UnloadingConstraint::IncreasingY
-                    || instance.unloading_constraint() == rectangle::UnloadingConstraint::OnlyYMovements) {
-                directions = {Direction::Y};
-            } else if (instance.number_of_bin_types() == 1) {
-                directions = {Direction::X, Direction::Y};
-            } else {
-                directions = {Direction::Any};
-            }
-
-            std::vector<BranchingScheme> branching_schemes;
-            std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
-            for (GuideId guide_id: guides) {
-                for (Direction direction: directions) {
-                    //std::cout << growth_factor << " " << guide_id << " " << direction << std::endl;
-                    BranchingScheme::Parameters branching_scheme_parameters;
-                    branching_scheme_parameters.guide_id = guide_id;
-                    branching_scheme_parameters.direction = direction;
-                    branching_scheme_parameters.maximum_number_of_selected_items = output.sequential_onedimensional_rectangle_number_of_items;
-                    branching_schemes.push_back(BranchingScheme(instance, branching_scheme_parameters));
-                    treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
-                    ibs_parameters.verbosity_level = 0;
-                    ibs_parameters.timer = parameters.timer;
-                    if (parameters.optimization_mode != OptimizationMode::Anytime) {
-                        ibs_parameters.minimum_size_of_the_queue = 1;
-                        ibs_parameters.growth_factor
-                            = parameters.not_anytime_tree_search_queue_size;
-                        ibs_parameters.maximum_size_of_the_queue
-                            = parameters.not_anytime_tree_search_queue_size;
-                    }
-                    //ibs_parameters.info.set_verbosity_level(1);
-                    ibs_parameters_list.push_back(ibs_parameters);
-                }
-            }
-
-            std::vector<std::thread> threads;
-            std::forward_list<std::exception_ptr> exception_ptr_list;
-            for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
-                ibs_parameters_list[i].new_solution_callback
-                    = [&algorithm_formatter, &branching_schemes, i](
-                            const treesearchsolver::Output<BranchingScheme>& tss_output)
-                    {
-                        const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
-                            = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
-                        Solution solution = branching_schemes[i].to_solution(
-                                tssibs_output.solution_pool.best());
-                        std::stringstream ss;
-                        ss << branching_schemes[i].parameters().guide_id
-                            << " " << branching_schemes[i].parameters().direction
-                            << " " << tssibs_output.maximum_size_of_the_queue;
-                        algorithm_formatter.update_solution(solution, ss.str());
-                    };
-                exception_ptr_list.push_front(std::exception_ptr());
-                if (parameters.optimization_mode != OptimizationMode::NotAnytimeSequential) {
-                    threads.push_back(std::thread(
-                                wrapper<decltype(&treesearchsolver::iterative_beam_search_2<BranchingScheme>), treesearchsolver::iterative_beam_search_2<BranchingScheme>>,
-                                std::ref(exception_ptr_list.front()),
-                                std::ref(branching_schemes[i]),
-                                ibs_parameters_list[i]));
-                } else {
-                    try {
-                        treesearchsolver::iterative_beam_search_2<BranchingScheme>(
-                                branching_schemes[i],
-                                ibs_parameters_list[i]);
-                    } catch (...) {
-                        exception_ptr_list.front() = std::current_exception();
-                    }
-                }
-            }
-            for (Counter i = 0; i < (Counter)threads.size(); ++i)
-                threads[i].join();
-            for (const std::exception_ptr& exception_ptr: exception_ptr_list)
-                if (exception_ptr)
-                    std::rethrow_exception(exception_ptr);
+            optimize_tree_search(
+                    instance,
+                    parameters,
+                    algorithm_formatter,
+                    output.sequential_onedimensional_rectangle_number_of_items);
 
             auto bs_end = std::chrono::steady_clock::now();
             std::chrono::duration<double> bs_time_span

--- a/src/boxstacks/sequential_onedimensional_rectangle.cpp
+++ b/src/boxstacks/sequential_onedimensional_rectangle.cpp
@@ -5,7 +5,7 @@
 #include "packingsolver/onedimensional/instance_builder.hpp"
 
 #include "packingsolver/rectangle/instance_builder.hpp"
-#include "rectangle/branching_scheme.hpp"
+#include "rectangle/tree_search.hpp"
 #include "rectangle/solution_builder.hpp"
 
 #include "treesearchsolver/iterative_beam_search_2.hpp"

--- a/src/boxstacks/tree_search.cpp
+++ b/src/boxstacks/tree_search.cpp
@@ -1,7 +1,11 @@
-#include "boxstacks/branching_scheme.hpp"
+#include "boxstacks/tree_search.hpp"
 
+#include "packingsolver/boxstacks/algorithm_formatter.hpp"
 #include "multiplechoicesubsetsumsolver/instance_builder.hpp"
 #include "multiplechoicesubsetsumsolver/algorithms/dynamic_programming_bellman.hpp"
+#include "treesearchsolver/iterative_beam_search_2.hpp"
+#include <thread>
+#include <sstream>
 
 #include <string>
 #include <cmath>
@@ -1634,4 +1638,108 @@ std::ostream& packingsolver::boxstacks::operator<<(
     os << std::endl;
 
     return os;
+}
+
+const packingsolver::boxstacks::TreeSearchOutput packingsolver::boxstacks::tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters)
+{
+    TreeSearchOutput output(instance);
+    AlgorithmFormatter algorithm_formatter(instance, parameters, output);
+    algorithm_formatter.start();
+    algorithm_formatter.print_header();
+
+    std::vector<GuideId> guides;
+    if (!parameters.guides.empty()) {
+        guides = parameters.guides;
+    } else if (instance.objective() == Objective::Knapsack) {
+        guides = {4, 5};
+    } else if (instance.objective() == Objective::BinPackingWithLeftovers) {
+        guides = {0, 1};
+    } else {
+        guides = {0, 2};
+    }
+    guides = {4};
+
+    std::vector<Direction> directions;
+    if (instance.objective() == Objective::OpenDimensionX) {
+        directions = {Direction::X};
+    } else if (instance.objective() == Objective::OpenDimensionY) {
+        directions = {Direction::Y};
+    } else if (instance.unloading_constraint() == rectangle::UnloadingConstraint::IncreasingX
+            || instance.unloading_constraint() == rectangle::UnloadingConstraint::OnlyXMovements) {
+        directions = {Direction::X};
+    } else if (instance.unloading_constraint() == rectangle::UnloadingConstraint::IncreasingY
+            || instance.unloading_constraint() == rectangle::UnloadingConstraint::OnlyYMovements) {
+        directions = {Direction::Y};
+    } else if (instance.number_of_bin_types() == 1) {
+        directions = {Direction::X, Direction::Y};
+    } else {
+        directions = {Direction::Any};
+    }
+
+    std::vector<BranchingScheme> branching_schemes;
+    std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
+    for (GuideId guide_id: guides) {
+        for (Direction direction: directions) {
+            BranchingScheme::Parameters branching_scheme_parameters;
+            branching_scheme_parameters.guide_id = guide_id;
+            branching_scheme_parameters.direction = direction;
+            branching_scheme_parameters.maximum_number_of_selected_items = parameters.maximum_number_of_selected_items;
+            branching_schemes.push_back(BranchingScheme(instance, branching_scheme_parameters));
+            treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
+            ibs_parameters.verbosity_level = 0;
+            ibs_parameters.timer = parameters.timer;
+            ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+            if (parameters.optimization_mode != OptimizationMode::Anytime) {
+                ibs_parameters.minimum_size_of_the_queue = 1;
+                ibs_parameters.growth_factor = parameters.not_anytime_tree_search_queue_size;
+                ibs_parameters.maximum_size_of_the_queue = parameters.not_anytime_tree_search_queue_size;
+            }
+            ibs_parameters_list.push_back(ibs_parameters);
+        }
+    }
+
+    std::vector<std::thread> threads;
+    std::forward_list<std::exception_ptr> exception_ptr_list;
+    for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
+        ibs_parameters_list[scheme_idx].new_solution_callback
+            = [&algorithm_formatter, &branching_schemes, scheme_idx](
+                    const treesearchsolver::Output<BranchingScheme>& tss_output)
+            {
+                const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
+                    = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
+                Solution solution = branching_schemes[scheme_idx].to_solution(
+                        tssibs_output.solution_pool.best());
+                std::stringstream ss;
+                ss << branching_schemes[scheme_idx].parameters().guide_id
+                    << " " << branching_schemes[scheme_idx].parameters().direction
+                    << " " << tssibs_output.maximum_size_of_the_queue;
+                algorithm_formatter.update_solution(solution, ss.str());
+            };
+        exception_ptr_list.push_front(std::exception_ptr());
+        if (parameters.optimization_mode != OptimizationMode::NotAnytimeSequential) {
+            threads.push_back(std::thread(
+                        wrapper<decltype(&treesearchsolver::iterative_beam_search_2<BranchingScheme>), treesearchsolver::iterative_beam_search_2<BranchingScheme>>,
+                        std::ref(exception_ptr_list.front()),
+                        std::ref(branching_schemes[scheme_idx]),
+                        ibs_parameters_list[scheme_idx]));
+        } else {
+            try {
+                treesearchsolver::iterative_beam_search_2<BranchingScheme>(
+                        branching_schemes[scheme_idx],
+                        ibs_parameters_list[scheme_idx]);
+            } catch (...) {
+                exception_ptr_list.front() = std::current_exception();
+            }
+        }
+    }
+    for (Counter thread_idx = 0; thread_idx < (Counter)threads.size(); ++thread_idx)
+        threads[thread_idx].join();
+    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
+        if (exception_ptr)
+            std::rethrow_exception(exception_ptr);
+
+    algorithm_formatter.end();
+    return output;
 }

--- a/src/boxstacks/tree_search.hpp
+++ b/src/boxstacks/tree_search.hpp
@@ -667,3 +667,34 @@ inline bool BranchingScheme::operator()(
 
 }
 }
+
+#include "packingsolver/boxstacks/solution.hpp"
+
+namespace packingsolver
+{
+namespace boxstacks
+{
+
+struct TreeSearchOutput: packingsolver::Output<Instance, Solution>
+{
+    TreeSearchOutput(const Instance& instance):
+        packingsolver::Output<Instance, Solution>(instance) { }
+};
+
+struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution>
+{
+    std::vector<GuideId> guides;
+
+    OptimizationMode optimization_mode = OptimizationMode::Anytime;
+
+    NodeId not_anytime_tree_search_queue_size = 1;
+
+    ItemPos maximum_number_of_selected_items = -1;
+};
+
+const TreeSearchOutput tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters = {});
+
+}
+}

--- a/src/irregular/CMakeLists.txt
+++ b/src/irregular/CMakeLists.txt
@@ -10,7 +10,7 @@ target_sources(PackingSolver_irregular PRIVATE
     shape_simplification.cpp
     rotations.cpp
     periodic_packing.cpp
-    branching_scheme.cpp
+    tree_search.cpp
     linear_programming.cpp
     milp_raster.cpp
     trivial.cpp

--- a/src/irregular/optimize.cpp
+++ b/src/irregular/optimize.cpp
@@ -3,7 +3,7 @@
 #include "packingsolver/irregular/algorithm_formatter.hpp"
 #include "packingsolver/irregular/instance_builder.hpp"
 #include "irregular/trivial.hpp"
-#include "irregular/branching_scheme.hpp"
+#include "irregular/tree_search.hpp"
 #include "irregular/milp_raster.hpp"
 #include "irregular/local_search.hpp"
 #include "irregular/sequential_feasibility.hpp"
@@ -12,8 +12,6 @@
 #include "algorithms/column_generation.hpp"
 #include "packingsolver/onedimensional/instance_builder.hpp"
 #include "packingsolver/onedimensional/optimize.hpp"
-
-#include "treesearchsolver/iterative_beam_search_2.hpp"
 
 #include <functional>
 #include <thread>
@@ -106,297 +104,7 @@ void optimize_trivial_single_item(
     trivial_single_item(instance, trivial_single_item_parameters);
 }
 
-void optimize_tree_search_worker(
-        const Instance& instance,
-        const OptimizeParameters& parameters,
-        AlgorithmFormatter& algorithm_formatter,
-        BranchingScheme::Parameters branching_scheme_parameters,
-        treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters,
-        std::function<void(const Solution&, const std::string&)> new_solution_callback)
-{
-    Counter queue_size = 1;
-    double maximum_approximation_ratio = parameters.initial_maximum_approximation_ratio;
-    std::shared_ptr<BranchingScheme::Node> cutoff = nullptr;
-    for (Counter iteration = 0;
-            ;
-            ++iteration) {
 
-        if (parameters.optimization_mode != OptimizationMode::Anytime) {
-            queue_size = parameters.not_anytime_tree_search_queue_size;
-            maximum_approximation_ratio = parameters.not_anytime_maximum_approximation_ratio;
-        }
-
-        // Run tree search.
-        branching_scheme_parameters.maximum_approximation_ratio = maximum_approximation_ratio;
-        ibs_parameters.cutoff = cutoff;
-        ibs_parameters.minimum_size_of_the_queue = queue_size;
-        ibs_parameters.maximum_size_of_the_queue = queue_size;
-        if (!parameters.json_search_tree_path.empty()) {
-            ibs_parameters.json_search_tree_path = parameters.json_search_tree_path
-                + "_guide_" + std::to_string(branching_scheme_parameters.guide_id)
-                + "_d_" + std::to_string((int)branching_scheme_parameters.direction);
-        }
-        BranchingScheme branching_scheme(instance, branching_scheme_parameters);
-        // Set the IBS callback here, after the BranchingScheme is created, so that
-        // to_solution is always called on the same scheme that built the nodes.
-        ibs_parameters.new_solution_callback =
-            [&branching_scheme, &branching_scheme_parameters, &new_solution_callback](
-                    const treesearchsolver::Output<BranchingScheme>& tss_output)
-            {
-                const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
-                    = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
-                Solution solution = branching_scheme.to_solution(
-                        tssibs_output.solution_pool.best());
-                std::stringstream ss;
-                ss << "TS g " << branching_scheme_parameters.guide_id
-                    << " d " << (int)branching_scheme_parameters.direction
-                    << " q " << tssibs_output.maximum_size_of_the_queue;
-                new_solution_callback(solution, ss.str());
-            };
-        auto ibs_output = treesearchsolver::iterative_beam_search_2<BranchingScheme>(
-                branching_scheme,
-                ibs_parameters);
-
-        // Check end.
-        if (ibs_output.optimal)
-            break;
-        if (algorithm_formatter.end_boolean())
-            break;
-        if (parameters.timer.needs_to_end())
-            break;
-
-        if (parameters.optimization_mode != OptimizationMode::Anytime)
-            break;
-
-        if (cutoff != nullptr)
-            ibs_output.solution_pool.add(cutoff);
-        cutoff = ibs_output.solution_pool.best();
-
-        // Update beam size.
-        queue_size = std::max(
-                queue_size + 1,
-                (NodeId)(queue_size * 1.5));
-        // Update maximum approximation ratio.
-        maximum_approximation_ratio *= parameters.maximum_approximation_ratio_factor;
-    }
-}
-
-void optimize_tree_search(
-        const Instance& instance,
-        const OptimizeParameters& parameters,
-        AlgorithmFormatter& algorithm_formatter)
-{
-    std::vector<GuideId> guides;
-    if (!parameters.tree_search_guides.empty()) {
-        guides = parameters.tree_search_guides;
-    } else if (instance.objective() == Objective::Knapsack) {
-        guides = {4, 5};
-    } else {
-        guides = {0, 1};
-    }
-    //guides = {0};
-
-    std::vector<BranchingScheme::Direction> directions;
-    if (instance.objective() == Objective::OpenDimensionX) {
-        directions = {
-            BranchingScheme::Direction::LeftToRightThenBottomToTop,
-            BranchingScheme::Direction::LeftToRightThenTopToBottom,
-        };
-    } else if (instance.objective() == Objective::OpenDimensionY) {
-        directions = {
-            BranchingScheme::Direction::BottomToTopThenLeftToRight,
-            BranchingScheme::Direction::BottomToTopThenRightToLeft,
-        };
-    } else if (instance.number_of_bins() == 1) {
-        if (instance.objective() == Objective::BinPackingWithLeftovers) {
-            switch (instance.parameters().leftover_corner) {
-            case Corner::BottomLeft: {
-                directions = {
-                    BranchingScheme::Direction::LeftToRightThenBottomToTop,
-                    BranchingScheme::Direction::BottomToTopThenLeftToRight,
-                    BranchingScheme::Direction::LeftToRightThenTopToBottom,
-                    BranchingScheme::Direction::BottomToTopThenRightToLeft,
-                };
-                break;
-            } case Corner::BottomRight: {
-                directions = {
-                    BranchingScheme::Direction::RightToLeftThenBottomToTop,
-                    BranchingScheme::Direction::BottomToTopThenLeftToRight,
-                    BranchingScheme::Direction::RightToLeftThenTopToBottom,
-                    BranchingScheme::Direction::BottomToTopThenRightToLeft,
-                };
-                break;
-            } case Corner::TopLeft: {
-                directions = {
-                    BranchingScheme::Direction::LeftToRightThenBottomToTop,
-                    BranchingScheme::Direction::TopToBottomThenLeftToRight,
-                    BranchingScheme::Direction::LeftToRightThenTopToBottom,
-                    BranchingScheme::Direction::TopToBottomThenRightToLeft,
-                };
-                break;
-            } case Corner::TopRight: {
-                directions = {
-                    BranchingScheme::Direction::RightToLeftThenBottomToTop,
-                    BranchingScheme::Direction::TopToBottomThenLeftToRight,
-                    BranchingScheme::Direction::RightToLeftThenTopToBottom,
-                    BranchingScheme::Direction::TopToBottomThenRightToLeft,
-                };
-                break;
-            }
-            }
-        } else {
-            directions = {
-                BranchingScheme::Direction::LeftToRightThenBottomToTop,
-                BranchingScheme::Direction::BottomToTopThenLeftToRight,
-                BranchingScheme::Direction::RightToLeftThenTopToBottom,
-                BranchingScheme::Direction::TopToBottomThenRightToLeft,
-            };
-        }
-    } else {
-        switch (instance.parameters().leftover_corner) {
-        case Corner::BottomLeft: {
-            directions = {BranchingScheme::Direction::LeftToRightThenBottomToTop};
-            break;
-        } case Corner::BottomRight: {
-            directions = {BranchingScheme::Direction::RightToLeftThenBottomToTop};
-            break;
-        } case Corner::TopLeft: {
-            directions = {BranchingScheme::Direction::LeftToRightThenTopToBottom,};
-            break;
-        } case Corner::TopRight: {
-            directions = {BranchingScheme::Direction::RightToLeftThenTopToBottom};
-            break;
-        }
-        }
-    }
-
-    // If all items have free rotations and all bins are squared, we consdier
-    // a single direction.
-    bool all_items_full_rotation = true;
-    for (ItemTypeId item_type_id = 0;
-            item_type_id < instance.number_of_item_types();
-            ++item_type_id) {
-        const ItemType& item_type = instance.item_type(item_type_id);
-        if (!item_type.has_full_continuous_rotations()) {
-            all_items_full_rotation = false;
-            break;
-        }
-    }
-    bool all_bins_squared = true;
-    for (BinTypeId bin_type_id = 0;
-            bin_type_id < instance.number_of_bin_types();
-            ++bin_type_id) {
-        const BinType& bin_type = instance.bin_type(bin_type_id);
-        if (!bin_type.shape_scaled.is_square()) {
-            all_bins_squared = false;
-            break;
-        }
-    }
-    if (all_items_full_rotation && all_bins_squared) {
-        directions = {BranchingScheme::Direction::LeftToRightThenBottomToTop};
-    }
-    //directions = {BranchingScheme::Direction::LeftToRightThenBottomToTop};
-
-    std::vector<double> growth_factors = {1.5};
-    if (guides.size() * directions.size() * 2 <= 4)
-        growth_factors = {1.33, 1.5};
-    if (parameters.optimization_mode != OptimizationMode::Anytime)
-        growth_factors = {1.5};
-    //growth_factors = {1.5};
-
-    std::vector<BranchingScheme::Parameters> branching_scheme_parameters_list;
-    std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
-    std::vector<irregular::Output> outputs;
-    for (double growth_factor: growth_factors) {
-        for (GuideId guide_id: guides) {
-            for (BranchingScheme::Direction direction: directions) {
-                //std::cout << growth_factor << " " << guide_id << " " << direction << std::endl;
-                BranchingScheme::Parameters branching_scheme_parameters;
-                branching_scheme_parameters.guide_id = guide_id;
-                branching_scheme_parameters.direction = direction;
-                if (parameters.optimization_mode == OptimizationMode::Anytime) {
-                    branching_scheme_parameters.maximum_approximation_ratio
-                        = parameters.initial_maximum_approximation_ratio;
-                } else {
-                    branching_scheme_parameters.maximum_approximation_ratio
-                        = parameters.not_anytime_maximum_approximation_ratio;
-                }
-                branching_scheme_parameters_list.push_back(branching_scheme_parameters);
-                treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
-                ibs_parameters.verbosity_level = 0;
-                ibs_parameters.timer = parameters.timer;
-                ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
-                ibs_parameters.growth_factor = growth_factor;
-                if (parameters.optimization_mode != OptimizationMode::Anytime) {
-                    ibs_parameters.minimum_size_of_the_queue
-                        = parameters.not_anytime_tree_search_queue_size;
-                    ibs_parameters.maximum_size_of_the_queue
-                        = parameters.not_anytime_tree_search_queue_size;
-                }
-                ibs_parameters_list.push_back(ibs_parameters);
-                outputs.push_back(irregular::Output(instance));
-            }
-        }
-    }
-
-    std::vector<std::thread> threads;
-    std::forward_list<std::exception_ptr> exception_ptr_list;
-    for (Counter i = 0; i < (Counter)branching_scheme_parameters_list.size(); ++i) {
-        std::function<void(const Solution&, const std::string&)> new_solution_callback;
-        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
-            new_solution_callback = [&algorithm_formatter](
-                    const Solution& solution,
-                    const std::string& label)
-            {
-                algorithm_formatter.update_solution(solution, label);
-            };
-        } else {
-            new_solution_callback = [&outputs, i](
-                    const Solution& solution,
-                    const std::string& /*label*/)
-            {
-                outputs[i].solution_pool.add(solution);
-            };
-        }
-        exception_ptr_list.push_front(std::exception_ptr());
-        if (parameters.optimization_mode != OptimizationMode::NotAnytimeSequential) {
-            threads.push_back(std::thread(
-                        wrapper<decltype(&optimize_tree_search_worker), optimize_tree_search_worker>,
-                        std::ref(exception_ptr_list.front()),
-                        std::ref(instance),
-                        std::ref(parameters),
-                        std::ref(algorithm_formatter),
-                        branching_scheme_parameters_list[i],
-                        ibs_parameters_list[i],
-                        new_solution_callback));
-        } else {
-            try {
-                optimize_tree_search_worker(
-                        instance,
-                        parameters,
-                        algorithm_formatter,
-                        branching_scheme_parameters_list[i],
-                        ibs_parameters_list[i],
-                        new_solution_callback);
-            } catch (...) {
-                exception_ptr_list.front() = std::current_exception();
-            }
-        }
-    }
-    for (Counter i = 0; i < (Counter)threads.size(); ++i)
-        threads[i].join();
-    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
-        if (exception_ptr)
-            std::rethrow_exception(exception_ptr);
-    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
-        for (Counter i = 0; i < (Counter)branching_scheme_parameters_list.size(); ++i) {
-            std::stringstream ss;
-            ss << "TS g " << branching_scheme_parameters_list[i].guide_id
-                << " d " << (int)branching_scheme_parameters_list[i].direction;
-            algorithm_formatter.update_solution(outputs[i].solution_pool.best(), ss.str());
-        }
-    }
-}
 
 void optimize_local_search(
         const Instance& instance,
@@ -708,6 +416,34 @@ void optimize_milp_raster(
                 "MILP raster");
     };
     milp_raster(instance, milp_raster_parameters);
+}
+
+void optimize_tree_search(
+        const Instance& instance,
+        const OptimizeParameters& parameters,
+        AlgorithmFormatter& algorithm_formatter)
+{
+    TreeSearchParameters ts_parameters;
+    ts_parameters.verbosity_level = 0;
+    ts_parameters.timer = parameters.timer;
+    ts_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    ts_parameters.guides = parameters.tree_search_guides;
+    ts_parameters.optimization_mode = parameters.optimization_mode;
+    ts_parameters.not_anytime_tree_search_queue_size = parameters.not_anytime_tree_search_queue_size;
+    ts_parameters.json_search_tree_path = parameters.json_search_tree_path;
+    ts_parameters.initial_maximum_approximation_ratio = parameters.initial_maximum_approximation_ratio;
+    ts_parameters.not_anytime_maximum_approximation_ratio = parameters.not_anytime_maximum_approximation_ratio;
+    ts_parameters.maximum_approximation_ratio_factor = parameters.maximum_approximation_ratio_factor;
+    ts_parameters.new_solution_callback = [&algorithm_formatter](
+            const packingsolver::Output<Instance, Solution>& ts_output)
+    {
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+        if (ts_output.bin_packing_bound > 0) {
+            algorithm_formatter.update_bin_packing_bound(
+                    ts_output.bin_packing_bound);
+        }
+    };
+    tree_search(instance, ts_parameters);
 }
 
 }

--- a/src/irregular/tree_search.cpp
+++ b/src/irregular/tree_search.cpp
@@ -1,7 +1,12 @@
-#include "irregular/branching_scheme.hpp"
+#include "irregular/tree_search.hpp"
 
+#include "packingsolver/irregular/algorithm_formatter.hpp"
 #include "irregular/rotations.hpp"
 #include "irregular/shape_simplification.hpp"
+#include "treesearchsolver/iterative_beam_search_2.hpp"
+#include <functional>
+#include <thread>
+#include <sstream>
 
 #include "shape/convex_hull.hpp"
 #include "shape/clean.hpp"
@@ -2559,4 +2564,295 @@ std::ostream& packingsolver::irregular::operator<<(
     os << std::endl;
 
     return os;
+}
+
+static void tree_search_worker(
+        const Instance& instance,
+        const TreeSearchParameters& parameters,
+        BranchingScheme::Parameters branching_scheme_parameters,
+        treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters,
+        std::function<void(const Solution&, const std::string&, bool)> new_solution_callback)
+{
+    Counter queue_size = 1;
+    double maximum_approximation_ratio = parameters.initial_maximum_approximation_ratio;
+    std::shared_ptr<BranchingScheme::Node> cutoff = nullptr;
+    for (Counter iteration = 0;
+            ;
+            ++iteration) {
+
+        if (parameters.optimization_mode != OptimizationMode::Anytime) {
+            queue_size = parameters.not_anytime_tree_search_queue_size;
+            maximum_approximation_ratio = parameters.not_anytime_maximum_approximation_ratio;
+        }
+
+        branching_scheme_parameters.maximum_approximation_ratio = maximum_approximation_ratio;
+        ibs_parameters.cutoff = cutoff;
+        ibs_parameters.minimum_size_of_the_queue = queue_size;
+        ibs_parameters.maximum_size_of_the_queue = queue_size;
+        if (!parameters.json_search_tree_path.empty()) {
+            ibs_parameters.json_search_tree_path = parameters.json_search_tree_path
+                + "_guide_" + std::to_string(branching_scheme_parameters.guide_id)
+                + "_d_" + std::to_string((int)branching_scheme_parameters.direction);
+        }
+        BranchingScheme branching_scheme(instance, branching_scheme_parameters);
+        ibs_parameters.new_solution_callback =
+            [&branching_scheme, &branching_scheme_parameters, &new_solution_callback](
+                    const treesearchsolver::Output<BranchingScheme>& tss_output)
+            {
+                const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
+                    = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
+                Solution solution = branching_scheme.to_solution(
+                        tssibs_output.solution_pool.best());
+                std::stringstream ss;
+                ss << "TS g " << branching_scheme_parameters.guide_id
+                    << " d " << (int)branching_scheme_parameters.direction
+                    << " q " << tssibs_output.maximum_size_of_the_queue;
+                new_solution_callback(solution, ss.str(), tssibs_output.optimal);
+            };
+        auto ibs_output = treesearchsolver::iterative_beam_search_2<BranchingScheme>(
+                branching_scheme,
+                ibs_parameters);
+
+        if (ibs_output.optimal)
+            break;
+        if (parameters.timer.needs_to_end())
+            break;
+
+        if (parameters.optimization_mode != OptimizationMode::Anytime)
+            break;
+
+        if (cutoff != nullptr)
+            ibs_output.solution_pool.add(cutoff);
+        cutoff = ibs_output.solution_pool.best();
+
+        queue_size = std::max(
+                queue_size + 1,
+                (NodeId)(queue_size * 1.5));
+        maximum_approximation_ratio *= parameters.maximum_approximation_ratio_factor;
+    }
+}
+
+const packingsolver::irregular::TreeSearchOutput packingsolver::irregular::tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters)
+{
+    TreeSearchOutput output(instance);
+    AlgorithmFormatter algorithm_formatter(instance, parameters, output);
+    algorithm_formatter.start();
+    algorithm_formatter.print_header();
+
+    std::vector<GuideId> guides;
+    if (!parameters.guides.empty()) {
+        guides = parameters.guides;
+    } else if (instance.objective() == Objective::Knapsack) {
+        guides = {4, 5};
+    } else {
+        guides = {0, 1};
+    }
+
+    std::vector<BranchingScheme::Direction> directions;
+    if (instance.objective() == Objective::OpenDimensionX) {
+        directions = {
+            BranchingScheme::Direction::LeftToRightThenBottomToTop,
+            BranchingScheme::Direction::LeftToRightThenTopToBottom,
+        };
+    } else if (instance.objective() == Objective::OpenDimensionY) {
+        directions = {
+            BranchingScheme::Direction::BottomToTopThenLeftToRight,
+            BranchingScheme::Direction::BottomToTopThenRightToLeft,
+        };
+    } else if (instance.number_of_bins() == 1) {
+        if (instance.objective() == Objective::BinPackingWithLeftovers) {
+            switch (instance.parameters().leftover_corner) {
+            case Corner::BottomLeft: {
+                directions = {
+                    BranchingScheme::Direction::LeftToRightThenBottomToTop,
+                    BranchingScheme::Direction::BottomToTopThenLeftToRight,
+                    BranchingScheme::Direction::LeftToRightThenTopToBottom,
+                    BranchingScheme::Direction::BottomToTopThenRightToLeft,
+                };
+                break;
+            } case Corner::BottomRight: {
+                directions = {
+                    BranchingScheme::Direction::RightToLeftThenBottomToTop,
+                    BranchingScheme::Direction::BottomToTopThenLeftToRight,
+                    BranchingScheme::Direction::RightToLeftThenTopToBottom,
+                    BranchingScheme::Direction::BottomToTopThenRightToLeft,
+                };
+                break;
+            } case Corner::TopLeft: {
+                directions = {
+                    BranchingScheme::Direction::LeftToRightThenBottomToTop,
+                    BranchingScheme::Direction::TopToBottomThenLeftToRight,
+                    BranchingScheme::Direction::LeftToRightThenTopToBottom,
+                    BranchingScheme::Direction::TopToBottomThenRightToLeft,
+                };
+                break;
+            } case Corner::TopRight: {
+                directions = {
+                    BranchingScheme::Direction::RightToLeftThenBottomToTop,
+                    BranchingScheme::Direction::TopToBottomThenLeftToRight,
+                    BranchingScheme::Direction::RightToLeftThenTopToBottom,
+                    BranchingScheme::Direction::TopToBottomThenRightToLeft,
+                };
+                break;
+            }
+            }
+        } else {
+            directions = {
+                BranchingScheme::Direction::LeftToRightThenBottomToTop,
+                BranchingScheme::Direction::BottomToTopThenLeftToRight,
+                BranchingScheme::Direction::RightToLeftThenTopToBottom,
+                BranchingScheme::Direction::TopToBottomThenRightToLeft,
+            };
+        }
+    } else {
+        switch (instance.parameters().leftover_corner) {
+        case Corner::BottomLeft: {
+            directions = {BranchingScheme::Direction::LeftToRightThenBottomToTop};
+            break;
+        } case Corner::BottomRight: {
+            directions = {BranchingScheme::Direction::RightToLeftThenBottomToTop};
+            break;
+        } case Corner::TopLeft: {
+            directions = {BranchingScheme::Direction::LeftToRightThenTopToBottom,};
+            break;
+        } case Corner::TopRight: {
+            directions = {BranchingScheme::Direction::RightToLeftThenTopToBottom};
+            break;
+        }
+        }
+    }
+
+    bool all_items_full_rotation = true;
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance.number_of_item_types();
+            ++item_type_id) {
+        const ItemType& item_type = instance.item_type(item_type_id);
+        if (!item_type.has_full_continuous_rotations()) {
+            all_items_full_rotation = false;
+            break;
+        }
+    }
+    bool all_bins_squared = true;
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < instance.number_of_bin_types();
+            ++bin_type_id) {
+        const BinType& bin_type = instance.bin_type(bin_type_id);
+        if (!bin_type.shape_scaled.is_square()) {
+            all_bins_squared = false;
+            break;
+        }
+    }
+    if (all_items_full_rotation && all_bins_squared) {
+        directions = {BranchingScheme::Direction::LeftToRightThenBottomToTop};
+    }
+
+    std::vector<double> growth_factors = {1.5};
+    if (guides.size() * directions.size() * 2 <= 4)
+        growth_factors = {1.33, 1.5};
+    if (parameters.optimization_mode != OptimizationMode::Anytime)
+        growth_factors = {1.5};
+
+    std::vector<BranchingScheme::Parameters> branching_scheme_parameters_list;
+    std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
+    std::vector<packingsolver::Output<Instance, Solution>> local_outputs;
+    for (double growth_factor: growth_factors) {
+        for (GuideId guide_id: guides) {
+            for (BranchingScheme::Direction direction: directions) {
+                BranchingScheme::Parameters branching_scheme_parameters;
+                branching_scheme_parameters.guide_id = guide_id;
+                branching_scheme_parameters.direction = direction;
+                if (parameters.optimization_mode == OptimizationMode::Anytime) {
+                    branching_scheme_parameters.maximum_approximation_ratio
+                        = parameters.initial_maximum_approximation_ratio;
+                } else {
+                    branching_scheme_parameters.maximum_approximation_ratio
+                        = parameters.not_anytime_maximum_approximation_ratio;
+                }
+                branching_scheme_parameters_list.push_back(branching_scheme_parameters);
+                treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
+                ibs_parameters.verbosity_level = 0;
+                ibs_parameters.timer = parameters.timer;
+                ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+                ibs_parameters.growth_factor = growth_factor;
+                if (parameters.optimization_mode != OptimizationMode::Anytime) {
+                    ibs_parameters.minimum_size_of_the_queue
+                        = parameters.not_anytime_tree_search_queue_size;
+                    ibs_parameters.maximum_size_of_the_queue
+                        = parameters.not_anytime_tree_search_queue_size;
+                }
+                ibs_parameters_list.push_back(ibs_parameters);
+                local_outputs.push_back(packingsolver::Output<Instance, Solution>(instance));
+            }
+        }
+    }
+
+    std::vector<std::thread> threads;
+    std::forward_list<std::exception_ptr> exception_ptr_list;
+    for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_scheme_parameters_list.size(); ++scheme_idx) {
+        std::function<void(const Solution&, const std::string&, bool)> new_solution_callback;
+        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
+            new_solution_callback = [&algorithm_formatter](
+                    const Solution& solution,
+                    const std::string& label,
+                    bool is_optimal)
+            {
+                algorithm_formatter.update_solution(solution, label);
+                if (is_optimal
+                        && solution.instance().objective() == packingsolver::Objective::BinPacking) {
+                    algorithm_formatter.update_bin_packing_bound(
+                            solution.number_of_bins());
+                }
+            };
+        } else {
+            new_solution_callback = [&local_outputs, scheme_idx](
+                    const Solution& solution,
+                    const std::string& /*label*/,
+                    bool /*is_optimal*/)
+            {
+                local_outputs[(size_t)scheme_idx].solution_pool.add(solution);
+            };
+        }
+        exception_ptr_list.push_front(std::exception_ptr());
+        if (parameters.optimization_mode != OptimizationMode::NotAnytimeSequential) {
+            threads.push_back(std::thread(
+                        wrapper<decltype(&tree_search_worker), tree_search_worker>,
+                        std::ref(exception_ptr_list.front()),
+                        std::ref(instance),
+                        std::ref(parameters),
+                        branching_scheme_parameters_list[scheme_idx],
+                        ibs_parameters_list[scheme_idx],
+                        new_solution_callback));
+        } else {
+            try {
+                tree_search_worker(
+                        instance,
+                        parameters,
+                        branching_scheme_parameters_list[scheme_idx],
+                        ibs_parameters_list[scheme_idx],
+                        new_solution_callback);
+            } catch (...) {
+                exception_ptr_list.front() = std::current_exception();
+            }
+        }
+    }
+    for (Counter thread_idx = 0; thread_idx < (Counter)threads.size(); ++thread_idx)
+        threads[thread_idx].join();
+    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
+        if (exception_ptr)
+            std::rethrow_exception(exception_ptr);
+    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
+        for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_scheme_parameters_list.size(); ++scheme_idx) {
+            std::stringstream ss;
+            ss << "TS g " << branching_scheme_parameters_list[scheme_idx].guide_id
+                << " d " << (int)branching_scheme_parameters_list[scheme_idx].direction;
+            algorithm_formatter.update_solution(
+                    local_outputs[(size_t)scheme_idx].solution_pool.best(),
+                    ss.str());
+        }
+    }
+
+    algorithm_formatter.end();
+    return output;
 }

--- a/src/irregular/tree_search.hpp
+++ b/src/irregular/tree_search.hpp
@@ -719,3 +719,41 @@ inline bool BranchingScheme::operator()(
 
 }
 }
+
+#include "packingsolver/irregular/solution.hpp"
+
+#include <functional>
+#include <limits>
+
+namespace packingsolver
+{
+namespace irregular
+{
+
+struct TreeSearchOutput: packingsolver::Output<Instance, Solution>
+{
+    TreeSearchOutput(const Instance& instance):
+        packingsolver::Output<Instance, Solution>(instance) { }
+};
+
+struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution>
+{
+    std::vector<GuideId> guides;
+
+    OptimizationMode optimization_mode = OptimizationMode::Anytime;
+
+    NodeId not_anytime_tree_search_queue_size = 1;
+
+    double initial_maximum_approximation_ratio = std::numeric_limits<double>::infinity();
+
+    double not_anytime_maximum_approximation_ratio = std::numeric_limits<double>::infinity();
+
+    double maximum_approximation_ratio_factor = 1.0;
+};
+
+const TreeSearchOutput tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters = {});
+
+}
+}

--- a/src/onedimensional/CMakeLists.txt
+++ b/src/onedimensional/CMakeLists.txt
@@ -7,7 +7,7 @@ target_sources(PackingSolver_onedimensional PRIVATE
     algorithm_formatter.cpp
     optimize.cpp
     post_process.cpp
-    branching_scheme.cpp)
+    tree_search.cpp)
 target_include_directories(PackingSolver_onedimensional PUBLIC
     ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(PackingSolver_onedimensional PRIVATE

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -2,12 +2,11 @@
 
 #include "packingsolver/onedimensional/algorithm_formatter.hpp"
 #include "packingsolver/onedimensional/instance_builder.hpp"
-#include "onedimensional/branching_scheme.hpp"
+#include "onedimensional/tree_search.hpp"
 #include "algorithms/dichotomic_search.hpp"
 #include "algorithms/sequential_value_correction.hpp"
 #include "algorithms/column_generation.hpp"
 
-#include "treesearchsolver/iterative_beam_search_2.hpp"
 
 #include "knapsacksolver/instance_builder.hpp"
 #include "knapsacksolver/algorithms/dynamic_programming_primal_dual.hpp"
@@ -84,125 +83,7 @@ void optimize_dynamic_programming(
     algorithm_formatter.update_knapsack_bound(solution.profit());
 }
 
-void optimize_tree_search(
-        const Instance& instance,
-        const OptimizeParameters& parameters,
-        AlgorithmFormatter& algorithm_formatter)
-{
-    // Try dynamic programming.
-    optimize_dynamic_programming(instance, parameters, algorithm_formatter);
-    if (algorithm_formatter.end_boolean())
-        return;
 
-    std::vector<GuideId> guides;
-    if (!parameters.tree_search_guides.empty()) {
-        guides = parameters.tree_search_guides;
-    } else if (instance.objective() == Objective::Knapsack) {
-        guides = {4, 5};
-    } else if (instance.objective() == Objective::BinPackingWithLeftovers) {
-        guides = {0, 1};
-    } else {
-        guides = {0, 2};
-    }
-
-    std::vector<double> growth_factors = {1.5};
-    if (guides.size() * 2 <= 4)
-        growth_factors = {1.33, 1.5};
-    if (parameters.optimization_mode != OptimizationMode::Anytime)
-        growth_factors = {1.5};
-
-    std::vector<BranchingScheme> branching_schemes;
-    std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
-    std::vector<onedimensional::Output> outputs;
-    for (double growth_factor: growth_factors) {
-        for (GuideId guide_id: guides) {
-            //std::cout << growth_factor << " " << guide_id << std::endl;
-            BranchingScheme::Parameters branching_scheme_parameters;
-            branching_scheme_parameters.guide_id = guide_id;
-            branching_schemes.push_back(BranchingScheme(instance, branching_scheme_parameters));
-            treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
-            ibs_parameters.verbosity_level = 0;
-            ibs_parameters.timer = parameters.timer;
-            ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
-            ibs_parameters.growth_factor = growth_factor;
-            if (parameters.optimization_mode != OptimizationMode::Anytime) {
-                ibs_parameters.minimum_size_of_the_queue = 1;
-                ibs_parameters.growth_factor
-                    = parameters.not_anytime_tree_search_queue_size;
-                ibs_parameters.maximum_size_of_the_queue
-                    = parameters.not_anytime_tree_search_queue_size;
-            }
-            ibs_parameters_list.push_back(ibs_parameters);
-            outputs.push_back(onedimensional::Output(instance));
-        }
-    }
-
-    std::vector<std::thread> threads;
-    std::forward_list<std::exception_ptr> exception_ptr_list;
-    for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
-        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
-            ibs_parameters_list[i].new_solution_callback
-                = [&algorithm_formatter, &branching_schemes, i](
-                        const treesearchsolver::Output<BranchingScheme>& tss_output)
-                {
-                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
-                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
-                    Solution solution = branching_schemes[i].to_solution(
-                            tssibs_output.solution_pool.best());
-                    std::stringstream ss;
-                    ss << "TS g " << branching_schemes[i].parameters().guide_id
-                        << " q " << tssibs_output.maximum_size_of_the_queue;
-                    algorithm_formatter.update_solution(solution, ss.str());
-
-                    if (tssibs_output.optimal) {
-                        if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
-                            algorithm_formatter.update_bin_packing_bound(
-                                    solution.number_of_bins());
-                        }
-                    }
-                };
-        } else {
-            ibs_parameters_list[i].new_solution_callback
-                = [&outputs, &branching_schemes, i](
-                        const treesearchsolver::Output<BranchingScheme>& tss_output)
-                {
-                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
-                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
-                    Solution solution = branching_schemes[i].to_solution(
-                            tssibs_output.solution_pool.best());
-                    outputs[i].solution_pool.add(solution);
-                };
-        }
-        exception_ptr_list.push_front(std::exception_ptr());
-        if (parameters.optimization_mode != OptimizationMode::NotAnytimeSequential) {
-            threads.push_back(std::thread(
-                        wrapper<decltype(&treesearchsolver::iterative_beam_search_2<BranchingScheme>), treesearchsolver::iterative_beam_search_2<BranchingScheme>>,
-                        std::ref(exception_ptr_list.front()),
-                        std::ref(branching_schemes[i]),
-                        ibs_parameters_list[i]));
-        } else {
-            try {
-                treesearchsolver::iterative_beam_search_2<BranchingScheme>(
-                        branching_schemes[i],
-                        ibs_parameters_list[i]);
-            } catch (...) {
-                exception_ptr_list.front() = std::current_exception();
-            }
-        }
-    }
-    for (Counter i = 0; i < (Counter)threads.size(); ++i)
-        threads[i].join();
-    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
-        if (exception_ptr)
-            std::rethrow_exception(exception_ptr);
-    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
-        for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
-            std::stringstream ss;
-            ss << "TS g " << branching_schemes[i].parameters().guide_id;
-            algorithm_formatter.update_solution(outputs[i].solution_pool.best(), ss.str());
-        }
-    }
-}
 
 void optimize_sequential_single_knapsack(
         const Instance& instance,
@@ -436,6 +317,35 @@ void optimize_column_generation(
     cgslds_parameters.column_generation_parameters.solver_name
         = parameters.linear_programming_solver_name;
     columngenerationsolver::limited_discrepancy_search(cgs_model, cgslds_parameters);
+}
+
+void optimize_tree_search(
+        const Instance& instance,
+        const OptimizeParameters& parameters,
+        AlgorithmFormatter& algorithm_formatter)
+{
+    optimize_dynamic_programming(instance, parameters, algorithm_formatter);
+    if (algorithm_formatter.end_boolean())
+        return;
+
+    TreeSearchParameters ts_parameters;
+    ts_parameters.verbosity_level = 0;
+    ts_parameters.timer = parameters.timer;
+    ts_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    ts_parameters.guides = parameters.tree_search_guides;
+    ts_parameters.optimization_mode = parameters.optimization_mode;
+    ts_parameters.not_anytime_tree_search_queue_size = parameters.not_anytime_tree_search_queue_size;
+    ts_parameters.json_search_tree_path = parameters.json_search_tree_path;
+    ts_parameters.new_solution_callback = [&algorithm_formatter](
+            const packingsolver::Output<Instance, Solution>& ts_output)
+    {
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+        if (ts_output.bin_packing_bound > 0) {
+            algorithm_formatter.update_bin_packing_bound(
+                    ts_output.bin_packing_bound);
+        }
+    };
+    tree_search(instance, ts_parameters);
 }
 
 }

--- a/src/onedimensional/tree_search.cpp
+++ b/src/onedimensional/tree_search.cpp
@@ -1,4 +1,9 @@
-#include "onedimensional/branching_scheme.hpp"
+#include "onedimensional/tree_search.hpp"
+
+#include "packingsolver/onedimensional/algorithm_formatter.hpp"
+#include "treesearchsolver/iterative_beam_search_2.hpp"
+
+#include <thread>
 
 using namespace packingsolver;
 using namespace packingsolver::onedimensional;
@@ -345,3 +350,126 @@ std::ostream& packingsolver::onedimensional::operator<<(
     return os;
 }
 
+
+const packingsolver::onedimensional::TreeSearchOutput packingsolver::onedimensional::tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters)
+{
+    TreeSearchOutput output(instance);
+    AlgorithmFormatter algorithm_formatter(instance, parameters, output);
+    algorithm_formatter.start();
+    algorithm_formatter.print_header();
+
+    std::vector<GuideId> guides;
+    if (!parameters.guides.empty()) {
+        guides = parameters.guides;
+    } else if (instance.objective() == Objective::Knapsack) {
+        guides = {4, 5};
+    } else if (instance.objective() == Objective::BinPackingWithLeftovers) {
+        guides = {0, 1};
+    } else {
+        guides = {0, 2};
+    }
+
+    std::vector<double> growth_factors = {1.5};
+    if (guides.size() * 2 <= 4)
+        growth_factors = {1.33, 1.5};
+    if (parameters.optimization_mode != OptimizationMode::Anytime)
+        growth_factors = {1.5};
+
+    std::vector<BranchingScheme> branching_schemes;
+    std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
+    std::vector<packingsolver::Output<Instance, Solution>> local_outputs;
+    for (double growth_factor: growth_factors) {
+        for (GuideId guide_id: guides) {
+            BranchingScheme::Parameters branching_scheme_parameters;
+            branching_scheme_parameters.guide_id = guide_id;
+            branching_schemes.push_back(BranchingScheme(instance, branching_scheme_parameters));
+            treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
+            ibs_parameters.verbosity_level = 0;
+            ibs_parameters.timer = parameters.timer;
+            ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+            ibs_parameters.growth_factor = growth_factor;
+            if (parameters.optimization_mode != OptimizationMode::Anytime) {
+                ibs_parameters.minimum_size_of_the_queue = 1;
+                ibs_parameters.growth_factor = parameters.not_anytime_tree_search_queue_size;
+                ibs_parameters.maximum_size_of_the_queue = parameters.not_anytime_tree_search_queue_size;
+            }
+            if (!parameters.json_search_tree_path.empty()) {
+                ibs_parameters.json_search_tree_path = parameters.json_search_tree_path
+                    + "_guide_" + std::to_string(guide_id);
+            }
+            ibs_parameters_list.push_back(ibs_parameters);
+            local_outputs.push_back(packingsolver::Output<Instance, Solution>(instance));
+        }
+    }
+
+    std::vector<std::thread> threads;
+    std::forward_list<std::exception_ptr> exception_ptr_list;
+    for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
+        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
+            ibs_parameters_list[scheme_idx].new_solution_callback
+                = [&algorithm_formatter, &branching_schemes, scheme_idx](
+                        const treesearchsolver::Output<BranchingScheme>& tss_output)
+                {
+                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
+                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
+                    Solution solution = branching_schemes[scheme_idx].to_solution(
+                            tssibs_output.solution_pool.best());
+                    std::stringstream ss;
+                    ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
+                        << " q " << tssibs_output.maximum_size_of_the_queue;
+                    algorithm_formatter.update_solution(solution, ss.str());
+                    if (tssibs_output.optimal
+                            && solution.instance().objective() == packingsolver::Objective::BinPacking) {
+                        algorithm_formatter.update_bin_packing_bound(
+                                solution.number_of_bins());
+                    }
+                };
+        } else {
+            ibs_parameters_list[scheme_idx].new_solution_callback
+                = [&local_outputs, &branching_schemes, scheme_idx](
+                        const treesearchsolver::Output<BranchingScheme>& tss_output)
+                {
+                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
+                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
+                    Solution solution = branching_schemes[scheme_idx].to_solution(
+                            tssibs_output.solution_pool.best());
+                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution);
+                };
+        }
+        exception_ptr_list.push_front(std::exception_ptr());
+        if (parameters.optimization_mode != OptimizationMode::NotAnytimeSequential) {
+            threads.push_back(std::thread(
+                        wrapper<decltype(&treesearchsolver::iterative_beam_search_2<BranchingScheme>), treesearchsolver::iterative_beam_search_2<BranchingScheme>>,
+                        std::ref(exception_ptr_list.front()),
+                        std::ref(branching_schemes[scheme_idx]),
+                        ibs_parameters_list[scheme_idx]));
+        } else {
+            try {
+                treesearchsolver::iterative_beam_search_2<BranchingScheme>(
+                        branching_schemes[scheme_idx],
+                        ibs_parameters_list[scheme_idx]);
+            } catch (...) {
+                exception_ptr_list.front() = std::current_exception();
+            }
+        }
+    }
+    for (Counter thread_idx = 0; thread_idx < (Counter)threads.size(); ++thread_idx)
+        threads[thread_idx].join();
+    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
+        if (exception_ptr)
+            std::rethrow_exception(exception_ptr);
+    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
+        for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
+            std::stringstream ss;
+            ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id;
+            algorithm_formatter.update_solution(
+                    local_outputs[(size_t)scheme_idx].solution_pool.best(),
+                    ss.str());
+        }
+    }
+
+    algorithm_formatter.end();
+    return output;
+}

--- a/src/onedimensional/tree_search.hpp
+++ b/src/onedimensional/tree_search.hpp
@@ -384,3 +384,32 @@ inline bool BranchingScheme::operator()(
 
 }
 }
+
+#include "packingsolver/onedimensional/solution.hpp"
+
+namespace packingsolver
+{
+namespace onedimensional
+{
+
+struct TreeSearchOutput: packingsolver::Output<Instance, Solution>
+{
+    TreeSearchOutput(const Instance& instance):
+        packingsolver::Output<Instance, Solution>(instance) { }
+};
+
+struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution>
+{
+    std::vector<GuideId> guides;
+
+    OptimizationMode optimization_mode = OptimizationMode::Anytime;
+
+    NodeId not_anytime_tree_search_queue_size = 1;
+};
+
+const TreeSearchOutput tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters = {});
+
+}
+}

--- a/src/rectangle/CMakeLists.txt
+++ b/src/rectangle/CMakeLists.txt
@@ -9,7 +9,7 @@ target_sources(PackingSolver_rectangle PRIVATE
     algorithm_formatter.cpp
     optimize.cpp
     post_process.cpp
-    branching_scheme.cpp
+    tree_search.cpp
     benders_decomposition.cpp
     dual_feasible_functions.cpp)
 target_include_directories(PackingSolver_rectangle PUBLIC

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -2,14 +2,12 @@
 
 #include "packingsolver/rectangle/algorithm_formatter.hpp"
 #include "packingsolver/rectangle/instance_builder.hpp"
-#include "rectangle/branching_scheme.hpp"
+#include "rectangle/tree_search.hpp"
 #include "rectangle/benders_decomposition.hpp"
 #include "rectangle/dual_feasible_functions.hpp"
 #include "algorithms/dichotomic_search.hpp"
 #include "algorithms/sequential_value_correction.hpp"
 #include "algorithms/column_generation.hpp"
-
-#include "treesearchsolver/iterative_beam_search_2.hpp"
 
 #include <thread>
 
@@ -37,146 +35,6 @@ void optimize_dual_feasible_functions(
     dual_feasible_functions(instance, dff_parameters);
 }
 
-void optimize_tree_search(
-        const Instance& instance,
-        const OptimizeParameters& parameters,
-        AlgorithmFormatter& algorithm_formatter)
-{
-    std::vector<GuideId> guides;
-    if (!parameters.tree_search_guides.empty()) {
-        guides = parameters.tree_search_guides;
-    } else if (instance.objective() == Objective::Knapsack) {
-        guides = {4, 5};
-    } else {
-        guides = {0, 1};
-    }
-
-    std::vector<Direction> directions;
-    if (instance.objective() == Objective::OpenDimensionX) {
-        directions = {Direction::X};
-    } else if (instance.objective() == Objective::OpenDimensionY) {
-        directions = {Direction::Y};
-    } else if (instance.unloading_constraint() == UnloadingConstraint::IncreasingX
-            || instance.unloading_constraint() == UnloadingConstraint::OnlyXMovements) {
-        directions = {Direction::X};
-    } else if (instance.unloading_constraint() == UnloadingConstraint::IncreasingY
-            || instance.unloading_constraint() == UnloadingConstraint::OnlyYMovements) {
-        directions = {Direction::Y};
-    } else if (instance.number_of_bin_types() == 1) {
-        directions = {Direction::X, Direction::Y};
-    } else {
-        directions = {Direction::Any};
-    }
-
-    std::vector<double> growth_factors = {1.5};
-    if (guides.size() * directions.size() * 2 <= 4)
-        growth_factors = {1.33, 1.5};
-    if (parameters.optimization_mode != OptimizationMode::Anytime)
-        growth_factors = {1.5};
-
-    std::vector<BranchingScheme> branching_schemes;
-    std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
-    std::vector<rectangle::Output> outputs;
-    for (double growth_factor: growth_factors) {
-        for (GuideId guide_id: guides) {
-            for (Direction direction: directions) {
-                //std::cout << growth_factor << " " << guide_id << " " << direction << std::endl;
-                BranchingScheme::Parameters branching_scheme_parameters;
-                branching_scheme_parameters.guide_id = guide_id;
-                branching_scheme_parameters.direction = direction;
-                branching_scheme_parameters.fixed_items = parameters.fixed_items;
-                branching_schemes.push_back(BranchingScheme(instance, branching_scheme_parameters));
-                treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
-                ibs_parameters.verbosity_level = 0;
-                ibs_parameters.timer = parameters.timer;
-                ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
-                ibs_parameters.growth_factor = growth_factor;
-                if (parameters.optimization_mode != OptimizationMode::Anytime) {
-                    ibs_parameters.minimum_size_of_the_queue = 1;
-                    ibs_parameters.growth_factor
-                        = parameters.not_anytime_tree_search_queue_size;
-                    ibs_parameters.maximum_size_of_the_queue
-                        = parameters.not_anytime_tree_search_queue_size;
-                }
-                if (!parameters.json_search_tree_path.empty()) {
-                    ibs_parameters.json_search_tree_path = parameters.json_search_tree_path
-                        + "_guide_" + std::to_string(branching_scheme_parameters.guide_id)
-                        + "_d_" + std::to_string((int)branching_scheme_parameters.direction);
-                }
-                ibs_parameters_list.push_back(ibs_parameters);
-                outputs.push_back(rectangle::Output(instance));
-            }
-        }
-    }
-
-    std::vector<std::thread> threads;
-    std::forward_list<std::exception_ptr> exception_ptr_list;
-    for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
-        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
-            ibs_parameters_list[i].new_solution_callback
-                = [&algorithm_formatter, &branching_schemes, i](
-                        const treesearchsolver::Output<BranchingScheme>& tss_output)
-                {
-                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
-                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
-                    Solution solution = branching_schemes[i].to_solution(
-                            tssibs_output.solution_pool.best());
-                    std::stringstream ss;
-                    ss << "TS g " << branching_schemes[i].parameters().guide_id
-                        << " d " << branching_schemes[i].parameters().direction
-                        << " q " << tssibs_output.maximum_size_of_the_queue;
-                    algorithm_formatter.update_solution(solution, ss.str());
-
-                    if (tssibs_output.optimal) {
-                        if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
-                            algorithm_formatter.update_bin_packing_bound(
-                                    solution.number_of_bins());
-                        }
-                    }
-                };
-        } else {
-            ibs_parameters_list[i].new_solution_callback
-                = [&outputs, &branching_schemes, i](
-                        const treesearchsolver::Output<BranchingScheme>& tss_output)
-                {
-                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
-                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
-                    Solution solution = branching_schemes[i].to_solution(
-                            tssibs_output.solution_pool.best());
-                    outputs[i].solution_pool.add(solution);
-                };
-        }
-        exception_ptr_list.push_front(std::exception_ptr());
-        if (parameters.optimization_mode != OptimizationMode::NotAnytimeSequential) {
-            threads.push_back(std::thread(
-                        wrapper<decltype(&treesearchsolver::iterative_beam_search_2<BranchingScheme>), treesearchsolver::iterative_beam_search_2<BranchingScheme>>,
-                        std::ref(exception_ptr_list.front()),
-                        std::ref(branching_schemes[i]),
-                        ibs_parameters_list[i]));
-        } else {
-            try {
-                treesearchsolver::iterative_beam_search_2<BranchingScheme>(
-                        branching_schemes[i],
-                        ibs_parameters_list[i]);
-            } catch (...) {
-                exception_ptr_list.front() = std::current_exception();
-            }
-        }
-    }
-    for (Counter i = 0; i < (Counter)threads.size(); ++i)
-        threads[i].join();
-    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
-        if (exception_ptr)
-            std::rethrow_exception(exception_ptr);
-    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
-        for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
-            std::stringstream ss;
-            ss << "TS g " << branching_schemes[i].parameters().guide_id
-                << " d " << branching_schemes[i].parameters().direction;
-            algorithm_formatter.update_solution(outputs[i].solution_pool.best(), ss.str());
-        }
-    }
-}
 
 void optimize_sequential_single_knapsack(
         const Instance& instance,
@@ -416,6 +274,32 @@ void optimize_benders_decomposition(
         algorithm_formatter.update_solution(psbd_output.solution_pool.best(), ss.str());
     };
     benders_decomposition(instance, bd_parameters);
+}
+
+void optimize_tree_search(
+        const Instance& instance,
+        const OptimizeParameters& parameters,
+        AlgorithmFormatter& algorithm_formatter)
+{
+    TreeSearchParameters ts_parameters;
+    ts_parameters.verbosity_level = 0;
+    ts_parameters.timer = parameters.timer;
+    ts_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    ts_parameters.guides = parameters.tree_search_guides;
+    ts_parameters.optimization_mode = parameters.optimization_mode;
+    ts_parameters.not_anytime_tree_search_queue_size = parameters.not_anytime_tree_search_queue_size;
+    ts_parameters.json_search_tree_path = parameters.json_search_tree_path;
+    ts_parameters.fixed_items = parameters.fixed_items;
+    ts_parameters.new_solution_callback = [&algorithm_formatter](
+            const packingsolver::Output<Instance, Solution>& ts_output)
+    {
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+        if (ts_output.bin_packing_bound > 0) {
+            algorithm_formatter.update_bin_packing_bound(
+                    ts_output.bin_packing_bound);
+        }
+    };
+    tree_search(instance, ts_parameters);
 }
 
 }

--- a/src/rectangle/tree_search.cpp
+++ b/src/rectangle/tree_search.cpp
@@ -1,8 +1,11 @@
-#include "rectangle/branching_scheme.hpp"
+#include "rectangle/tree_search.hpp"
 
+#include "packingsolver/rectangle/algorithm_formatter.hpp"
 #include "rectangle/solution_builder.hpp"
 
 #include <iostream>
+#include "treesearchsolver/iterative_beam_search_2.hpp"
+#include <thread>
 #include <string>
 
 #include "shape/shape.hpp"
@@ -1400,4 +1403,149 @@ std::ostream& packingsolver::rectangle::operator<<(
     os << std::endl;
 
     return os;
+}
+
+const packingsolver::rectangle::TreeSearchOutput packingsolver::rectangle::tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters)
+{
+    TreeSearchOutput output(instance);
+    AlgorithmFormatter algorithm_formatter(instance, parameters, output);
+    algorithm_formatter.start();
+    algorithm_formatter.print_header();
+
+    std::vector<GuideId> guides;
+    if (!parameters.guides.empty()) {
+        guides = parameters.guides;
+    } else if (instance.objective() == Objective::Knapsack) {
+        guides = {4, 5};
+    } else {
+        guides = {0, 1};
+    }
+
+    std::vector<Direction> directions;
+    if (instance.objective() == Objective::OpenDimensionX) {
+        directions = {Direction::X};
+    } else if (instance.objective() == Objective::OpenDimensionY) {
+        directions = {Direction::Y};
+    } else if (instance.unloading_constraint() == UnloadingConstraint::IncreasingX
+            || instance.unloading_constraint() == UnloadingConstraint::OnlyXMovements) {
+        directions = {Direction::X};
+    } else if (instance.unloading_constraint() == UnloadingConstraint::IncreasingY
+            || instance.unloading_constraint() == UnloadingConstraint::OnlyYMovements) {
+        directions = {Direction::Y};
+    } else if (instance.number_of_bin_types() == 1) {
+        directions = {Direction::X, Direction::Y};
+    } else {
+        directions = {Direction::Any};
+    }
+
+    std::vector<double> growth_factors = {1.5};
+    if (guides.size() * directions.size() * 2 <= 4)
+        growth_factors = {1.33, 1.5};
+    if (parameters.optimization_mode != OptimizationMode::Anytime)
+        growth_factors = {1.5};
+
+    std::vector<BranchingScheme> branching_schemes;
+    std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
+    std::vector<packingsolver::Output<Instance, Solution>> local_outputs;
+    for (double growth_factor: growth_factors) {
+        for (GuideId guide_id: guides) {
+            for (Direction direction: directions) {
+                BranchingScheme::Parameters branching_scheme_parameters;
+                branching_scheme_parameters.guide_id = guide_id;
+                branching_scheme_parameters.direction = direction;
+                branching_scheme_parameters.fixed_items = parameters.fixed_items;
+                branching_schemes.push_back(BranchingScheme(instance, branching_scheme_parameters));
+                treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
+                ibs_parameters.verbosity_level = 0;
+                ibs_parameters.timer = parameters.timer;
+                ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+                ibs_parameters.growth_factor = growth_factor;
+                if (parameters.optimization_mode != OptimizationMode::Anytime) {
+                    ibs_parameters.minimum_size_of_the_queue = 1;
+                    ibs_parameters.growth_factor = parameters.not_anytime_tree_search_queue_size;
+                    ibs_parameters.maximum_size_of_the_queue = parameters.not_anytime_tree_search_queue_size;
+                }
+                if (!parameters.json_search_tree_path.empty()) {
+                    ibs_parameters.json_search_tree_path = parameters.json_search_tree_path
+                        + "_guide_" + std::to_string(branching_scheme_parameters.guide_id)
+                        + "_d_" + std::to_string((int)branching_scheme_parameters.direction);
+                }
+                ibs_parameters_list.push_back(ibs_parameters);
+                local_outputs.push_back(packingsolver::Output<Instance, Solution>(instance));
+            }
+        }
+    }
+
+    std::vector<std::thread> threads;
+    std::forward_list<std::exception_ptr> exception_ptr_list;
+    for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
+        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
+            ibs_parameters_list[scheme_idx].new_solution_callback
+                = [&algorithm_formatter, &branching_schemes, scheme_idx](
+                        const treesearchsolver::Output<BranchingScheme>& tss_output)
+                {
+                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
+                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
+                    Solution solution = branching_schemes[scheme_idx].to_solution(
+                            tssibs_output.solution_pool.best());
+                    std::stringstream ss;
+                    ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
+                        << " d " << branching_schemes[scheme_idx].parameters().direction
+                        << " q " << tssibs_output.maximum_size_of_the_queue;
+                    algorithm_formatter.update_solution(solution, ss.str());
+                    if (tssibs_output.optimal
+                            && solution.instance().objective() == packingsolver::Objective::BinPacking) {
+                        algorithm_formatter.update_bin_packing_bound(
+                                solution.number_of_bins());
+                    }
+                };
+        } else {
+            ibs_parameters_list[scheme_idx].new_solution_callback
+                = [&local_outputs, &branching_schemes, scheme_idx](
+                        const treesearchsolver::Output<BranchingScheme>& tss_output)
+                {
+                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
+                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
+                    Solution solution = branching_schemes[scheme_idx].to_solution(
+                            tssibs_output.solution_pool.best());
+                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution);
+                };
+        }
+        exception_ptr_list.push_front(std::exception_ptr());
+        if (parameters.optimization_mode != OptimizationMode::NotAnytimeSequential) {
+            threads.push_back(std::thread(
+                        wrapper<decltype(&treesearchsolver::iterative_beam_search_2<BranchingScheme>), treesearchsolver::iterative_beam_search_2<BranchingScheme>>,
+                        std::ref(exception_ptr_list.front()),
+                        std::ref(branching_schemes[scheme_idx]),
+                        ibs_parameters_list[scheme_idx]));
+        } else {
+            try {
+                treesearchsolver::iterative_beam_search_2<BranchingScheme>(
+                        branching_schemes[scheme_idx],
+                        ibs_parameters_list[scheme_idx]);
+            } catch (...) {
+                exception_ptr_list.front() = std::current_exception();
+            }
+        }
+    }
+    for (Counter thread_idx = 0; thread_idx < (Counter)threads.size(); ++thread_idx)
+        threads[thread_idx].join();
+    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
+        if (exception_ptr)
+            std::rethrow_exception(exception_ptr);
+    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
+        for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
+            std::stringstream ss;
+            ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
+                << " d " << branching_schemes[scheme_idx].parameters().direction;
+            algorithm_formatter.update_solution(
+                    local_outputs[(size_t)scheme_idx].solution_pool.best(),
+                    ss.str());
+        }
+    }
+
+    algorithm_formatter.end();
+    return output;
 }

--- a/src/rectangle/tree_search.hpp
+++ b/src/rectangle/tree_search.hpp
@@ -683,3 +683,34 @@ inline bool BranchingScheme::operator()(
 
 }
 }
+
+#include "packingsolver/rectangle/solution.hpp"
+
+namespace packingsolver
+{
+namespace rectangle
+{
+
+struct TreeSearchOutput: packingsolver::Output<Instance, Solution>
+{
+    TreeSearchOutput(const Instance& instance):
+        packingsolver::Output<Instance, Solution>(instance) { }
+};
+
+struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution>
+{
+    std::vector<GuideId> guides;
+
+    OptimizationMode optimization_mode = OptimizationMode::Anytime;
+
+    NodeId not_anytime_tree_search_queue_size = 1;
+
+    Solution* fixed_items = nullptr;
+};
+
+const TreeSearchOutput tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters = {});
+
+}
+}

--- a/src/rectangleguillotine/CMakeLists.txt
+++ b/src/rectangleguillotine/CMakeLists.txt
@@ -9,7 +9,7 @@ target_sources(PackingSolver_rectangleguillotine PRIVATE
     algorithm_formatter.cpp
     optimize.cpp
     post_process.cpp
-    branching_scheme.cpp
+    tree_search.cpp
     column_generation_2.cpp)
 target_include_directories(PackingSolver_rectangleguillotine PUBLIC
     ${PROJECT_SOURCE_DIR}/include)

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -2,15 +2,13 @@
 
 #include "packingsolver/rectangleguillotine/algorithm_formatter.hpp"
 #include "packingsolver/rectangleguillotine/instance_builder.hpp"
-#include "rectangleguillotine/branching_scheme.hpp"
+#include "rectangleguillotine/tree_search.hpp"
 #include "rectangleguillotine/column_generation_2.hpp"
 #include "rectangle/dual_feasible_functions.hpp"
 #include "packingsolver/rectangle/instance_builder.hpp"
 #include "algorithms/dichotomic_search.hpp"
 #include "algorithms/sequential_value_correction.hpp"
 #include "algorithms/column_generation.hpp"
-
-#include "treesearchsolver/iterative_beam_search_2.hpp"
 
 #include <thread>
 
@@ -62,134 +60,6 @@ void optimize_dual_feasible_functions(
     rectangle::dual_feasible_functions(rectangle_instance, dff_parameters);
 }
 
-void optimize_tree_search(
-        const Instance& instance,
-        const OptimizeParameters& parameters,
-        AlgorithmFormatter& algorithm_formatter)
-{
-    std::vector<GuideId> guides;
-    if (!parameters.tree_search_guides.empty()) {
-        guides = parameters.tree_search_guides;
-    } else if (instance.objective() == Objective::Knapsack) {
-        guides = {4, 5};
-    } else {
-        guides = {0, 1};
-    }
-
-    std::vector<CutOrientation> first_stage_orientations = {instance.parameters().first_stage_orientation};
-    if (instance.number_of_bin_types() == 1
-            && instance.parameters().first_stage_orientation == CutOrientation::Any) {
-        first_stage_orientations = {CutOrientation::Vertical, CutOrientation::Horizontal};
-    }
-
-    std::vector<double> growth_factors = {1.5};
-    if (guides.size() * first_stage_orientations.size() * 2 <= 4)
-        growth_factors = {1.33, 1.5};
-    if (parameters.optimization_mode != OptimizationMode::Anytime)
-        growth_factors = {1.5};
-
-    std::vector<BranchingScheme> branching_schemes;
-    std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
-    std::vector<rectangleguillotine::Output> outputs;
-    for (double growth_factor: growth_factors) {
-        for (GuideId guide_id: guides) {
-            for (CutOrientation first_stage_orientation: first_stage_orientations) {
-                //std::cout << growth_factor << " " << guide_id << " " << first_stage_orientation << std::endl;
-                BranchingScheme::Parameters branching_scheme_parameters;
-                branching_scheme_parameters.guide_id = guide_id;
-                branching_scheme_parameters.first_stage_orientation = first_stage_orientation;
-                branching_schemes.push_back(BranchingScheme(instance, branching_scheme_parameters));
-                treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
-                ibs_parameters.verbosity_level = 0;
-                ibs_parameters.timer = parameters.timer;
-                ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
-                ibs_parameters.growth_factor = growth_factor;
-                if (parameters.optimization_mode != OptimizationMode::Anytime) {
-                    ibs_parameters.minimum_size_of_the_queue = 1;
-                    ibs_parameters.growth_factor
-                        = parameters.not_anytime_tree_search_queue_size;
-                    ibs_parameters.maximum_size_of_the_queue
-                        = parameters.not_anytime_tree_search_queue_size + 1;
-                }
-                if (!parameters.json_search_tree_path.empty()) {
-                    ibs_parameters.json_search_tree_path = parameters.json_search_tree_path
-                        + "_guide_" + std::to_string(branching_scheme_parameters.guide_id)
-                        + "_d_" + std::to_string((int)branching_scheme_parameters.first_stage_orientation);
-                }
-                ibs_parameters_list.push_back(ibs_parameters);
-                outputs.push_back(rectangleguillotine::Output(instance));
-            }
-        }
-    }
-
-    std::vector<std::thread> threads;
-    std::forward_list<std::exception_ptr> exception_ptr_list;
-    for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
-        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
-            ibs_parameters_list[i].new_solution_callback
-                = [&algorithm_formatter, &branching_schemes, i](
-                        const treesearchsolver::Output<BranchingScheme>& tss_output)
-                {
-                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
-                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
-                    Solution solution = branching_schemes[i].to_solution(
-                            tssibs_output.solution_pool.best());
-                    std::stringstream ss;
-                    ss << "TS g " << branching_schemes[i].parameters().guide_id
-                        << " d " << branching_schemes[i].parameters().first_stage_orientation
-                        << " q " << tssibs_output.maximum_size_of_the_queue;
-                    algorithm_formatter.update_solution(solution, ss.str());
-
-                    if (tssibs_output.optimal) {
-                        if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
-                            algorithm_formatter.update_bin_packing_bound(
-                                    solution.number_of_bins());
-                        }
-                    }
-                };
-        } else {
-            ibs_parameters_list[i].new_solution_callback
-                = [&outputs, &branching_schemes, i](
-                        const treesearchsolver::Output<BranchingScheme>& tss_output)
-                {
-                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
-                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
-                    Solution solution = branching_schemes[i].to_solution(
-                            tssibs_output.solution_pool.best());
-                    outputs[i].solution_pool.add(solution);
-                };
-        }
-        exception_ptr_list.push_front(std::exception_ptr());
-        if (parameters.optimization_mode != OptimizationMode::NotAnytimeSequential) {
-            threads.push_back(std::thread(
-                        wrapper<decltype(&treesearchsolver::iterative_beam_search_2<BranchingScheme>), treesearchsolver::iterative_beam_search_2<BranchingScheme>>,
-                        std::ref(exception_ptr_list.front()),
-                        std::ref(branching_schemes[i]),
-                        ibs_parameters_list[i]));
-        } else {
-            try {
-                treesearchsolver::iterative_beam_search_2<BranchingScheme>(
-                        branching_schemes[i],
-                        ibs_parameters_list[i]);
-            } catch (...) {
-                exception_ptr_list.front() = std::current_exception();
-            }
-        }
-    }
-    for (Counter i = 0; i < (Counter)threads.size(); ++i)
-        threads[i].join();
-    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
-        if (exception_ptr)
-            std::rethrow_exception(exception_ptr);
-    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
-        for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
-            std::stringstream ss;
-            ss << "TS g " << branching_schemes[i].parameters().guide_id
-                << " d " << branching_schemes[i].parameters().first_stage_orientation;
-            algorithm_formatter.update_solution(outputs[i].solution_pool.best(), ss.str());
-        }
-    }
-}
 
 void optimize_column_generation_2(
         const Instance& instance,
@@ -451,6 +321,31 @@ void optimize_column_generation(
     cgslds_parameters.column_generation_parameters.solver_name
         = parameters.linear_programming_solver_name;
     columngenerationsolver::limited_discrepancy_search(cgs_model, cgslds_parameters);
+}
+
+void optimize_tree_search(
+        const Instance& instance,
+        const OptimizeParameters& parameters,
+        AlgorithmFormatter& algorithm_formatter)
+{
+    TreeSearchParameters ts_parameters;
+    ts_parameters.verbosity_level = 0;
+    ts_parameters.timer = parameters.timer;
+    ts_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    ts_parameters.guides = parameters.tree_search_guides;
+    ts_parameters.optimization_mode = parameters.optimization_mode;
+    ts_parameters.not_anytime_tree_search_queue_size = parameters.not_anytime_tree_search_queue_size;
+    ts_parameters.json_search_tree_path = parameters.json_search_tree_path;
+    ts_parameters.new_solution_callback = [&algorithm_formatter](
+            const packingsolver::Output<Instance, Solution>& ts_output)
+    {
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+        if (ts_output.bin_packing_bound > 0) {
+            algorithm_formatter.update_bin_packing_bound(
+                    ts_output.bin_packing_bound);
+        }
+    };
+    tree_search(instance, ts_parameters);
 }
 
 }

--- a/src/rectangleguillotine/tree_search.cpp
+++ b/src/rectangleguillotine/tree_search.cpp
@@ -1,8 +1,11 @@
-#include "rectangleguillotine/branching_scheme.hpp"
+#include "rectangleguillotine/tree_search.hpp"
 
+#include "packingsolver/rectangleguillotine/algorithm_formatter.hpp"
 #include "rectangleguillotine/solution_builder.hpp"
 
 #include <sstream>
+#include "treesearchsolver/iterative_beam_search_2.hpp"
+#include <thread>
 
 using namespace packingsolver;
 using namespace packingsolver::rectangleguillotine;
@@ -2079,4 +2082,137 @@ std::ostream& packingsolver::rectangleguillotine::operator<<(
     //os << std::endl;
 
     return os;
+}
+
+const packingsolver::rectangleguillotine::TreeSearchOutput packingsolver::rectangleguillotine::tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters)
+{
+    TreeSearchOutput output(instance);
+    AlgorithmFormatter algorithm_formatter(instance, parameters, output);
+    algorithm_formatter.start();
+    algorithm_formatter.print_header();
+
+    std::vector<GuideId> guides;
+    if (!parameters.guides.empty()) {
+        guides = parameters.guides;
+    } else if (instance.objective() == Objective::Knapsack) {
+        guides = {4, 5};
+    } else {
+        guides = {0, 1};
+    }
+
+    std::vector<CutOrientation> first_stage_orientations = {instance.parameters().first_stage_orientation};
+    if (instance.number_of_bin_types() == 1
+            && instance.parameters().first_stage_orientation == CutOrientation::Any) {
+        first_stage_orientations = {CutOrientation::Vertical, CutOrientation::Horizontal};
+    }
+
+    std::vector<double> growth_factors = {1.5};
+    if (guides.size() * first_stage_orientations.size() * 2 <= 4)
+        growth_factors = {1.33, 1.5};
+    if (parameters.optimization_mode != OptimizationMode::Anytime)
+        growth_factors = {1.5};
+
+    std::vector<BranchingScheme> branching_schemes;
+    std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
+    std::vector<packingsolver::Output<Instance, Solution>> local_outputs;
+    for (double growth_factor: growth_factors) {
+        for (GuideId guide_id: guides) {
+            for (CutOrientation first_stage_orientation: first_stage_orientations) {
+                BranchingScheme::Parameters branching_scheme_parameters;
+                branching_scheme_parameters.guide_id = guide_id;
+                branching_scheme_parameters.first_stage_orientation = first_stage_orientation;
+                branching_schemes.push_back(BranchingScheme(instance, branching_scheme_parameters));
+                treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
+                ibs_parameters.verbosity_level = 0;
+                ibs_parameters.timer = parameters.timer;
+                ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+                ibs_parameters.growth_factor = growth_factor;
+                if (parameters.optimization_mode != OptimizationMode::Anytime) {
+                    ibs_parameters.minimum_size_of_the_queue = 1;
+                    ibs_parameters.growth_factor = parameters.not_anytime_tree_search_queue_size;
+                    ibs_parameters.maximum_size_of_the_queue = parameters.not_anytime_tree_search_queue_size + 1;
+                }
+                if (!parameters.json_search_tree_path.empty()) {
+                    ibs_parameters.json_search_tree_path = parameters.json_search_tree_path
+                        + "_guide_" + std::to_string(branching_scheme_parameters.guide_id)
+                        + "_d_" + std::to_string((int)branching_scheme_parameters.first_stage_orientation);
+                }
+                ibs_parameters_list.push_back(ibs_parameters);
+                local_outputs.push_back(packingsolver::Output<Instance, Solution>(instance));
+            }
+        }
+    }
+
+    std::vector<std::thread> threads;
+    std::forward_list<std::exception_ptr> exception_ptr_list;
+    for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
+        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
+            ibs_parameters_list[scheme_idx].new_solution_callback
+                = [&algorithm_formatter, &branching_schemes, scheme_idx](
+                        const treesearchsolver::Output<BranchingScheme>& tss_output)
+                {
+                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
+                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
+                    Solution solution = branching_schemes[scheme_idx].to_solution(
+                            tssibs_output.solution_pool.best());
+                    std::stringstream ss;
+                    ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
+                        << " d " << branching_schemes[scheme_idx].parameters().first_stage_orientation
+                        << " q " << tssibs_output.maximum_size_of_the_queue;
+                    algorithm_formatter.update_solution(solution, ss.str());
+                    if (tssibs_output.optimal
+                            && solution.instance().objective() == packingsolver::Objective::BinPacking) {
+                        algorithm_formatter.update_bin_packing_bound(
+                                solution.number_of_bins());
+                    }
+                };
+        } else {
+            ibs_parameters_list[scheme_idx].new_solution_callback
+                = [&local_outputs, &branching_schemes, scheme_idx](
+                        const treesearchsolver::Output<BranchingScheme>& tss_output)
+                {
+                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
+                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
+                    Solution solution = branching_schemes[scheme_idx].to_solution(
+                            tssibs_output.solution_pool.best());
+                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution);
+                };
+        }
+        exception_ptr_list.push_front(std::exception_ptr());
+        if (parameters.optimization_mode != OptimizationMode::NotAnytimeSequential) {
+            threads.push_back(std::thread(
+                        wrapper<decltype(&treesearchsolver::iterative_beam_search_2<BranchingScheme>), treesearchsolver::iterative_beam_search_2<BranchingScheme>>,
+                        std::ref(exception_ptr_list.front()),
+                        std::ref(branching_schemes[scheme_idx]),
+                        ibs_parameters_list[scheme_idx]));
+        } else {
+            try {
+                treesearchsolver::iterative_beam_search_2<BranchingScheme>(
+                        branching_schemes[scheme_idx],
+                        ibs_parameters_list[scheme_idx]);
+            } catch (...) {
+                exception_ptr_list.front() = std::current_exception();
+            }
+        }
+    }
+    for (Counter thread_idx = 0; thread_idx < (Counter)threads.size(); ++thread_idx)
+        threads[thread_idx].join();
+    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
+        if (exception_ptr)
+            std::rethrow_exception(exception_ptr);
+    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
+        for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
+            std::stringstream ss;
+            ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
+                << " d " << branching_schemes[scheme_idx].parameters().first_stage_orientation;
+            algorithm_formatter.update_solution(
+                    local_outputs[(size_t)scheme_idx].solution_pool.best(),
+                    ss.str());
+        }
+    }
+
+    algorithm_formatter.end();
+    return output;
 }

--- a/src/rectangleguillotine/tree_search.hpp
+++ b/src/rectangleguillotine/tree_search.hpp
@@ -714,3 +714,32 @@ bool BranchingScheme::operator()(
 
 }
 }
+
+#include "packingsolver/rectangleguillotine/solution.hpp"
+
+namespace packingsolver
+{
+namespace rectangleguillotine
+{
+
+struct TreeSearchOutput: packingsolver::Output<Instance, Solution>
+{
+    TreeSearchOutput(const Instance& instance):
+        packingsolver::Output<Instance, Solution>(instance) { }
+};
+
+struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution>
+{
+    std::vector<GuideId> guides;
+
+    OptimizationMode optimization_mode = OptimizationMode::Anytime;
+
+    NodeId not_anytime_tree_search_queue_size = 1;
+};
+
+const TreeSearchOutput tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters = {});
+
+}
+}

--- a/test/rectangle/branching_scheme/defects_test.cpp
+++ b/test/rectangle/branching_scheme/defects_test.cpp
@@ -1,5 +1,5 @@
 #include "packingsolver/rectangle/instance_builder.hpp"
-#include "rectangle/branching_scheme.hpp"
+#include "rectangle/tree_search.hpp"
 
 #include <gtest/gtest.h>
 

--- a/test/rectangle/branching_scheme/test.cpp
+++ b/test/rectangle/branching_scheme/test.cpp
@@ -1,5 +1,5 @@
 #include "packingsolver/rectangle/instance_builder.hpp"
-#include "rectangle/branching_scheme.hpp"
+#include "rectangle/tree_search.hpp"
 
 #include <gtest/gtest.h>
 

--- a/test/rectangleguillotine/branching_scheme/add_test.cpp
+++ b/test/rectangleguillotine/branching_scheme/add_test.cpp
@@ -1,5 +1,5 @@
 #include "packingsolver/rectangleguillotine/instance_builder.hpp"
-#include "rectangleguillotine/branching_scheme.hpp"
+#include "rectangleguillotine/tree_search.hpp"
 
 #include <gtest/gtest.h>
 

--- a/test/rectangleguillotine/branching_scheme/cut_thickness_test.cpp
+++ b/test/rectangleguillotine/branching_scheme/cut_thickness_test.cpp
@@ -1,5 +1,5 @@
 #include "packingsolver/rectangleguillotine/instance_builder.hpp"
-#include "rectangleguillotine/branching_scheme.hpp"
+#include "rectangleguillotine/tree_search.hpp"
 
 #include <gtest/gtest.h>
 

--- a/test/rectangleguillotine/branching_scheme/cut_through_defect_test.cpp
+++ b/test/rectangleguillotine/branching_scheme/cut_through_defect_test.cpp
@@ -1,5 +1,5 @@
 #include "packingsolver/rectangleguillotine/instance_builder.hpp"
-#include "rectangleguillotine/branching_scheme.hpp"
+#include "rectangleguillotine/tree_search.hpp"
 
 #include <gtest/gtest.h>
 

--- a/test/rectangleguillotine/branching_scheme/defect_test.cpp
+++ b/test/rectangleguillotine/branching_scheme/defect_test.cpp
@@ -1,5 +1,5 @@
 #include "packingsolver/rectangleguillotine/instance_builder.hpp"
-#include "rectangleguillotine/branching_scheme.hpp"
+#include "rectangleguillotine/tree_search.hpp"
 
 #include <gtest/gtest.h>
 

--- a/test/rectangleguillotine/branching_scheme/insertion_test.cpp
+++ b/test/rectangleguillotine/branching_scheme/insertion_test.cpp
@@ -1,5 +1,5 @@
 #include "packingsolver/rectangleguillotine/instance_builder.hpp"
-#include "rectangleguillotine/branching_scheme.hpp"
+#include "rectangleguillotine/tree_search.hpp"
 
 #include <gtest/gtest.h>
 

--- a/test/rectangleguillotine/branching_scheme/integration_test.cpp
+++ b/test/rectangleguillotine/branching_scheme/integration_test.cpp
@@ -1,5 +1,5 @@
 #include "packingsolver/rectangleguillotine/instance_builder.hpp"
-#include "rectangleguillotine/branching_scheme.hpp"
+#include "rectangleguillotine/tree_search.hpp"
 
 #include "treesearchsolver/iterative_beam_search_2.hpp"
 

--- a/test/rectangleguillotine/branching_scheme/trim_test.cpp
+++ b/test/rectangleguillotine/branching_scheme/trim_test.cpp
@@ -1,5 +1,5 @@
 #include "packingsolver/rectangleguillotine/instance_builder.hpp"
-#include "rectangleguillotine/branching_scheme.hpp"
+#include "rectangleguillotine/tree_search.hpp"
 
 #include <gtest/gtest.h>
 

--- a/test/rectangleguillotine/branching_scheme/waste_test.cpp
+++ b/test/rectangleguillotine/branching_scheme/waste_test.cpp
@@ -1,5 +1,5 @@
 #include "packingsolver/rectangleguillotine/instance_builder.hpp"
-#include "rectangleguillotine/branching_scheme.hpp"
+#include "rectangleguillotine/tree_search.hpp"
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Each module's branching_scheme.{hpp,cpp} is renamed to tree_search.{hpp,cpp} and gains a tree_search() function (with TreeSearchOutput/TreeSearchParameters structs) following the same pattern as rectangleguillotine/column_generation_2. The optimize_tree_search helper that previously lived in each optimize.cpp anonymous namespace is eliminated; optimize.cpp now calls tree_search() directly.

For box, branching_scheme_maximal_spaces.* becomes tree_search_maximal_spaces.* with a tree_search_maximal_spaces() function.