### PR TITLE
Move thread_pool.hpp to src/ and consolidate wrapper

### DIFF
--- a/include/packingsolver/algorithms/common.hpp
+++ b/include/packingsolver/algorithms/common.hpp
@@ -323,25 +323,6 @@ double largest_bin_space(const Instance& instance)
     return space_max;
 }
 
-template<class F, F f> struct wrapper_impl;
-template<class R, class... Args, R(*f)(Args...)>
-struct wrapper_impl<R(*)(Args...), f>
-{
-    static void wrap(
-            std::exception_ptr& exception_ptr,
-            Args... args)
-    {
-        try {
-            f(args...);
-        } catch (...) {
-            exception_ptr = std::current_exception();
-        }
-    }
-};
-
-template<class F, F f>
-constexpr auto wrapper = wrapper_impl<F, f>::wrap;
-
 /**
  * Return a copy of the solution with identical bins grouped together.
  *

--- a/src/algorithms/thread_pool.hpp
+++ b/src/algorithms/thread_pool.hpp
@@ -1,16 +1,20 @@
 #pragma once
 
 /**
- * This header provides two small, portable, C++14-only helpers shared by all
+ * This header provides three small, portable, C++14-only helpers shared by all
  * problem types:
  *
- * 1. 'run': a task executor that runs tasks in parallel or sequentially.
+ * 1. 'wrapper'/'wrapper_impl': a template that wraps a plain function so that
+ *    any exception it throws is caught and stored in a caller-supplied
+ *    'std::exception_ptr' instead of propagating.
  *
- * 2. 'current_memory_megabytes': a portable reader of the current resident set
+ * 2. 'run': a task executor that runs tasks in parallel or sequentially.
+ *
+ * 3. 'current_memory_megabytes': a portable reader of the current resident set
  *    size (RSS) of the process, used to CAP memory usage at the existing
  *    cooperative stop checkpoints.
  *
- * Both helpers are intentionally dependency-free (only the standard library and
+ * All helpers are intentionally dependency-free (only the standard library and
  * platform headers) so they can be included from every 'src/<type>/optimize.cpp'.
  */
 
