### PR TITLE
rectangle: add tree_search() function and simplify optimize.cpp

### DIFF
--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -11,8 +11,6 @@
 #include "algorithms/column_generation.hpp"
 #include "algorithms/thread_pool.hpp"
 
-#include "treesearchsolver/iterative_beam_search_2.hpp"
-
 
 using namespace packingsolver;
 using namespace packingsolver::rectangle;
@@ -43,133 +41,21 @@ void optimize_tree_search(
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter)
 {
-    std::vector<GuideId> guides;
-    if (!parameters.tree_search_guides.empty()) {
-        guides = parameters.tree_search_guides;
-    } else if (instance.objective() == Objective::Knapsack) {
-        guides = {4, 5};
-    } else {
-        guides = {0, 1};
-    }
-
-    std::vector<Direction> directions;
-    if (instance.objective() == Objective::OpenDimensionX) {
-        directions = {Direction::X};
-    } else if (instance.objective() == Objective::OpenDimensionY) {
-        directions = {Direction::Y};
-    } else if (instance.unloading_constraint() == UnloadingConstraint::IncreasingX
-            || instance.unloading_constraint() == UnloadingConstraint::OnlyXMovements) {
-        directions = {Direction::X};
-    } else if (instance.unloading_constraint() == UnloadingConstraint::IncreasingY
-            || instance.unloading_constraint() == UnloadingConstraint::OnlyYMovements) {
-        directions = {Direction::Y};
-    } else if (instance.number_of_bin_types() == 1) {
-        directions = {Direction::X, Direction::Y};
-    } else {
-        directions = {Direction::Any};
-    }
-
-    std::vector<double> growth_factors = {1.5};
-    if (guides.size() * directions.size() * 2 <= 4)
-        growth_factors = {1.33, 1.5};
-    if (parameters.optimization_mode != OptimizationMode::Anytime)
-        growth_factors = {1.5};
-
-    std::vector<BranchingScheme> branching_schemes;
-    std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
-    std::vector<rectangle::Output> outputs;
-    for (double growth_factor: growth_factors) {
-        for (GuideId guide_id: guides) {
-            for (Direction direction: directions) {
-                //std::cout << growth_factor << " " << guide_id << " " << direction << std::endl;
-                BranchingScheme::Parameters branching_scheme_parameters;
-                branching_scheme_parameters.guide_id = guide_id;
-                branching_scheme_parameters.direction = direction;
-                branching_scheme_parameters.fixed_items = parameters.fixed_items;
-                branching_schemes.push_back(BranchingScheme(instance, branching_scheme_parameters));
-                treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
-                ibs_parameters.verbosity_level = 0;
-                ibs_parameters.timer = parameters.timer;
-                ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
-                ibs_parameters.growth_factor = growth_factor;
-                if (parameters.optimization_mode != OptimizationMode::Anytime) {
-                    ibs_parameters.minimum_size_of_the_queue = 1;
-                    ibs_parameters.growth_factor
-                        = parameters.not_anytime_tree_search_queue_size;
-                    ibs_parameters.maximum_size_of_the_queue
-                        = parameters.not_anytime_tree_search_queue_size;
-                }
-                if (!parameters.json_search_tree_path.empty()) {
-                    ibs_parameters.json_search_tree_path = parameters.json_search_tree_path
-                        + "_guide_" + std::to_string(branching_scheme_parameters.guide_id)
-                        + "_d_" + std::to_string((int)branching_scheme_parameters.direction);
-                }
-                ibs_parameters_list.push_back(ibs_parameters);
-                outputs.push_back(rectangle::Output(instance));
-            }
-        }
-    }
-
-    std::vector<std::function<void()>> tasks;
-    std::forward_list<std::exception_ptr> exception_ptr_list;
-    for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
-        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
-            ibs_parameters_list[i].new_solution_callback
-                = [&algorithm_formatter, &branching_schemes, i](
-                        const treesearchsolver::Output<BranchingScheme>& tss_output)
-                {
-                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
-                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
-                    Solution solution = branching_schemes[i].to_solution(
-                            tssibs_output.solution_pool.best());
-                    std::stringstream ss;
-                    ss << "TS g " << branching_schemes[i].parameters().guide_id
-                        << " d " << branching_schemes[i].parameters().direction
-                        << " q " << tssibs_output.maximum_size_of_the_queue;
-                    algorithm_formatter.update_solution(solution, ss.str());
-
-                    if (tssibs_output.optimal) {
-                        if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
-                            algorithm_formatter.update_bin_packing_bound(
-                                    solution.number_of_bins());
-                        }
-                    }
-                };
-        } else {
-            ibs_parameters_list[i].new_solution_callback
-                = [&outputs, &branching_schemes, i](
-                        const treesearchsolver::Output<BranchingScheme>& tss_output)
-                {
-                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
-                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
-                    Solution solution = branching_schemes[i].to_solution(
-                            tssibs_output.solution_pool.best());
-                    outputs[i].solution_pool.add(solution);
-                };
-        }
-        exception_ptr_list.push_front(std::exception_ptr());
-        std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        BranchingScheme& branching_scheme = branching_schemes[i];
-        treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters = ibs_parameters_list[i];
-        tasks.push_back([&exception_ptr, &branching_scheme, ibs_parameters]() {
-            wrapper<decltype(&treesearchsolver::iterative_beam_search_2<BranchingScheme>), treesearchsolver::iterative_beam_search_2<BranchingScheme>>(
-                    exception_ptr,
-                    branching_scheme,
-                    ibs_parameters);
-        });
-    }
-    run(tasks, parameters.optimization_mode != OptimizationMode::NotAnytimeSequential);
-    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
-        if (exception_ptr)
-            std::rethrow_exception(exception_ptr);
-    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
-        for (Counter i = 0; i < (Counter)branching_schemes.size(); ++i) {
-            std::stringstream ss;
-            ss << "TS g " << branching_schemes[i].parameters().guide_id
-                << " d " << branching_schemes[i].parameters().direction;
-            algorithm_formatter.update_solution(outputs[i].solution_pool.best(), ss.str());
-        }
-    }
+    TreeSearchParameters ts_parameters;
+    ts_parameters.verbosity_level = 0;
+    ts_parameters.timer = parameters.timer;
+    ts_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    ts_parameters.optimization_mode = parameters.optimization_mode;
+    ts_parameters.guides = parameters.tree_search_guides;
+    ts_parameters.not_anytime_tree_search_queue_size = parameters.not_anytime_tree_search_queue_size;
+    ts_parameters.json_search_tree_path = parameters.json_search_tree_path;
+    ts_parameters.fixed_items = parameters.fixed_items;
+    ts_parameters.new_solution_callback = [&algorithm_formatter](
+            const packingsolver::Output<Instance, Solution>& ts_output)
+    {
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+    };
+    tree_search(instance, ts_parameters);
 }
 
 void optimize_sequential_single_knapsack(

--- a/src/rectangle/tree_search.cpp
+++ b/src/rectangle/tree_search.cpp
@@ -1,8 +1,13 @@
 #include "rectangle/tree_search.hpp"
 
+#include "packingsolver/rectangle/algorithm_formatter.hpp"
+#include "algorithms/thread_pool.hpp"
+#include "treesearchsolver/iterative_beam_search_2.hpp"
+
 #include "rectangle/solution_builder.hpp"
 
 #include <iostream>
+#include <thread>
 #include <string>
 
 #include "shape/shape.hpp"
@@ -1400,4 +1405,148 @@ std::ostream& packingsolver::rectangle::operator<<(
     os << std::endl;
 
     return os;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////// tree_search //////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+const packingsolver::rectangle::TreeSearchOutput packingsolver::rectangle::tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters)
+{
+    TreeSearchOutput output(instance);
+    AlgorithmFormatter algorithm_formatter(instance, parameters, output);
+    algorithm_formatter.start();
+    algorithm_formatter.print_header();
+
+    std::vector<GuideId> guides = parameters.guides;
+    if (guides.empty()) {
+        if (instance.objective() == Objective::Knapsack) {
+            guides = {4, 5};
+        } else {
+            guides = {0, 1};
+        }
+    }
+
+    std::vector<Direction> directions;
+    if (instance.objective() == Objective::OpenDimensionX) {
+        directions = {Direction::X};
+    } else if (instance.objective() == Objective::OpenDimensionY) {
+        directions = {Direction::Y};
+    } else if (instance.unloading_constraint() == UnloadingConstraint::IncreasingX
+            || instance.unloading_constraint() == UnloadingConstraint::OnlyXMovements) {
+        directions = {Direction::X};
+    } else if (instance.unloading_constraint() == UnloadingConstraint::IncreasingY
+            || instance.unloading_constraint() == UnloadingConstraint::OnlyYMovements) {
+        directions = {Direction::Y};
+    } else if (instance.number_of_bin_types() == 1) {
+        directions = {Direction::X, Direction::Y};
+    } else {
+        directions = {Direction::Any};
+    }
+
+    std::vector<double> growth_factors = {1.5};
+    if (guides.size() * directions.size() * 2 <= 4)
+        growth_factors = {1.33, 1.5};
+    if (parameters.optimization_mode != OptimizationMode::Anytime)
+        growth_factors = {1.5};
+
+    std::vector<BranchingScheme> branching_schemes;
+    std::vector<treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme>> ibs_parameters_list;
+    std::vector<packingsolver::Output<Instance, Solution>> local_outputs;
+    for (double growth_factor: growth_factors) {
+        for (GuideId guide_id: guides) {
+            for (Direction direction: directions) {
+                BranchingScheme::Parameters branching_scheme_parameters;
+                branching_scheme_parameters.guide_id = guide_id;
+                branching_scheme_parameters.direction = direction;
+                branching_scheme_parameters.fixed_items = parameters.fixed_items;
+                branching_schemes.push_back(BranchingScheme(instance, branching_scheme_parameters));
+                treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters;
+                ibs_parameters.verbosity_level = 0;
+                ibs_parameters.timer = parameters.timer;
+                ibs_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+                ibs_parameters.growth_factor = growth_factor;
+                if (parameters.optimization_mode != OptimizationMode::Anytime) {
+                    ibs_parameters.minimum_size_of_the_queue = 1;
+                    ibs_parameters.growth_factor = parameters.not_anytime_tree_search_queue_size;
+                    ibs_parameters.maximum_size_of_the_queue = parameters.not_anytime_tree_search_queue_size;
+                }
+                if (!parameters.json_search_tree_path.empty()) {
+                    ibs_parameters.json_search_tree_path = parameters.json_search_tree_path
+                        + "_guide_" + std::to_string(branching_scheme_parameters.guide_id)
+                        + "_d_" + std::to_string((int)branching_scheme_parameters.direction);
+                }
+                ibs_parameters_list.push_back(ibs_parameters);
+                local_outputs.push_back(packingsolver::Output<Instance, Solution>(instance));
+            }
+        }
+    }
+
+    std::vector<std::function<void()>> tasks;
+    std::forward_list<std::exception_ptr> exception_ptr_list;
+    for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
+        if (parameters.optimization_mode != OptimizationMode::NotAnytimeDeterministic) {
+            ibs_parameters_list[scheme_idx].new_solution_callback
+                = [&algorithm_formatter, &branching_schemes, scheme_idx](
+                        const treesearchsolver::Output<BranchingScheme>& tss_output)
+                {
+                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
+                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
+                    Solution solution = branching_schemes[scheme_idx].to_solution(
+                            tssibs_output.solution_pool.best());
+                    std::stringstream ss;
+                    ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
+                        << " d " << branching_schemes[scheme_idx].parameters().direction
+                        << " q " << tssibs_output.maximum_size_of_the_queue;
+                    algorithm_formatter.update_solution(solution, ss.str());
+
+                    if (tssibs_output.optimal) {
+                        if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
+                            algorithm_formatter.update_bin_packing_bound(
+                                    solution.number_of_bins());
+                        }
+                    }
+                };
+        } else {
+            ibs_parameters_list[scheme_idx].new_solution_callback
+                = [&local_outputs, &branching_schemes, scheme_idx](
+                        const treesearchsolver::Output<BranchingScheme>& tss_output)
+                {
+                    const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>& tssibs_output
+                        = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
+                    Solution solution = branching_schemes[scheme_idx].to_solution(
+                            tssibs_output.solution_pool.best());
+                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution);
+                };
+        }
+        exception_ptr_list.push_front(std::exception_ptr());
+        std::exception_ptr& exception_ptr = exception_ptr_list.front();
+        BranchingScheme& branching_scheme = branching_schemes[scheme_idx];
+        treesearchsolver::IterativeBeamSearch2Parameters<BranchingScheme> ibs_parameters = ibs_parameters_list[scheme_idx];
+        tasks.push_back([&exception_ptr, &branching_scheme, ibs_parameters]() {
+            wrapper<decltype(&treesearchsolver::iterative_beam_search_2<BranchingScheme>), treesearchsolver::iterative_beam_search_2<BranchingScheme>>(
+                    exception_ptr,
+                    branching_scheme,
+                    ibs_parameters);
+        });
+    }
+    run(tasks, parameters.optimization_mode != OptimizationMode::NotAnytimeSequential);
+    for (const std::exception_ptr& exception_ptr: exception_ptr_list)
+        if (exception_ptr)
+            std::rethrow_exception(exception_ptr);
+    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
+        for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
+            std::stringstream ss;
+            ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
+                << " d " << branching_schemes[scheme_idx].parameters().direction;
+            algorithm_formatter.update_solution(
+                    local_outputs[(size_t)scheme_idx].solution_pool.best(),
+                    ss.str());
+        }
+    }
+
+    algorithm_formatter.end();
+    return output;
 }

