### PR TITLE
Refactor column generation into generic column_generation() template

### DIFF
--- a/include/packingsolver/box/algorithm_formatter.hpp
+++ b/include/packingsolver/box/algorithm_formatter.hpp
@@ -56,6 +56,10 @@ public:
     void update_bin_packing_bound(
             BinPos number_of_bins);
 
+    /** Update all applicable bounds from another output. */
+    void update_bounds(
+            const packingsolver::Output<Instance, Solution>& output);
+
     /** Method to call at the end of the algorithm. */
     void end();
 

--- a/include/packingsolver/irregular/algorithm_formatter.hpp
+++ b/include/packingsolver/irregular/algorithm_formatter.hpp
@@ -64,6 +64,10 @@ public:
     void update_variable_sized_bin_packing_bound(
             Profit cost);
 
+    /** Update all applicable bounds from another output. */
+    void update_bounds(
+            const packingsolver::Output<Instance, Solution>& output);
+
     /** Method to call at the end of the algorithm. */
     void end();
 

--- a/include/packingsolver/onedimensional/algorithm_formatter.hpp
+++ b/include/packingsolver/onedimensional/algorithm_formatter.hpp
@@ -69,6 +69,10 @@ public:
     void update_variable_sized_bin_packing_bound(
             Profit cost);
 
+    /** Update all applicable bounds from another output. */
+    void update_bounds(
+            const packingsolver::Output<Instance, Solution>& output);
+
     /** Method to call at the end of the algorithm. */
     void end();
 

--- a/include/packingsolver/rectangle/algorithm_formatter.hpp
+++ b/include/packingsolver/rectangle/algorithm_formatter.hpp
@@ -47,6 +47,10 @@ public:
     void update_bin_packing_bound(
             BinPos number_of_bins);
 
+    /** Update all applicable bounds from another output. */
+    void update_bounds(
+            const packingsolver::Output<Instance, Solution>& output);
+
     /** Method to call at the end of the algorithm. */
     void end();
 

--- a/include/packingsolver/rectangleguillotine/algorithm_formatter.hpp
+++ b/include/packingsolver/rectangleguillotine/algorithm_formatter.hpp
@@ -60,6 +60,10 @@ public:
     void update_variable_sized_bin_packing_bound(
             Profit cost);
 
+    /** Update all applicable bounds from another output. */
+    void update_bounds(
+            const packingsolver::Output<Instance, Solution>& output);
+
     /** Method to call at the end of the algorithm. */
     void end();
 

--- a/src/algorithms/column_generation.hpp
+++ b/src/algorithms/column_generation.hpp
@@ -48,6 +48,8 @@
 #include "columngenerationsolver/algorithms/heuristic_tree_search.hpp"
 #include "columngenerationsolver/algorithms/limited_discrepancy_search.hpp"
 
