### PR TITLE
Add label to SolutionPool entries and propagate algorithm details

### DIFF
--- a/include/packingsolver/algorithms/common.hpp
+++ b/include/packingsolver/algorithms/common.hpp
@@ -157,47 +157,53 @@ struct AbstractBinType
     BinPos copies;
 };
 
-template <typename Solution>
-struct SolutionPoolComparator
-{
-    bool operator()(
-            const Solution& solution_1,
-            const Solution& solution_2) const {
-        if (solution_1 < solution_2)
-            return false;
-        if (solution_2 < solution_1)
-            return true;
-        for (ItemTypeId item_type_id = 0;
-                item_type_id < solution_1.instance().number_of_item_types();
-                ++item_type_id)
-            if (solution_1.item_copies(item_type_id)
-                    != solution_2.item_copies(item_type_id))
-                return solution_1.item_copies(item_type_id)
-                    < solution_2.item_copies(item_type_id);
-        return false;
-    }
-};
-
 template <typename Instance, typename Solution>
 class SolutionPool
 {
 
 public:
 
+    struct Entry {
+        Solution solution;
+        std::string label;
+    };
+
+private:
+
+    struct EntryComparator {
+        bool operator()(const Entry& e1, const Entry& e2) const {
+            if (e1.solution < e2.solution)
+                return false;
+            if (e2.solution < e1.solution)
+                return true;
+            for (ItemTypeId item_type_id = 0;
+                    item_type_id < e1.solution.instance().number_of_item_types();
+                    ++item_type_id)
+                if (e1.solution.item_copies(item_type_id)
+                        != e2.solution.item_copies(item_type_id))
+                    return e1.solution.item_copies(item_type_id)
+                        < e2.solution.item_copies(item_type_id);
+            return false;
+        }
+    };
+
+public:
+
     SolutionPool(const Instance& instance, Counter size_max):
         size_max_(size_max),
-        best_(instance),
-        worst_(instance)
+        best_{Solution(instance), ""},
+        worst_{Solution(instance), ""}
     {
-        solutions_.insert(Solution(instance));
+        solutions_.insert({Solution(instance), ""});
     }
 
     virtual ~SolutionPool() { }
 
-    const std::set<Solution, SolutionPoolComparator<Solution>>& solutions() const { return solutions_; };
+    const std::set<Entry, EntryComparator>& solutions() const { return solutions_; };
 
-    const Solution& best() const { return best_; }
-    const Solution& worst() const { return worst_; }
+    const Solution& best() const { return best_.solution; }
+    const std::string& best_label() const { return best_.label; }
+    const Solution& worst() const { return worst_.solution; }
 
     /**
      * Add a solution to the solution pool.
@@ -207,22 +213,23 @@ public:
      *         0 if the solution is added but is not the new best solution.
      */
     int add(
-            const Solution& solution)
+            const Solution& solution,
+            const std::string& label = "")
     {
         // If the solution is worse than the worst solution of the pool, stop.
         if ((Counter)solutions_.size() >= size_max_)
-            if (!(worst_ < solution))
+            if (!(worst_.solution < solution))
                 return -1;
 
         // Check again after mutex lock.
         if ((Counter)solutions_.size() >= size_max_) {
-            if (!(worst_ < solution)) {
+            if (!(worst_.solution < solution)) {
                 return -1;
             }
         }
 
         // Add new solution to solution pool.
-        auto res = solutions_.insert(solution);
+        auto res = solutions_.insert({solution, label});
         if (!res.second)
             return -1;
 
@@ -243,10 +250,9 @@ public:
 private:
 
     Counter size_max_;
-    SolutionPoolComparator<Solution> solution_pool_comparator_;
-    std::set<Solution, SolutionPoolComparator<Solution>> solutions_;
-    Solution best_;
-    Solution worst_;
+    std::set<Entry, EntryComparator> solutions_;
+    Entry best_;
+    Entry worst_;
 
 };
 

--- a/src/algorithms/column_generation.hpp
+++ b/src/algorithms/column_generation.hpp
@@ -294,15 +294,15 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution>
         //std::cout << "pricing_function end" << std::endl;
 
         // Retrieve column.
-        for (const Solution& kp_solution: kp_output.solution_pool.solutions()) {
-            if (kp_solution.number_of_bins() == 0)
+        for (const auto& kp_entry: kp_output.solution_pool.solutions()) {
+            if (kp_entry.solution.number_of_bins() == 0)
                 continue;
 
             Column column;
 
             Solution extra_solution(instance_);
             extra_solution.append(
-                    kp_solution,
+                    kp_entry.solution,
                     0,
                     1,
                     {bin_type_id},
@@ -325,10 +325,10 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution>
             for (ItemTypeId kp_item_type_id = 0;
                     kp_item_type_id < kp_instance.number_of_item_types();
                     ++kp_item_type_id) {
-                if (kp_solution.item_copies(kp_item_type_id) > 0) {
+                if (kp_entry.solution.item_copies(kp_item_type_id) > 0) {
                     columngenerationsolver::LinearTerm element;
                     element.row = instance_.number_of_bin_types() + kp2vbpp[kp_item_type_id];
-                    element.coefficient = kp_solution.item_copies(kp_item_type_id);
+                    element.coefficient = kp_entry.solution.item_copies(kp_item_type_id);
                     column.elements.push_back(element);
                     //std::cout << duals[m + extra->kp2vbpp[kp_j]] << std::endl;
                 }
@@ -415,7 +415,7 @@ ColumnGenerationOutput<Instance, Solution> column_generation(
                         value);
             }
             std::stringstream ss;
-            ss << "CG n " << cgslds_output.number_of_nodes;
+            ss << "n " << cgslds_output.number_of_nodes;
             algorithm_formatter.update_solution(solution, ss.str());
         }
     };

--- a/src/box/algorithm_formatter.cpp
+++ b/src/box/algorithm_formatter.cpp
@@ -235,7 +235,7 @@ void AlgorithmFormatter::update_solution(
 {
     mutex_.lock();
     output_.time = parameters_.timer.elapsed_time();
-    int new_best = output_.solution_pool.add(solution);
+    int new_best = output_.solution_pool.add(solution, s);
     if (new_best == 1) {
         print(s);
         if (parameters_.write_json_output)

--- a/src/box/optimize.cpp
+++ b/src/box/optimize.cpp
@@ -31,7 +31,7 @@ void optimize_tree_search(
     ts_parameters.new_solution_callback = [&algorithm_formatter](
             const packingsolver::Output<Instance, Solution>& ts_output)
     {
-        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
         algorithm_formatter.update_bounds(ts_output);
     };
     tree_search(instance, ts_parameters);
@@ -51,7 +51,7 @@ void optimize_tree_search_maximal_spaces(
     ts_ms_parameters.new_solution_callback = [&algorithm_formatter](
             const packingsolver::Output<Instance, Solution>& ts_output)
     {
-        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TSMS");
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TSMS " + ts_output.solution_pool.best_label());
     };
     tree_search_maximal_spaces(instance, ts_ms_parameters);
 }

--- a/src/box/tree_search.cpp
+++ b/src/box/tree_search.cpp
@@ -1005,7 +1005,7 @@ const packingsolver::box::TreeSearchOutput packingsolver::box::tree_search(
                     Solution solution = branching_schemes[scheme_idx].to_solution(
                             tssibs_output.solution_pool.best());
                     std::stringstream ss;
-                    ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
+                    ss << "g " << branching_schemes[scheme_idx].parameters().guide_id
                         << " d " << branching_schemes[scheme_idx].parameters().direction
                         << " q " << tssibs_output.maximum_size_of_the_queue;
                     algorithm_formatter.update_solution(solution, ss.str());
@@ -1026,7 +1026,11 @@ const packingsolver::box::TreeSearchOutput packingsolver::box::tree_search(
                         = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
                     Solution solution = branching_schemes[scheme_idx].to_solution(
                             tssibs_output.solution_pool.best());
-                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution);
+                    std::stringstream ss;
+                    ss << "g " << branching_schemes[scheme_idx].parameters().guide_id
+                        << " d " << branching_schemes[scheme_idx].parameters().direction
+                        << " q " << tssibs_output.maximum_size_of_the_queue;
+                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution, ss.str());
                 };
         }
         exception_ptr_list.push_front(std::exception_ptr());
@@ -1046,12 +1050,9 @@ const packingsolver::box::TreeSearchOutput packingsolver::box::tree_search(
             std::rethrow_exception(exception_ptr);
     if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
         for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
-            std::stringstream ss;
-            ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
-                << " d " << branching_schemes[scheme_idx].parameters().direction;
             algorithm_formatter.update_solution(
                     local_outputs[(size_t)scheme_idx].solution_pool.best(),
-                    ss.str());
+                    local_outputs[(size_t)scheme_idx].solution_pool.best_label());
         }
     }
 

--- a/src/box/tree_search_maximal_spaces.cpp
+++ b/src/box/tree_search_maximal_spaces.cpp
@@ -881,7 +881,7 @@ const packingsolver::box::TreeSearchMaximalSpacesOutput packingsolver::box::tree
                     Solution solution = branching_schemes[scheme_idx].to_solution(
                             tssibs_output.solution_pool.best());
                     std::stringstream ss;
-                    ss << "TSMS n " << tssibs_output.maximum_size_of_the_queue;
+                    ss << "n " << tssibs_output.maximum_size_of_the_queue;
                     algorithm_formatter.update_solution(solution, ss.str());
                 };
         } else {
@@ -893,7 +893,9 @@ const packingsolver::box::TreeSearchMaximalSpacesOutput packingsolver::box::tree
                         = static_cast<const treesearchsolver::IterativeBeamSearchOutput<BranchingSchemeMaximalSpaces>&>(tss_output);
                     Solution solution = branching_schemes[scheme_idx].to_solution(
                             tssibs_output.solution_pool.best());
-                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution);
+                    std::stringstream ss;
+                    ss << "n " << tssibs_output.maximum_size_of_the_queue;
+                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution, ss.str());
                 };
         }
         exception_ptr_list.push_front(std::exception_ptr());