--- a/src/rectangle/tree_search.hpp
+++ b/src/rectangle/tree_search.hpp
@@ -683,3 +683,32 @@ inline bool BranchingScheme::operator()(
 
 }
 }
+
+namespace packingsolver
+{
+namespace rectangle
+{
+
+struct TreeSearchOutput: packingsolver::Output<Instance, Solution>
+{
+    TreeSearchOutput(const Instance& instance):
+        packingsolver::Output<Instance, Solution>(instance) { }
+};
+
+struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution>
+{
+    std::vector<GuideId> guides;
+
+    OptimizationMode optimization_mode = OptimizationMode::Anytime;
+
+    NodeId not_anytime_tree_search_queue_size = 1;
+
+    Solution* fixed_items = nullptr;
+};
+
+const TreeSearchOutput tree_search(
+        const Instance& instance,
+        const TreeSearchParameters& parameters = {});
+
+}
+}


### PR DESCRIPTION
Adds TreeSearchOutput, TreeSearchParameters and tree_search() to tree_search.{hpp,cpp}. The guide/direction/growth_factor enumeration and IBS loop previously in optimize_tree_search() are now encapsulated in tree_search(). optimize_tree_search() becomes a thin wrapper. The fixed_items field is forwarded through TreeSearchParameters to the BranchingScheme. The treesearchsolver/iterative_beam_search_2.hpp include moves from optimize.cpp to tree_search.cpp.