@@ -24,6 +28,25 @@
 
 namespace packingsolver
 {
+
+template<class F, F f> struct wrapper_impl;
+template<class R, class... Args, R(*f)(Args...)>
+struct wrapper_impl<R(*)(Args...), f>
+{
+    static void wrap(
+            std::exception_ptr& exception_ptr,
+            Args... args)
+    {
+        try {
+            f(args...);
+        } catch (...) {
+            exception_ptr = std::current_exception();
+        }
+    }
+};
+
+template<class F, F f>
+constexpr auto wrapper = wrapper_impl<F, f>::wrap;
 
 /**
  * Run a set of independent tasks, spawning all of them concurrently.
@@ -159,7 +182,7 @@ inline void run(
     bool parallel = parameters.optimization_mode != OptimizationMode::NotAnytimeSequential;
 
     std::thread monitor_thread;
-    if (parameters.memory_limit_megabytes > 0 && parallel) {
+    if (parameters.memory_limit_megabytes > 0) {
         monitor_thread = std::thread([&algorithm_formatter, &parameters]() {
             monitor_memory(algorithm_formatter, parameters);
         });

--- a/src/box/optimize.cpp
+++ b/src/box/optimize.cpp
@@ -7,7 +7,7 @@
 #include "algorithms/dichotomic_search.hpp"
 #include "algorithms/sequential_value_correction.hpp"
 #include "algorithms/column_generation.hpp"
-#include "packingsolver/algorithms/thread_pool.hpp"
+#include "algorithms/thread_pool.hpp"
 
 #include "treesearchsolver/iterative_beam_search_2.hpp"
 #include "treesearchsolver/iterative_beam_search.hpp"

--- a/src/boxstacks/optimize.cpp
+++ b/src/boxstacks/optimize.cpp
@@ -6,7 +6,7 @@
 #include "boxstacks/sequential_onedimensional_rectangle.hpp"
 
 #include "algorithms/sequential_value_correction.hpp"
-#include "packingsolver/algorithms/thread_pool.hpp"
+#include "algorithms/thread_pool.hpp"
 
 #include "treesearchsolver/iterative_beam_search_2.hpp"
 

--- a/src/irregular/optimize.cpp
+++ b/src/irregular/optimize.cpp
@@ -10,7 +10,7 @@
 #include "algorithms/dichotomic_search.hpp"
 #include "algorithms/sequential_value_correction.hpp"
 #include "algorithms/column_generation.hpp"
-#include "packingsolver/algorithms/thread_pool.hpp"
+#include "algorithms/thread_pool.hpp"
 #include "packingsolver/onedimensional/instance_builder.hpp"
 #include "packingsolver/onedimensional/optimize.hpp"
 

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -6,7 +6,7 @@
 #include "algorithms/dichotomic_search.hpp"
 #include "algorithms/sequential_value_correction.hpp"
 #include "algorithms/column_generation.hpp"
-#include "packingsolver/algorithms/thread_pool.hpp"
+#include "algorithms/thread_pool.hpp"
 
 #include "treesearchsolver/iterative_beam_search_2.hpp"
 

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -8,7 +8,7 @@
 #include "algorithms/dichotomic_search.hpp"
 #include "algorithms/sequential_value_correction.hpp"
 #include "algorithms/column_generation.hpp"
-#include "packingsolver/algorithms/thread_pool.hpp"
+#include "algorithms/thread_pool.hpp"
 
 #include "treesearchsolver/iterative_beam_search_2.hpp"
 

--- a/src/rectangleguillotine/column_generation_2.cpp
+++ b/src/rectangleguillotine/column_generation_2.cpp
@@ -3,13 +3,13 @@
 #include "packingsolver/rectangleguillotine/algorithm_formatter.hpp"
 #include "rectangleguillotine/instance_flipper.hpp"
 #include "rectangleguillotine/solution_builder.hpp"
+#include "algorithms/thread_pool.hpp"
 
 #include "packingsolver/onedimensional/instance_builder.hpp"
 #include "packingsolver/onedimensional/optimize.hpp"
 
 #include "columngenerationsolver/algorithms/limited_discrepancy_search.hpp"
 
-#include <thread>
 
 using namespace packingsolver;
 using namespace packingsolver::rectangleguillotine;
@@ -1600,24 +1600,28 @@ const ColumnGeneration2Output packingsolver::rectangleguillotine::column_generat
                 parameters,
                 algorithm_formatter);
     } else {
-        std::vector<std::thread> threads;
+        std::vector<std::function<void()>> tasks;
         std::forward_list<std::exception_ptr> exception_ptr_list;
         exception_ptr_list.push_front(std::exception_ptr());
-        threads.push_back(std::thread(
-                    wrapper<decltype(&column_generation_2_vertical), column_generation_2_vertical>,
-                    std::ref(exception_ptr_list.front()),
-                    std::ref(instance),
-                    std::ref(parameters),
-                    std::ref(algorithm_formatter)));
-        threads.push_back(std::thread(
-                    wrapper<decltype(&column_generation_2_horizontal), column_generation_2_horizontal>,
-                    std::ref(exception_ptr_list.front()),
-                    std::ref(instance),
-                    std::ref(parameters),
-                    std::ref(algorithm_formatter)));
-        for (Counter i = 0; i < (Counter)threads.size(); ++i)
-            threads[i].join();
-        for (std::exception_ptr exception_ptr: exception_ptr_list)
+        std::exception_ptr& exception_ptr_1 = exception_ptr_list.front();
+        tasks.push_back([&exception_ptr_1, &instance, &parameters, &algorithm_formatter]() {
+            wrapper<decltype(&column_generation_2_vertical), column_generation_2_vertical>(
+                    exception_ptr_1,
+                    instance,
+                    parameters,
+                    algorithm_formatter);
+        });
+        exception_ptr_list.push_front(std::exception_ptr());
+        std::exception_ptr& exception_ptr_2 = exception_ptr_list.front();
+        tasks.push_back([&exception_ptr_2, &instance, &parameters, &algorithm_formatter]() {
+            wrapper<decltype(&column_generation_2_horizontal), column_generation_2_horizontal>(
+                    exception_ptr_2,
+                    instance,
+                    parameters,
+                    algorithm_formatter);
+        });
+        run(tasks, true);
+        for (const std::exception_ptr& exception_ptr: exception_ptr_list)
             if (exception_ptr)
                 std::rethrow_exception(exception_ptr);
     }

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -9,7 +9,7 @@
 #include "algorithms/dichotomic_search.hpp"
 #include "algorithms/sequential_value_correction.hpp"
 #include "algorithms/column_generation.hpp"
-#include "packingsolver/algorithms/thread_pool.hpp"
+#include "algorithms/thread_pool.hpp"
 
 #include "treesearchsolver/iterative_beam_search_2.hpp"
 


### PR DESCRIPTION
- Rename include/packingsolver/algorithms/thread_pool.hpp → src/algorithms/thread_pool.hpp (internal-only header; no public API)
- Move wrapper_impl/wrapper templates from common.hpp into thread_pool.hpp so all threading helpers live in one place
- Update include paths in all optimize.cpp files and column_generation_2.cpp
- Refactor column_generation_2.cpp to use run(tasks, true) instead of manual std::thread management; fixes a latent data race where both threads shared a single exception_ptr
- Update thread_pool.hpp header comment to document all three helpers
- Start memory monitor thread regardless of parallel mode