@@ -920,11 +922,9 @@ const packingsolver::box::TreeSearchMaximalSpacesOutput packingsolver::box::tree
             std::rethrow_exception(exception_ptr);
     if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
         for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
-            std::stringstream ss;
-            ss << "TSMS";
             algorithm_formatter.update_solution(
                     local_outputs[(size_t)scheme_idx].solution_pool.best(),
-                    ss.str());
+                    local_outputs[(size_t)scheme_idx].solution_pool.best_label());
         }
     }
 

--- a/src/boxstacks/algorithm_formatter.cpp
+++ b/src/boxstacks/algorithm_formatter.cpp
@@ -235,7 +235,7 @@ void AlgorithmFormatter::update_solution(
 {
     mutex_.lock();
     output_.time = parameters_.timer.elapsed_time();
-    int new_best = output_.solution_pool.add(solution);
+    int new_best = output_.solution_pool.add(solution, s);
     if (new_best == 1) {
         print(s);
         if (parameters_.write_json_output)

--- a/src/boxstacks/optimize.cpp
+++ b/src/boxstacks/optimize.cpp
@@ -123,7 +123,7 @@ packingsolver::boxstacks::Output packingsolver::boxstacks::optimize(
             ts_parameters.new_solution_callback = [&algorithm_formatter](
                     const packingsolver::Output<Instance, Solution>& ts_output)
             {
-                algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+                algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
             };
             tree_search(instance, ts_parameters);
 

--- a/src/irregular/algorithm_formatter.cpp
+++ b/src/irregular/algorithm_formatter.cpp
@@ -250,7 +250,7 @@ void AlgorithmFormatter::update_solution(
 {
     mutex_.lock();
     output_.time = parameters_.timer.elapsed_time();
-    int new_best = output_.solution_pool.add(solution);
+    int new_best = output_.solution_pool.add(solution, s);
     if (new_best == 1) {
         print(s);
         if (parameters_.write_json_output)

--- a/src/irregular/optimize.cpp
+++ b/src/irregular/optimize.cpp
@@ -121,7 +121,7 @@ void optimize_tree_search(
     ts_parameters.new_solution_callback = [&algorithm_formatter](
             const packingsolver::Output<Instance, Solution>& ts_output)
     {
-        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
     };
     tree_search(instance, ts_parameters);
 }
@@ -367,7 +367,7 @@ void optimize_column_generation(
     cg_parameters.new_solution_callback = [&algorithm_formatter](
             const packingsolver::Output<Instance, Solution>& ps_output)
     {
-        algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG");
+        algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
         algorithm_formatter.update_bounds(ps_output);
     };
     column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, pricing_function, cg_parameters);

--- a/src/irregular/tree_search.cpp
+++ b/src/irregular/tree_search.cpp
@@ -2614,7 +2614,7 @@ void tree_search_worker(
                 Solution solution = branching_scheme.to_solution(
                         tssibs_output.solution_pool.best());
                 std::stringstream ss;
-                ss << "TS g " << branching_scheme_parameters.guide_id
+                ss << "g " << branching_scheme_parameters.guide_id
                     << " d " << (int)branching_scheme_parameters.direction
                     << " q " << tssibs_output.maximum_size_of_the_queue;
                 new_solution_callback(solution, ss.str());
@@ -2817,9 +2817,9 @@ const packingsolver::irregular::TreeSearchOutput packingsolver::irregular::tree_
         } else {
             new_solution_callback = [&local_outputs, scheme_idx](
                     const Solution& solution,
-                    const std::string& /*label*/)
+                    const std::string& label)
             {
-                local_outputs[(size_t)scheme_idx].solution_pool.add(solution);
+                local_outputs[(size_t)scheme_idx].solution_pool.add(solution, label);
             };
         }
         exception_ptr_list.push_front(std::exception_ptr());
@@ -2847,12 +2847,9 @@ const packingsolver::irregular::TreeSearchOutput packingsolver::irregular::tree_
         for (Counter scheme_idx = 0;
                 scheme_idx < (Counter)branching_scheme_parameters_list.size();
                 ++scheme_idx) {
-            std::stringstream ss;
-            ss << "TS g " << branching_scheme_parameters_list[scheme_idx].guide_id
-                << " d " << (int)branching_scheme_parameters_list[scheme_idx].direction;
             algorithm_formatter.update_solution(
                     local_outputs[(size_t)scheme_idx].solution_pool.best(),
-                    ss.str());
+                    local_outputs[(size_t)scheme_idx].solution_pool.best_label());
         }
     }
 

--- a/src/onedimensional/algorithm_formatter.cpp
+++ b/src/onedimensional/algorithm_formatter.cpp
@@ -199,7 +199,7 @@ void AlgorithmFormatter::update_solution(
 {
     mutex_.lock();
     output_.time = parameters_.timer.elapsed_time();
-    int new_best = output_.solution_pool.add(solution);
+    int new_best = output_.solution_pool.add(solution, s);
     if (new_best == 1) {
         print(s);
         if (parameters_.write_json_output)

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -102,7 +102,7 @@ void optimize_tree_search(
     ts_parameters.new_solution_callback = [&algorithm_formatter](
             const packingsolver::Output<Instance, Solution>& ts_output)
     {
-        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
         algorithm_formatter.update_bounds(ts_output);
     };
     tree_search(instance, ts_parameters);
@@ -299,7 +299,7 @@ void optimize_column_generation(
     cg_parameters.new_solution_callback = [&algorithm_formatter](
             const packingsolver::Output<Instance, Solution>& ps_output)
     {
-        algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG");
+        algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
         algorithm_formatter.update_bounds(ps_output);
     };
     column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, pricing_function, cg_parameters);

--- a/src/onedimensional/tree_search.cpp
+++ b/src/onedimensional/tree_search.cpp
@@ -421,7 +421,7 @@ const packingsolver::onedimensional::TreeSearchOutput packingsolver::onedimensio
                     Solution solution = branching_schemes[scheme_idx].to_solution(
                             tssibs_output.solution_pool.best());
                     std::stringstream ss;
-                    ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
+                    ss << "g " << branching_schemes[scheme_idx].parameters().guide_id
                         << " q " << tssibs_output.maximum_size_of_the_queue;
                     algorithm_formatter.update_solution(solution, ss.str());
                     if (tssibs_output.optimal
@@ -439,7 +439,10 @@ const packingsolver::onedimensional::TreeSearchOutput packingsolver::onedimensio
                         = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
                     Solution solution = branching_schemes[scheme_idx].to_solution(
                             tssibs_output.solution_pool.best());
-                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution);
+                    std::stringstream ss;
+                    ss << "g " << branching_schemes[scheme_idx].parameters().guide_id
+                        << " q " << tssibs_output.maximum_size_of_the_queue;
+                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution, ss.str());
                 };
         }
         exception_ptr_list.push_front(std::exception_ptr());
@@ -466,11 +469,9 @@ const packingsolver::onedimensional::TreeSearchOutput packingsolver::onedimensio
             std::rethrow_exception(exception_ptr);
     if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
         for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
-            std::stringstream ss;
-            ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id;
             algorithm_formatter.update_solution(
                     local_outputs[(size_t)scheme_idx].solution_pool.best(),
-                    ss.str());
+                    local_outputs[(size_t)scheme_idx].solution_pool.best_label());
         }
     }
 

--- a/src/rectangle/algorithm_formatter.cpp
+++ b/src/rectangle/algorithm_formatter.cpp
@@ -235,7 +235,7 @@ void AlgorithmFormatter::update_solution(
 {
     mutex_.lock();
     output_.time = parameters_.timer.elapsed_time();
-    int new_best = output_.solution_pool.add(solution);
+    int new_best = output_.solution_pool.add(solution, s);
     if (new_best == 1) {
         print(s);
         if (parameters_.write_json_output)

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -53,7 +53,7 @@ void optimize_tree_search(
     ts_parameters.new_solution_callback = [&algorithm_formatter](
             const packingsolver::Output<Instance, Solution>& ts_output)
     {
-        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
         algorithm_formatter.update_bounds(ts_output);
     };
     tree_search(instance, ts_parameters);
@@ -256,7 +256,7 @@ void optimize_column_generation(
     cg_parameters.new_solution_callback = [&algorithm_formatter](
             const packingsolver::Output<Instance, Solution>& ps_output)
     {
-        algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG");
+        algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
         algorithm_formatter.update_bounds(ps_output);
     };
     column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, pricing_function, cg_parameters);
@@ -276,7 +276,7 @@ void optimize_tree_search_maximal_spaces(
     ts_ms_parameters.new_solution_callback = [&algorithm_formatter](
             const packingsolver::Output<Instance, Solution>& ts_output)
     {
-        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TSMS");
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TSMS " + ts_output.solution_pool.best_label());
     };
     tree_search_maximal_spaces(instance, ts_ms_parameters);
 }

--- a/src/rectangle/tree_search.cpp
+++ b/src/rectangle/tree_search.cpp
@@ -1497,7 +1497,7 @@ const packingsolver::rectangle::TreeSearchOutput packingsolver::rectangle::tree_
                     Solution solution = branching_schemes[scheme_idx].to_solution(
                             tssibs_output.solution_pool.best());
                     std::stringstream ss;
-                    ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
+                    ss << "g " << branching_schemes[scheme_idx].parameters().guide_id
                         << " d " << branching_schemes[scheme_idx].parameters().direction
                         << " q " << tssibs_output.maximum_size_of_the_queue;
                     algorithm_formatter.update_solution(solution, ss.str());
@@ -1518,7 +1518,11 @@ const packingsolver::rectangle::TreeSearchOutput packingsolver::rectangle::tree_
                         = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
                     Solution solution = branching_schemes[scheme_idx].to_solution(
                             tssibs_output.solution_pool.best());
-                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution);
+                    std::stringstream ss;
+                    ss << "g " << branching_schemes[scheme_idx].parameters().guide_id
+                        << " d " << branching_schemes[scheme_idx].parameters().direction
+                        << " q " << tssibs_output.maximum_size_of_the_queue;
+                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution, ss.str());
                 };
         }
         exception_ptr_list.push_front(std::exception_ptr());
@@ -1538,12 +1542,9 @@ const packingsolver::rectangle::TreeSearchOutput packingsolver::rectangle::tree_
             std::rethrow_exception(exception_ptr);
     if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
         for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
-            std::stringstream ss;
-            ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
-                << " d " << branching_schemes[scheme_idx].parameters().direction;
             algorithm_formatter.update_solution(
                     local_outputs[(size_t)scheme_idx].solution_pool.best(),
-                    ss.str());
+                    local_outputs[(size_t)scheme_idx].solution_pool.best_label());
         }
     }
 