+#include <sstream>
+
 namespace packingsolver
 {
 
@@ -354,6 +356,93 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution>
         * reduced_cost_bound;
 
     //std::cout << "solve_pricing end" << std::endl;
+    return output;
+}
+
+template <typename Instance, typename Solution>
+struct ColumnGenerationOutput: packingsolver::Output<Instance, Solution>
+{
+    ColumnGenerationOutput(const Instance& instance):
+        packingsolver::Output<Instance, Solution>(instance) { }
+};
+
+template <typename Instance, typename Solution>
+struct ColumnGenerationParameters: packingsolver::Parameters<Instance, Solution>
+{
+    OptimizationMode optimization_mode = OptimizationMode::Anytime;
+    int internal_diving = 1;
+    columngenerationsolver::SolverName linear_programming_solver_name
+        = columngenerationsolver::SolverName::CLP;
+};
+
+template <typename Instance, typename InstanceBuilder, typename Solution, typename AlgorithmFormatter>
+ColumnGenerationOutput<Instance, Solution> column_generation(
+        const Instance& instance,
+        const ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution>& pricing_function,
+        const ColumnGenerationParameters<Instance, Solution>& parameters = {})
+{
+    ColumnGenerationOutput<Instance, Solution> output(instance);
+    AlgorithmFormatter algorithm_formatter(instance, parameters, output);
+    algorithm_formatter.start();
+    algorithm_formatter.print_header();
+
+    columngenerationsolver::Model cgs_model
+        = get_model<Instance, InstanceBuilder, Solution>(instance, pricing_function);
+    columngenerationsolver::LimitedDiscrepancySearchParameters cgslds_parameters;
+    cgslds_parameters.verbosity_level = 0;
+    cgslds_parameters.timer = parameters.timer;
+    cgslds_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    cgslds_parameters.internal_diving = parameters.internal_diving;
+    cgslds_parameters.dummy_column_objective_coefficient
+        = 2 * (double)instance.largest_item_copies();
+    if (parameters.optimization_mode != OptimizationMode::Anytime)
+        cgslds_parameters.automatic_stop = true;
+    cgslds_parameters.new_solution_callback = [&instance, &algorithm_formatter](
+            const columngenerationsolver::Output& cgs_output)
+    {
+        const columngenerationsolver::LimitedDiscrepancySearchOutput& cgslds_output
+            = static_cast<const columngenerationsolver::LimitedDiscrepancySearchOutput&>(cgs_output);
+        if (cgslds_output.solution.feasible()) {
+            Solution solution(instance);
+            for (const auto& pair: cgslds_output.solution.columns()) {
+                const Column& column = *(pair.first);
+                BinPos value = std::round(pair.second);
+                if (value < 0.5)
+                    continue;
+                solution.append(
+                        *std::static_pointer_cast<Solution>(column.extra),
+                        0,
+                        value);
+            }
+            std::stringstream ss;
+            ss << "CG n " << cgslds_output.number_of_nodes;
+            algorithm_formatter.update_solution(solution, ss.str());
+        }
+    };
+    cgslds_parameters.new_bound_callback = [&instance, &output, &parameters](
+            const columngenerationsolver::Output& cgs_output)
+    {
+        const columngenerationsolver::LimitedDiscrepancySearchOutput& cgslds_output
+            = static_cast<const columngenerationsolver::LimitedDiscrepancySearchOutput&>(cgs_output);
+        if (instance.objective() == Objective::VariableSizedBinPacking) {
+            double multiplier_cost = largest_power_of_two_lesser_or_equal(instance.largest_bin_cost());
+            output.variable_sized_bin_packing_bound = cgslds_output.bound * multiplier_cost;
+        } else if (instance.objective() == Objective::Knapsack) {
+            double multiplier_profit = largest_power_of_two_lesser_or_equal(instance.largest_item_profit());
+            output.knapsack_bound = cgslds_output.bound * multiplier_profit;
+        } else if (instance.objective() == Objective::BinPacking) {
+            double multiplier_cost = largest_power_of_two_lesser_or_equal(instance.largest_bin_cost());
+            output.bin_packing_bound = std::ceil(
+                    cgslds_output.bound * multiplier_cost / instance.bin_type(0).space() - 0.001);
+        }
+        if (parameters.new_solution_callback)
+            parameters.new_solution_callback(output);
+    };
+    cgslds_parameters.column_generation_parameters.solver_name
+        = parameters.linear_programming_solver_name;
+    columngenerationsolver::limited_discrepancy_search(cgs_model, cgslds_parameters);
+
+    algorithm_formatter.end();
     return output;
 }
 

--- a/src/box/algorithm_formatter.cpp
+++ b/src/box/algorithm_formatter.cpp
@@ -295,6 +295,21 @@ void AlgorithmFormatter::update_bin_packing_bound(
     mutex_.unlock();
 }
 
+void AlgorithmFormatter::update_bounds(
+        const packingsolver::Output<Instance, Solution>& output)
+{
+    switch (instance_.objective()) {
+    case Objective::Knapsack:
+        update_knapsack_bound(output.knapsack_bound);
+        break;
+    case Objective::BinPacking:
+        update_bin_packing_bound(output.bin_packing_bound);
+        break;
+    default:
+        break;
+    }
+}
+
 void AlgorithmFormatter::end()
 {
     output_.time = parameters_.timer.elapsed_time();

--- a/src/box/optimize.cpp
+++ b/src/box/optimize.cpp
@@ -32,6 +32,7 @@ void optimize_tree_search(
             const packingsolver::Output<Instance, Solution>& ts_output)
     {
         algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+        algorithm_formatter.update_bounds(ts_output);
     };
     tree_search(instance, ts_parameters);
 }

--- a/src/irregular/algorithm_formatter.cpp
+++ b/src/irregular/algorithm_formatter.cpp
@@ -333,6 +333,24 @@ void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
     mutex_.unlock();
 }
 
