### PR TITLE
rectangleguillotine: add tree_search() function and simplify optimize.cpp

### DIFF
--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -15,7 +15,6 @@
 #include "algorithms/column_generation.hpp"
 #include "algorithms/thread_pool.hpp"
 
-#include "treesearchsolver/iterative_beam_search_2.hpp"
 
 
 using namespace packingsolver;
@@ -71,121 +70,20 @@ void optimize_tree_search(
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter)
 {
-    std::vector<GuideId> guides;
-    if (!parameters.tree_search_guides.empty()) {
-        guides = parameters.tree_search_guides;
-    } else if (instance.objective() == Objective::Knapsack) {
-        guides = {4, 5};
-    } else {
-        guides = {0, 1};
-    }
-
-    std::vector<CutOrientation> first_stage_orientations = {instance.parameters().first_stage_orientation};
-    if (instance.number_of_bin_types() == 1
-            && instance.parameters().first_stage_orientation == CutOrientation::Any) {
-        first_stage_orientations = {CutOrientation::Vertical, CutOrientation::Horizontal};
-    }
-
-    std::vector<double> growth_factors = {1.5};
-    if (guides.size() * first_stage_orientations.size() * 2 <= 4)
-        growth_factors = {1.33, 1.5};
-    if (parameters.optimization_mode != OptimizationMode::Anytime)
-        growth_factors = {1.5};
-
-    std::vector<BranchingScheme> branching_schemes;
-    std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
-    std::vector<rectangleguillotine::Output> outputs;
-    for (double growth_factor: growth_factors) {
-        for (GuideId guide_id: guides) {
-            for (CutOrientation first_stage_orientation: first_stage_orientations) {
-                //std::cout << growth_factor << " " << guide_id << " " << first_stage_orientation << std::endl;
-                BranchingScheme::Parameters branching_scheme_parameters;
-                branching_scheme_parameters.guide_id = guide_id;
-                branching_scheme_parameters.first_stage_orientation = first_stage_orientation;
-                branching_schemes.push_back(BranchingScheme(instance, branching_scheme_parameters));
-                treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
-                ibs_parameters.verbosity_level = 0;
-                ibs_parameters.timer = parameters.timer;
-                ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
-                ibs_parameters.growth_factor = growth_factor;
-                if (parameters.optimization_mode != OptimizationMode::Anytime) {
-                    ibs_parameters.minimum_size_of_the_queue = 1;
-                    ibs_parameters.growth_factor
-                        = parameters.not_anytime_tree_search_queue_size;
-                    ibs_parameters.maximum_size_of_the_queue
-                        = parameters.not_anytime_tree_search_queue_size + 1;
-                }
-                if (!parameters.json_search_tree_path.empty()) {
-                    ibs_parameters.json_search_tree_path = parameters.json_search_tree_path
-                        + "_guide_" + std::to_string(branching_scheme_parameters.guide_id)
-                        + "_d_" + std::to_string((int)branching_scheme_parameters.first_stage_orientation);
-                }
-                ibs_parameters_list.push_back(ibs_parameters);
-                outputs.push_back(rectangleguillotine::Output(instance));
-            }
-        }
-    }
-
-    std::vector<std::function<void()>> tasks;
-    std::forward_list<std::exception_ptr> exception_ptr_list;
-    for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
-        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
-            ibs_parameters_list[i].new_solution_callback
-                = [&algorithm_formatter, &branching_schemes, i](
-                        const treesearchsolver::Output<BranchingScheme>& tss_output)
-                {
-                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
-                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
-                    Solution solution = branching_schemes[i].to_solution(
-                            tssibs_output.solution_pool.best());
-                    std::stringstream ss;
-                    ss << "TS g " << branching_schemes[i].parameters().guide_id
-                        << " d " << branching_schemes[i].parameters().first_stage_orientation
-                        << " q " << tssibs_output.maximum_size_of_the_queue;
-                    algorithm_formatter.update_solution(solution, ss.str());
-
-                    if (tssibs_output.optimal) {
-                        if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
-                            algorithm_formatter.update_bin_packing_bound(
-                                    solution.number_of_bins());
-                        }
-                    }
-                };
-        } else {
-            ibs_parameters_list[i].new_solution_callback
-                = [&outputs, &branching_schemes, i](
-                        const treesearchsolver::Output<BranchingScheme>& tss_output)
-                {
-                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
-                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
-                    Solution solution = branching_schemes[i].to_solution(
-                            tssibs_output.solution_pool.best());
-                    outputs[i].solution_pool.add(solution);
-                };
-        }
-        exception_ptr_list.push_front(std::exception_ptr());
-        std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        BranchingScheme& branching_scheme = branching_schemes[i];
-        treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters = ibs_parameters_list[i];
-        tasks.push_back([&exception_ptr, &branching_scheme, ibs_parameters]() {
-            wrapper<decltype(&treesearchsolver::iterative_beam_search_2<BranchingScheme>), treesearchsolver::iterative_beam_search_2<BranchingScheme>>(
-                    exception_ptr,
-                    branching_scheme,
-                    ibs_parameters);
-        });
-    }
-    run(tasks, parameters.optimization_mode != OptimizationMode::NotAnytimeSequential);
-    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
-        if (exception_ptr)
-            std::rethrow_exception(exception_ptr);
-    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
-        for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
-            std::stringstream ss;
-            ss << "TS g " << branching_schemes[i].parameters().guide_id
-                << " d " << branching_schemes[i].parameters().first_stage_orientation;
-            algorithm_formatter.update_solution(outputs[i].solution_pool.best(), ss.str());
-        }
-    }
+    TreeSearchParameters ts_parameters;
+    ts_parameters.verbosity_level = 0;
+    ts_parameters.timer = parameters.timer;
+    ts_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    ts_parameters.optimization_mode = parameters.optimization_mode;
+    ts_parameters.guides = parameters.tree_search_guides;
+    ts_parameters.not_anytime_tree_search_queue_size = parameters.not_anytime_tree_search_queue_size;
+    ts_parameters.json_search_tree_path = parameters.json_search_tree_path;
+    ts_parameters.new_solution_callback = [&algorithm_formatter](
+            const packingsolver::Output<Instance, Solution>& ts_output)
+    {
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+    };
+    tree_search(instance, ts_parameters);
 }
 
 void optimize_tree_search_maximal_spaces(

--- a/src/rectangleguillotine/tree_search.cpp
+++ b/src/rectangleguillotine/tree_search.cpp
@@ -1,8 +1,13 @@
 #include "rectangleguillotine/tree_search.hpp"
 
+#include "packingsolver/rectangleguillotine/algorithm_formatter.hpp"
+#include "algorithms/thread_pool.hpp"
+#include "treesearchsolver/iterative_beam_search_2.hpp"
+
 #include "rectangleguillotine/solution_builder.hpp"
 
 #include <sstream>
+#include <thread>
 
 using namespace packingsolver;
 using namespace packingsolver::rectangleguillotine;
@@ -2080,4 +2085,136 @@ std::ostream& packingsolver::rectangleguillotine::operator<<(
     //os << std::endl;
 
     return os;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////// tree_search //////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+const packingsolver::rectangleguillotine::TreeSearchOutput packingsolver::rectangleguillotine::tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters)
+{
+    TreeSearchOutput output(instance);
+    AlgorithmFormatter algorithm_formatter(instance, parameters, output);
+    algorithm_formatter.start();
+    algorithm_formatter.print_header();
+
+    std::vector<GuideId> guides = parameters.guides;
+    if (guides.empty()) {
+        if (instance.objective() == Objective::Knapsack) {
+            guides = {4, 5};
+        } else {
+            guides = {0, 1};
+        }
+    }
+
+    std::vector<CutOrientation> first_stage_orientations = {instance.parameters().first_stage_orientation};
+    if (instance.number_of_bin_types() == 1
+            && instance.parameters().first_stage_orientation == CutOrientation::Any) {
+        first_stage_orientations = {CutOrientation::Vertical, CutOrientation::Horizontal};
+    }
+
+    std::vector<double> growth_factors = {1.5};
+    if (guides.size() * first_stage_orientations.size() * 2 <= 4)
+        growth_factors = {1.33, 1.5};
+    if (parameters.optimization_mode != OptimizationMode::Anytime)
+        growth_factors = {1.5};
+
+    std::vector<BranchingScheme> branching_schemes;
+    std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
+    std::vector<packingsolver::Output<Instance, Solution>> local_outputs;
+    for (double growth_factor: growth_factors) {
+        for (GuideId guide_id: guides) {
+            for (CutOrientation first_stage_orientation: first_stage_orientations) {
+                BranchingScheme::Parameters branching_scheme_parameters;
+                branching_scheme_parameters.guide_id = guide_id;
+                branching_scheme_parameters.first_stage_orientation = first_stage_orientation;
+                branching_schemes.push_back(BranchingScheme(instance, branching_scheme_parameters));
+                treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
+                ibs_parameters.verbosity_level = 0;
+                ibs_parameters.timer = parameters.timer;
+                ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+                ibs_parameters.growth_factor = growth_factor;
+                if (parameters.optimization_mode != OptimizationMode::Anytime) {
+                    ibs_parameters.minimum_size_of_the_queue = 1;
+                    ibs_parameters.growth_factor = parameters.not_anytime_tree_search_queue_size;
+                    ibs_parameters.maximum_size_of_the_queue = parameters.not_anytime_tree_search_queue_size + 1;
+                }
+                if (!parameters.json_search_tree_path.empty()) {
+                    ibs_parameters.json_search_tree_path = parameters.json_search_tree_path
+                        + "_guide_" + std::to_string(branching_scheme_parameters.guide_id)
+                        + "_d_" + std::to_string((int)branching_scheme_parameters.first_stage_orientation);
+                }
+                ibs_parameters_list.push_back(ibs_parameters);
+                local_outputs.push_back(packingsolver::Output<Instance, Solution>(instance));
+            }
+        }
+    }
+
+    std::vector<std::function<void()>> tasks;
+    std::forward_list<std::exception_ptr> exception_ptr_list;
+    for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
+        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
+            ibs_parameters_list[scheme_idx].new_solution_callback
+                = [&algorithm_formatter, &branching_schemes, scheme_idx](
+                        const treesearchsolver::Output<BranchingScheme>& tss_output)
+                {
+                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
+                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
+                    Solution solution = branching_schemes[scheme_idx].to_solution(
+                            tssibs_output.solution_pool.best());
+                    std::stringstream ss;
+                    ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
+                        << " d " << branching_schemes[scheme_idx].parameters().first_stage_orientation
+                        << " q " << tssibs_output.maximum_size_of_the_queue;
+                    algorithm_formatter.update_solution(solution, ss.str());
+
+                    if (tssibs_output.optimal) {
+                        if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
+                            algorithm_formatter.update_bin_packing_bound(
+                                    solution.number_of_bins());
+                        }
+                    }
+                };
+        } else {
+            ibs_parameters_list[scheme_idx].new_solution_callback
+                = [&local_outputs, &branching_schemes, scheme_idx](
+                        const treesearchsolver::Output<BranchingScheme>& tss_output)
+                {
+                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
+                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
+                    Solution solution = branching_schemes[scheme_idx].to_solution(
+                            tssibs_output.solution_pool.best());
+                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution);
+                };
+        }
+        exception_ptr_list.push_front(std::exception_ptr());
+        std::exception_ptr& exception_ptr = exception_ptr_list.front();
+        BranchingScheme& branching_scheme = branching_schemes[scheme_idx];
+        treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters = ibs_parameters_list[scheme_idx];
+        tasks.push_back([&exception_ptr, &branching_scheme, ibs_parameters]() {
+            wrapper<decltype(&treesearchsolver::iterative_beam_search_2<BranchingScheme>), treesearchsolver::iterative_beam_search_2<BranchingScheme>>(
+                    exception_ptr,
+                    branching_scheme,
+                    ibs_parameters);
+        });
+    }
+    run(tasks, parameters.optimization_mode != OptimizationMode::NotAnytimeSequential);
+    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
+        if (exception_ptr)
+            std::rethrow_exception(exception_ptr);
+    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
+        for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
+            std::stringstream ss;
+            ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
+                << " d " << branching_schemes[scheme_idx].parameters().first_stage_orientation;
+            algorithm_formatter.update_solution(
+                    local_outputs[(size_t)scheme_idx].solution_pool.best(),
+                    ss.str());
+        }
+    }
+
+    algorithm_formatter.end();
+    return output;
 }

--- a/src/rectangleguillotine/tree_search.hpp
+++ b/src/rectangleguillotine/tree_search.hpp
@@ -714,3 +714,30 @@ bool BranchingScheme::operator()(
 
 }
 }
+
+namespace packingsolver
+{
+namespace rectangleguillotine
+{
+
+struct TreeSearchOutput: packingsolver::Output<Instance, Solution>
+{
+    TreeSearchOutput(const Instance& instance):
+        packingsolver::Output<Instance, Solution>(instance) { }
+};
+
+struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution>
+{
+    std::vector<GuideId> guides;
+
+    OptimizationMode optimization_mode = OptimizationMode::Anytime;
+
+    NodeId not_anytime_tree_search_queue_size = 1;
+};
+
+const TreeSearchOutput tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters = {});
+
+}
+}


### PR DESCRIPTION
Adds TreeSearchOutput, TreeSearchParameters and tree_search() to tree_search.{hpp,cpp}. The guide/first_stage_orientation/growth_factor enumeration and IBS loop previously in optimize_tree_search() are now encapsulated in tree_search(). optimize_tree_search() becomes a thin wrapper. The treesearchsolver/iterative_beam_search_2.hpp include moves from optimize.cpp to tree_search.cpp.