--- a/src/rectangle/tree_search_maximal_spaces.cpp
+++ b/src/rectangle/tree_search_maximal_spaces.cpp
@@ -691,7 +691,7 @@ const packingsolver::rectangle::TreeSearchMaximalSpacesOutput packingsolver::rec
                     Solution solution = branching_schemes[scheme_idx].to_solution(
                             tssibs_output.solution_pool.best());
                     std::stringstream ss;
-                    ss << "TSMS n " << tssibs_output.maximum_size_of_the_queue;
+                    ss << "n " << tssibs_output.maximum_size_of_the_queue;
                     algorithm_formatter.update_solution(solution, ss.str());
                 };
         } else {
@@ -703,7 +703,9 @@ const packingsolver::rectangle::TreeSearchMaximalSpacesOutput packingsolver::rec
                         = static_cast<const treesearchsolver::IterativeBeamSearchOutput<BranchingSchemeMaximalSpaces>&>(tss_output);
                     Solution solution = branching_schemes[scheme_idx].to_solution(
                             tssibs_output.solution_pool.best());
-                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution);
+                    std::stringstream ss;
+                    ss << "n " << tssibs_output.maximum_size_of_the_queue;
+                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution, ss.str());
                 };
         }
         exception_ptr_list.push_front(std::exception_ptr());