+void AlgorithmFormatter::update_bounds(
+        const packingsolver::Output<Instance, Solution>& output)
+{
+    switch (instance_.objective()) {
+    case Objective::Knapsack:
+        update_knapsack_bound(output.knapsack_bound);
+        break;
+    case Objective::BinPacking:
+        update_bin_packing_bound(output.bin_packing_bound);
+        break;
+    case Objective::VariableSizedBinPacking:
+        update_variable_sized_bin_packing_bound(output.variable_sized_bin_packing_bound);
+        break;
+    default:
+        break;
+    }
+}
+
 void AlgorithmFormatter::end()
 {
     output_.time = parameters_.timer.elapsed_time();

--- a/src/irregular/optimize.cpp
+++ b/src/irregular/optimize.cpp
@@ -350,47 +350,27 @@ void optimize_column_generation(
                 = (parameters.optimization_mode == OptimizationMode::NotAnytimeSequential)?
                 OptimizationMode::NotAnytimeSequential:
                 OptimizationMode::NotAnytimeDeterministic;
-            kp_parameters.not_anytime_maximum_approximation_ratio = parameters.not_anytime_maximum_approximation_ratio;
+            kp_parameters.not_anytime_maximum_approximation_ratio
+                = parameters.not_anytime_maximum_approximation_ratio;
             kp_parameters.not_anytime_tree_search_queue_size
                 = parameters.column_generation_subproblem_tree_search_queue_size;
             kp_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
             return optimize(kp_instance, kp_parameters);
         };
 
-    columngenerationsolver::Model cgs_model = get_model<Instance, InstanceBuilder, Solution>(instance, pricing_function);
-    columngenerationsolver::LimitedDiscrepancySearchParameters cgslds_parameters;
-    cgslds_parameters.verbosity_level = 0;
-    cgslds_parameters.timer = parameters.timer;
-    cgslds_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
-    cgslds_parameters.internal_diving = 1;
-    cgslds_parameters.dummy_column_objective_coefficient = 2 * (double)instance.largest_item_copies();
-    if (parameters.optimization_mode != OptimizationMode::Anytime)
-        cgslds_parameters.automatic_stop = true;
-    cgslds_parameters.new_solution_callback = [&instance, &algorithm_formatter](
-            const columngenerationsolver::Output& cgs_output)
+    ColumnGenerationParameters<Instance, Solution> cg_parameters;
+    cg_parameters.verbosity_level = 0;
+    cg_parameters.timer = parameters.timer;
+    cg_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    cg_parameters.optimization_mode = parameters.optimization_mode;
+    cg_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
+    cg_parameters.new_solution_callback = [&algorithm_formatter](
+            const packingsolver::Output<Instance, Solution>& ps_output)
     {
-        const columngenerationsolver::LimitedDiscrepancySearchOutput& cgslds_output
-            = static_cast<const columngenerationsolver::LimitedDiscrepancySearchOutput&>(cgs_output);
-        if (cgslds_output.solution.feasible()) {
-            Solution solution(instance);
-            for (const auto& pair: cgslds_output.solution.columns()) {
-                const Column& column = *(pair.first);
-                BinPos value = std::round(pair.second);
-                if (value < 0.5)
-                    continue;
-                solution.append(
-                        *std::static_pointer_cast<Solution>(column.extra),
-                        0,
-                        value);
-            }
-            std::stringstream ss;
-            ss << "CG n " << cgslds_output.number_of_nodes;
-            algorithm_formatter.update_solution(solution, ss.str());
-        }
+        algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG");
+        algorithm_formatter.update_bounds(ps_output);
     };
-    cgslds_parameters.column_generation_parameters.solver_name
-        = parameters.linear_programming_solver_name;
-    columngenerationsolver::limited_discrepancy_search(cgs_model, cgslds_parameters);
+    column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, pricing_function, cg_parameters);
 }
 
 void optimize_sequential_feasibility(

--- a/src/onedimensional/algorithm_formatter.cpp
+++ b/src/onedimensional/algorithm_formatter.cpp
@@ -286,6 +286,24 @@ void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
     mutex_.unlock();
 }
 
+void AlgorithmFormatter::update_bounds(
+        const packingsolver::Output<Instance, Solution>& output)
+{
+    switch (instance_.objective()) {
+    case Objective::Knapsack:
+        update_knapsack_bound(output.knapsack_bound);
+        break;
+    case Objective::BinPacking:
+        update_bin_packing_bound(output.bin_packing_bound);
+        break;
+    case Objective::VariableSizedBinPacking:
+        update_variable_sized_bin_packing_bound(output.variable_sized_bin_packing_bound);
+        break;
+    default:
+        break;
+    }
+}
+
 void AlgorithmFormatter::end()
 {
     output_.time = parameters_.timer.elapsed_time();

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -292,57 +292,20 @@ void optimize_column_generation(
             return optimize(kp_instance, kp_parameters);
         };
 
-    columngenerationsolver::Model cgs_model = get_model<Instance, InstanceBuilder, Solution>(instance, pricing_function);
-    columngenerationsolver::LimitedDiscrepancySearchParameters cgslds_parameters;
-    cgslds_parameters.verbosity_level = 0;
-    cgslds_parameters.timer = parameters.timer;
-    cgslds_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
-    cgslds_parameters.internal_diving = 0;
-    cgslds_parameters.dummy_column_objective_coefficient = 2 * (double)instance.largest_item_copies();
-    if (parameters.optimization_mode != OptimizationMode::Anytime)
-        cgslds_parameters.automatic_stop = true;
-    cgslds_parameters.new_solution_callback = [&instance, &algorithm_formatter](
-            const columngenerationsolver::Output& cgs_output)
+    ColumnGenerationParameters<Instance, Solution> cg_parameters;
+    cg_parameters.verbosity_level = 0;
+    cg_parameters.timer = parameters.timer;
+    cg_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    cg_parameters.optimization_mode = parameters.optimization_mode;
+    cg_parameters.internal_diving = 0;
+    cg_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
+    cg_parameters.new_solution_callback = [&algorithm_formatter](
+            const packingsolver::Output<Instance, Solution>& ps_output)
     {
-        const columngenerationsolver::LimitedDiscrepancySearchOutput& cgslds_output
-            = static_cast<const columngenerationsolver::LimitedDiscrepancySearchOutput&>(cgs_output);
-        if (cgslds_output.solution.feasible()) {
-            Solution solution(instance);
-            for (const auto& pair: cgslds_output.solution.columns()) {
-                const Column& column = *(pair.first);
-                BinPos value = std::round(pair.second);
-                if (value < 0.5)
-                    continue;
-                solution.append(
-                        *std::static_pointer_cast<Solution>(column.extra),
-                        0,
-                        value);
-            }
-            std::stringstream ss;
-            ss << "CG n " << cgslds_output.number_of_nodes;
-            algorithm_formatter.update_solution(solution, ss.str());
-        }
+        algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG");
+        algorithm_formatter.update_bounds(ps_output);
     };
-    cgslds_parameters.new_bound_callback = [&instance, &algorithm_formatter](
-            const columngenerationsolver::Output& cgs_output)
-    {
-        const columngenerationsolver::LimitedDiscrepancySearchOutput& cgslds_output
-            = static_cast<const columngenerationsolver::LimitedDiscrepancySearchOutput&>(cgs_output);
-        if (instance.objective() == Objective::VariableSizedBinPacking) {
-            double multiplier_cost = largest_power_of_two_lesser_or_equal(instance.largest_bin_cost());
-            algorithm_formatter.update_variable_sized_bin_packing_bound(cgslds_output.bound * multiplier_cost);
-        } else if (instance.objective() == Objective::Knapsack) {
-            double multiplier_profit = largest_power_of_two_lesser_or_equal(instance.largest_item_profit());
-            algorithm_formatter.update_knapsack_bound(cgslds_output.bound * multiplier_profit);
-        } else if (instance.objective() == Objective::BinPacking) {
-            double multiplier_cost = largest_power_of_two_lesser_or_equal(instance.largest_bin_cost());
-            BinPos bin_packing_bound = std::ceil(cgslds_output.bound * multiplier_cost / instance.bin_type(0).space() - 0.001);
-            algorithm_formatter.update_bin_packing_bound(bin_packing_bound);
-        }
-    };
-    cgslds_parameters.column_generation_parameters.solver_name
-        = parameters.linear_programming_solver_name;
-    columngenerationsolver::limited_discrepancy_search(cgs_model, cgslds_parameters);
+    column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, pricing_function, cg_parameters);
 }
 
 }

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -103,10 +103,7 @@ void optimize_tree_search(
             const packingsolver::Output<Instance, Solution>& ts_output)
     {
         algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
-        if (ts_output.bin_packing_bound > 0) {
-            algorithm_formatter.update_bin_packing_bound(
-                    ts_output.bin_packing_bound);
-        }
+        algorithm_formatter.update_bounds(ts_output);
     };
     tree_search(instance, ts_parameters);
 }

--- a/src/rectangle/algorithm_formatter.cpp
+++ b/src/rectangle/algorithm_formatter.cpp
@@ -299,6 +299,21 @@ void AlgorithmFormatter::update_bin_packing_bound(
     mutex_.unlock();
 }
 