@@ -730,11 +732,9 @@ const packingsolver::rectangle::TreeSearchMaximalSpacesOutput packingsolver::rec
             std::rethrow_exception(exception_ptr);
     if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
         for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
-            std::stringstream ss;
-            ss << "TSMS";
             algorithm_formatter.update_solution(
                     local_outputs[(size_t)scheme_idx].solution_pool.best(),
-                    ss.str());
+                    local_outputs[(size_t)scheme_idx].solution_pool.best_label());
         }
     }
 

--- a/src/rectangleguillotine/algorithm_formatter.cpp
+++ b/src/rectangleguillotine/algorithm_formatter.cpp
@@ -238,7 +238,7 @@ void AlgorithmFormatter::update_solution(
 {
     mutex_.lock();
     output_.time = parameters_.timer.elapsed_time();
-    int new_best = output_.solution_pool.add(solution);
+    int new_best = output_.solution_pool.add(solution, s);
     if (new_best == 1) {
         print(s);
         if (parameters_.write_json_output)

--- a/src/rectangleguillotine/column_generation_strips.cpp
+++ b/src/rectangleguillotine/column_generation_strips.cpp
@@ -1767,7 +1767,7 @@ void column_generation_strips_vertical(
             }
             Solution solution = solution_builder.build();
             std::stringstream ss;
-            ss << "CGV n " << cgslds_output.number_of_nodes;
+            ss << "V n " << cgslds_output.number_of_nodes;
             algorithm_formatter.update_solution(solution, ss.str());
             //std::cout << "callback end" << std::endl;
         }
@@ -1802,7 +1802,7 @@ void column_generation_strips_horizontal(
             const ColumnGenerationStripsOutput& flipped_output
                 = static_cast<const ColumnGenerationStripsOutput&>(ps_output);
             std::stringstream ss;
-            ss << "CGH n ";
+            ss << "H n ";
             //std::cout << "callback flipped" << std::endl;
             Solution solution = instance_flippper.unflip_solution(
                     flipped_output.solution_pool.best());

--- a/src/rectangleguillotine/labeling.cpp
+++ b/src/rectangleguillotine/labeling.cpp
@@ -494,7 +494,7 @@ const LabelingOutput packingsolver::rectangleguillotine::labeling(
                 Solution solution = reconstruct_solution(
                         instance, returned_blocks, block,
                         eff_width, eff_height, cut_thickness);
-                algorithm_formatter.update_solution(solution, "LS");
+                algorithm_formatter.update_solution(solution, "b " + std::to_string(returned_blocks.size()));
             }
 
             if (block.priority > best_solution_profit) {
@@ -580,7 +580,7 @@ const LabelingOutput packingsolver::rectangleguillotine::labeling(
                         Solution solution = reconstruct_solution(
                                 instance, returned_blocks, combined,
                                 eff_width, eff_height, cut_thickness);
-                        algorithm_formatter.update_solution(solution, "LS");
+                        algorithm_formatter.update_solution(solution, "b " + std::to_string(returned_blocks.size()));
                     }
                     blocks_to_process[bucket_index(combined.priority)].push_back(
                             std::move(combined));
@@ -601,7 +601,7 @@ const LabelingOutput packingsolver::rectangleguillotine::labeling(
                         Solution solution = reconstruct_solution(
                                 instance, returned_blocks, combined,
                                 eff_width, eff_height, cut_thickness);
-                        algorithm_formatter.update_solution(solution, "LS");
+                        algorithm_formatter.update_solution(solution, "n " + std::to_string(returned_blocks.size()));
                     }
                     blocks_to_process[bucket_index(combined.priority)].push_back(
                             std::move(combined));

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -81,7 +81,7 @@ void optimize_tree_search(
     ts_parameters.new_solution_callback = [&algorithm_formatter](
             const packingsolver::Output<Instance, Solution>& ts_output)
     {
-        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS");
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
         algorithm_formatter.update_bounds(ts_output);
     };
     tree_search(instance, ts_parameters);
@@ -101,7 +101,7 @@ void optimize_tree_search_maximal_spaces(
     ts_ms_parameters.new_solution_callback = [&algorithm_formatter](
             const packingsolver::Output<Instance, Solution>& ts_output)
     {
-        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TSMS");
+        algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TSMS " + ts_output.solution_pool.best_label());
     };
     tree_search_maximal_spaces(instance, ts_ms_parameters);
 }
@@ -137,7 +137,7 @@ void optimize_labeling(
     {
         algorithm_formatter.update_solution(
                 ps_output.solution_pool.best(),
-                "LS");
+                "L " + ps_output.solution_pool.best_label());
     };
     labeling(instance, ls_parameters);
 }
@@ -160,9 +160,9 @@ void optimize_column_generation_strips(
     {
         const SequentialValueCorrectionOutput<Instance, Solution>& pscg_output
             = static_cast<const SequentialValueCorrectionOutput<Instance, Solution>&>(ps_output);
-        std::stringstream ss;
-        ss << "CG";
-        algorithm_formatter.update_solution(pscg_output.solution_pool.best(), ss.str());
+        algorithm_formatter.update_solution(
+                pscg_output.solution_pool.best(),
+                "CGS " + pscg_output.solution_pool.best_label());
         algorithm_formatter.update_knapsack_bound(pscg_output.knapsack_bound);
     };
     column_generation_strips(instance, cg_parameters);
@@ -366,7 +366,7 @@ void optimize_column_generation(
     cg_parameters.new_solution_callback = [&algorithm_formatter](
             const packingsolver::Output<Instance, Solution>& ps_output)
     {
-        algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG");
+        algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
         algorithm_formatter.update_bounds(ps_output);
     };
     column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, pricing_function, cg_parameters);

--- a/src/rectangleguillotine/tree_search.cpp
+++ b/src/rectangleguillotine/tree_search.cpp
@@ -2165,7 +2165,7 @@ const packingsolver::rectangleguillotine::TreeSearchOutput packingsolver::rectan
                     Solution solution = branching_schemes[scheme_idx].to_solution(
                             tssibs_output.solution_pool.best());
                     std::stringstream ss;
-                    ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
+                    ss << "g " << branching_schemes[scheme_idx].parameters().guide_id
                         << " d " << branching_schemes[scheme_idx].parameters().first_stage_orientation
                         << " q " << tssibs_output.maximum_size_of_the_queue;
                     algorithm_formatter.update_solution(solution, ss.str());
@@ -2186,7 +2186,11 @@ const packingsolver::rectangleguillotine::TreeSearchOutput packingsolver::rectan
                         = static_cast<const treesearchsolver::IterativeBeamSearch2Output<BranchingScheme>&>(tss_output);
                     Solution solution = branching_schemes[scheme_idx].to_solution(
                             tssibs_output.solution_pool.best());
-                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution);
+                    std::stringstream ss;
+                    ss << "g " << branching_schemes[scheme_idx].parameters().guide_id
+                        << " d " << branching_schemes[scheme_idx].parameters().first_stage_orientation
+                        << " q " << tssibs_output.maximum_size_of_the_queue;
+                    local_outputs[(size_t)scheme_idx].solution_pool.add(solution, ss.str());
                 };
         }
         exception_ptr_list.push_front(std::exception_ptr());
@@ -2206,12 +2210,9 @@ const packingsolver::rectangleguillotine::TreeSearchOutput packingsolver::rectan
             std::rethrow_exception(exception_ptr);
     if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
         for (Counter scheme_idx = 0; scheme_idx < (Counter)branching_schemes.size(); ++scheme_idx) {
-            std::stringstream ss;
-            ss << "TS g " << branching_schemes[scheme_idx].parameters().guide_id
-                << " d " << branching_schemes[scheme_idx].parameters().first_stage_orientation;
             algorithm_formatter.update_solution(
                     local_outputs[(size_t)scheme_idx].solution_pool.best(),
-                    ss.str());
+                    local_outputs[(size_t)scheme_idx].solution_pool.best_label());
         }
     }
 