+void AlgorithmFormatter::update_bounds(
+        const packingsolver::Output<Instance, Solution>& output)
+{
+    switch (instance_.objective()) {
+    case Objective::Knapsack:
+        update_knapsack_bound(output.knapsack_bound);
+        break;
+    case Objective::BinPacking:
+        update_bin_packing_bound(output.bin_packing_bound);
+        break;
+    default:
+        break;
+    }
+}
+
 void AlgorithmFormatter::end()
 {
     output_.time = parameters_.timer.elapsed_time();

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -246,40 +246,19 @@ void optimize_column_generation(
             return optimize(kp_instance, kp_parameters);
         };
 
-    columngenerationsolver::Model cgs_model = get_model<Instance, InstanceBuilder, Solution>(instance, pricing_function);
-    columngenerationsolver::LimitedDiscrepancySearchParameters cgslds_parameters;
-    cgslds_parameters.verbosity_level = 0;
-    cgslds_parameters.timer = parameters.timer;
-    cgslds_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
-    cgslds_parameters.internal_diving = 1;
-    cgslds_parameters.dummy_column_objective_coefficient = 2 * (double)instance.largest_item_copies();
-    if (parameters.optimization_mode != OptimizationMode::Anytime)
-        cgslds_parameters.automatic_stop = true;
-    cgslds_parameters.new_solution_callback = [&instance, &algorithm_formatter](
-            const columngenerationsolver::Output& cgs_output)
+    ColumnGenerationParameters<Instance, Solution> cg_parameters;
+    cg_parameters.verbosity_level = 0;
+    cg_parameters.timer = parameters.timer;
+    cg_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    cg_parameters.optimization_mode = parameters.optimization_mode;
+    cg_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
+    cg_parameters.new_solution_callback = [&algorithm_formatter](
+            const packingsolver::Output<Instance, Solution>& ps_output)
     {
-        const columngenerationsolver::LimitedDiscrepancySearchOutput& cgslds_output
-            = static_cast<const columngenerationsolver::LimitedDiscrepancySearchOutput&>(cgs_output);
-        if (cgslds_output.solution.feasible()) {
-            Solution solution(instance);
-            for (const auto& pair: cgslds_output.solution.columns()) {
-                const Column& column = *(pair.first);
-                BinPos value = std::round(pair.second);
-                if (value < 0.5)
-                    continue;
-                solution.append(
-                        *std::static_pointer_cast<Solution>(column.extra),
-                        0,
-                        value);
-            }
-            std::stringstream ss;
-            ss << "CG n " << cgslds_output.number_of_nodes;
-            algorithm_formatter.update_solution(solution, ss.str());
-        }
+        algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG");
+        algorithm_formatter.update_bounds(ps_output);
     };
-    cgslds_parameters.column_generation_parameters.solver_name
-        = parameters.linear_programming_solver_name;
-    columngenerationsolver::limited_discrepancy_search(cgs_model, cgslds_parameters);
+    column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, pricing_function, cg_parameters);
 }
 
 void optimize_tree_search_maximal_spaces(

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -54,6 +54,7 @@ void optimize_tree_search(
             const packingsolver::Output<Instance, Solution>& ts_output)
     {
         algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+        algorithm_formatter.update_bounds(ts_output);
     };
     tree_search(instance, ts_parameters);
 }

--- a/src/rectangleguillotine/algorithm_formatter.cpp
+++ b/src/rectangleguillotine/algorithm_formatter.cpp
@@ -317,6 +317,24 @@ void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
     mutex_.unlock();
 }
 
+void AlgorithmFormatter::update_bounds(
+        const packingsolver::Output<Instance, Solution>& output)
+{
+    switch (instance_.objective()) {
+    case Objective::Knapsack:
+        update_knapsack_bound(output.knapsack_bound);
+        break;
+    case Objective::BinPacking:
+        update_bin_packing_bound(output.bin_packing_bound);
+        break;
+    case Objective::VariableSizedBinPacking:
+        update_variable_sized_bin_packing_bound(output.variable_sized_bin_packing_bound);
+        break;
+    default:
+        break;
+    }
+}
+
 void AlgorithmFormatter::end()
 {
     output_.time = parameters_.timer.elapsed_time();

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -356,58 +356,19 @@ void optimize_column_generation(
             return optimize(kp_instance, kp_parameters);
         };
 
-    columngenerationsolver::Model cgs_model = get_model<Instance, InstanceBuilder, Solution>(instance, pricing_function);
-    columngenerationsolver::LimitedDiscrepancySearchParameters cgslds_parameters;
-    cgslds_parameters.verbosity_level = 0;
-    cgslds_parameters.timer = parameters.timer;
-    cgslds_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
-    cgslds_parameters.internal_diving = 1;
-    cgslds_parameters.dummy_column_objective_coefficient = 2 * (double)instance.largest_item_copies();
-    if (parameters.optimization_mode != OptimizationMode::Anytime)
-        cgslds_parameters.automatic_stop = true;
-    cgslds_parameters.new_solution_callback = [&instance, &algorithm_formatter](
-            const columngenerationsolver::Output& cgs_output)
+    ColumnGenerationParameters<Instance, Solution> cg_parameters;
+    cg_parameters.verbosity_level = 0;
+    cg_parameters.timer = parameters.timer;
+    cg_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    cg_parameters.optimization_mode = parameters.optimization_mode;
+    cg_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
+    cg_parameters.new_solution_callback = [&algorithm_formatter](
+            const packingsolver::Output<Instance, Solution>& ps_output)
     {
-        const columngenerationsolver::LimitedDiscrepancySearchOutput& cgslds_output
-            = static_cast<const columngenerationsolver::LimitedDiscrepancySearchOutput&>(cgs_output);
-        if (cgslds_output.solution.feasible()) {
-            Solution solution(instance);
-            for (const auto& pair: cgslds_output.solution.columns()) {
-                const Column& column = *(pair.first);
-                BinPos value = std::round(pair.second);
-                if (value < 0.5)
-                    continue;
-                solution.append(
-                        *std::static_pointer_cast<Solution>(column.extra),
-                        0,
-                        value);
-            }
-            std::stringstream ss;
-            ss << "CG n " << cgslds_output.number_of_nodes;
-            algorithm_formatter.update_solution(solution, ss.str());
-        }
+        algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG");
+        algorithm_formatter.update_bounds(ps_output);
     };
-    cgslds_parameters.new_bound_callback = [&instance, &algorithm_formatter](
-            const columngenerationsolver::Output& cgs_output)
-    {
-        const columngenerationsolver::LimitedDiscrepancySearchOutput& cgslds_output
-            = static_cast<const columngenerationsolver::LimitedDiscrepancySearchOutput&>(cgs_output);
-        if (instance.objective() == Objective::VariableSizedBinPacking) {
-            double multiplier_cost = largest_power_of_two_lesser_or_equal(instance.largest_bin_cost());
-            algorithm_formatter.update_variable_sized_bin_packing_bound(cgslds_output.bound * multiplier_cost);
-        } else if (instance.objective() == Objective::Knapsack) {
-            double multiplier_profit = largest_power_of_two_lesser_or_equal(instance.largest_item_profit());
-            algorithm_formatter.update_knapsack_bound(cgslds_output.bound * multiplier_profit);
-        } else if (instance.objective() == Objective::BinPacking) {
-            double multiplier_cost = largest_power_of_two_lesser_or_equal(instance.largest_bin_cost());
-            BinPos bin_packing_bound = std::ceil(cgslds_output.bound * multiplier_cost / instance.bin_type(0).space() - 0.001);
-            std::cout << "bin_packing_bound " << bin_packing_bound << std::endl;
-            algorithm_formatter.update_bin_packing_bound(bin_packing_bound);
-        }
-    };
-    cgslds_parameters.column_generation_parameters.solver_name
-        = parameters.linear_programming_solver_name;
-    columngenerationsolver::limited_discrepancy_search(cgs_model, cgslds_parameters);
+    column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, pricing_function, cg_parameters);
 }
 
 }

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -82,6 +82,7 @@ void optimize_tree_search(
             const packingsolver::Output<Instance, Solution>& ts_output)
     {
         algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+        algorithm_formatter.update_bounds(ts_output);
     };
     tree_search(instance, ts_parameters);
 }


### PR DESCRIPTION
Add ColumnGenerationOutput<Instance, Solution> and ColumnGenerationParameters<Instance, Solution> template structs to algorithms/column_generation.hpp, along with a
column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter>() function that handles solution assembly and bound propagation generically.

Add AlgorithmFormatter::update_bounds() helper to onedimensional, rectangle, rectangleguillotine, and irregular domains.

Reduce optimize_column_generation() in each domain to a thin wrapper that builds the pricing function and delegates to column_generation().