--- a/src/rectangleguillotine/tree_search_maximal_spaces.cpp
+++ b/src/rectangleguillotine/tree_search_maximal_spaces.cpp
@@ -812,7 +812,7 @@ const packingsolver::rectangleguillotine::TreeSearchMaximalSpacesOutput packings
                 Solution solution = branching_scheme.to_solution(
                         tssibs_output.solution_pool.best());
                 std::stringstream ss;
-                ss << "TSMS n " << tssibs_output.maximum_size_of_the_queue;
+                ss << "n " << tssibs_output.maximum_size_of_the_queue;
                 algorithm_formatter.update_solution(solution, ss.str());
             };
     } else {
@@ -824,7 +824,9 @@ const packingsolver::rectangleguillotine::TreeSearchMaximalSpacesOutput packings
                     = static_cast<const treesearchsolver::IterativeBeamSearchOutput<BranchingSchemeMaximalSpaces>&>(tss_output);
                 Solution solution = branching_scheme.to_solution(
                         tssibs_output.solution_pool.best());
-                local_output.solution_pool.add(solution);
+                std::stringstream ss;
+                ss << "n " << tssibs_output.maximum_size_of_the_queue;
+                local_output.solution_pool.add(solution, ss.str());
             };
     }
 
@@ -849,7 +851,7 @@ const packingsolver::rectangleguillotine::TreeSearchMaximalSpacesOutput packings
     if (exception_ptr)
         std::rethrow_exception(exception_ptr);
     if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic)
-        algorithm_formatter.update_solution(local_output.solution_pool.best(), "TSMS");
+        algorithm_formatter.update_solution(local_output.solution_pool.best(), local_output.solution_pool.best_label());
 
     algorithm_formatter.end();
     return output;


### PR DESCRIPTION
SolutionPool now stores a label string alongside each solution (via a nested Entry struct) and exposes best_label(). SolutionPoolComparator is folded into EntryComparator inside SolutionPool.

Inner algorithms (tree_search, tree_search_maximal_spaces, column_generation) now emit detail-only labels without an algorithm prefix (e.g. "g 0 d 0 q 1024", "n 256"). The outer optimize wrappers reconstruct the full label by prepending the algorithm name ("TS g 0 d 0 q 1024", "TSMS n 256", "CG n 42"). The labeling algorithm uses the number of processed blocks as its label ("b 42").