### PR TITLE
irregular: integrate sequential_feasibility into tree_search and local_search

### DIFF
--- a/include/packingsolver/irregular/optimize.hpp
+++ b/include/packingsolver/irregular/optimize.hpp
@@ -53,9 +53,6 @@ struct OptimizeParameters: packingsolver::Parameters<Instance, Solution>
     /** Use column generation algorithm. */
     bool use_column_generation = false;
 
-    /** Use sequential feasibility algorithm. */
-    bool use_sequential_feasibility = false;
-
     /** Initial maximum approximation ratio. */
     double initial_maximum_approximation_ratio = 0.20;
 
@@ -70,15 +67,6 @@ struct OptimizeParameters: packingsolver::Parameters<Instance, Solution>
 
     /** Guides used in the tree search algorithm. */
     std::vector<GuideId> tree_search_guides;
-
-    /** Use tree search in sequential feasibility sub-problems. */
-    bool sequential_feasibility_use_tree_search = false;
-
-    /** Use local search in sequential feasibility sub-problems. */
-    bool sequential_feasibility_use_local_search = false;
-
-    /** Use MILP raster in sequential feasibility sub-problems. */
-    bool sequential_feasibility_use_milp_raster = false;
 
     /**
      * Size of the queue for the pricing knapsack subproblem of the sequential

--- a/src/irregular/local_search.cpp
+++ b/src/irregular/local_search.cpp
@@ -1,4 +1,5 @@
 #include "irregular/local_search.hpp"
+#include "irregular/sequential_feasibility.hpp"
 #include "irregular/linear_programming.hpp"
 
 #include "packingsolver/irregular/algorithm_formatter.hpp"
@@ -221,6 +222,41 @@ LocalSearchOutput packingsolver::irregular::local_search(
         const Instance& instance,
         const LocalSearchParameters& parameters)
 {
+    if (instance.objective() != Objective::Feasibility) {
+        LocalSearchOutput output(instance);
+        AlgorithmFormatter algorithm_formatter(instance, parameters, output);
+        algorithm_formatter.start();
+        algorithm_formatter.print_header();
+
+        SequentialFeasibilitySolver solver = [&parameters, &algorithm_formatter](
+                const Instance& sub_instance)
+        {
+            LocalSearchParameters inner_parameters;
+            inner_parameters.verbosity_level = 0;
+            inner_parameters.timer = parameters.timer;
+            inner_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+            inner_parameters.seed = parameters.seed;
+            return local_search(sub_instance, inner_parameters).solution_pool;
+        };
+
+        SequentialFeasibilityParameters sf_parameters;
+        sf_parameters.verbosity_level = 0;
+        sf_parameters.timer = parameters.timer;
+        sf_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+        sf_parameters.new_solution_callback = [&algorithm_formatter](
+                const packingsolver::Output<Instance, Solution>& sf_output)
+        {
+            algorithm_formatter.update_solution(
+                    sf_output.solution_pool.best(),
+                    sf_output.solution_pool.best_label());
+        };
+
+        sequential_feasibility(instance, solver, sf_parameters);
+
+        algorithm_formatter.end();
+        return output;
+    }
+
     LocalSearchOutput output(instance);
 
     AlgorithmFormatter algorithm_formatter(instance, parameters, output);

--- a/src/irregular/main.cpp
+++ b/src/irregular/main.cpp
@@ -85,10 +85,6 @@ int main(int argc, char *argv[])
             ("use-tree-search,", po::value<bool>(), "enable tree search algorithm")
             ("use-milp-raster,", po::value<bool>(), "enable MILP raster algorithm")
             ("use-local-search,", po::value<bool>(), "enable local search algorithm")
-            ("use-sequential-feasibility,", po::value<bool>(), "enable sequential feasibility")
-            ("sequential-feasibility-use-tree-search,", po::value<bool>(), "enable tree search in sequential feasibility sub-problems")
-            ("sequential-feasibility-use-local-search,", po::value<bool>(), "enable local search in sequential feasibility sub-problems")
-            ("sequential-feasibility-use-milp-raster,", po::value<bool>(), "enable MILP raster in sequential feasibility sub-problems")
             ("use-sequential-single-knapsack,", po::value<bool>(), "enable sequential-single-knapsack")
             ("use-sequential-value-correction,", po::value<bool>(), "enable sequential-value-correction")
             ("use-column-generation,", po::value<bool>(), "enable column-generation")
@@ -163,14 +159,6 @@ int main(int argc, char *argv[])
             parameters.use_milp_raster = vm["use-milp-raster"].as<bool>();
         if (vm.count("use-local-search"))
             parameters.use_local_search = vm["use-local-search"].as<bool>();
-        if (vm.count("use-sequential-feasibility"))
-            parameters.use_sequential_feasibility = vm["use-sequential-feasibility"].as<bool>();
-        if (vm.count("sequential-feasibility-use-tree-search"))
-            parameters.sequential_feasibility_use_tree_search = vm["sequential-feasibility-use-tree-search"].as<bool>();
-        if (vm.count("sequential-feasibility-use-local-search"))
-            parameters.sequential_feasibility_use_local_search = vm["sequential-feasibility-use-local-search"].as<bool>();
-        if (vm.count("sequential-feasibility-use-milp-raster"))
-            parameters.sequential_feasibility_use_milp_raster = vm["sequential-feasibility-use-milp-raster"].as<bool>();
         if (vm.count("use-sequential-single-knapsack"))
             parameters.use_sequential_single_knapsack = vm["use-sequential-single-knapsack"].as<bool>();
         if (vm.count("use-sequential-value-correction"))

--- a/src/irregular/optimize.cpp
+++ b/src/irregular/optimize.cpp
@@ -6,7 +6,6 @@
 #include "irregular/tree_search.hpp"
 #include "irregular/milp_raster.hpp"
 #include "irregular/local_search.hpp"
-#include "irregular/sequential_feasibility.hpp"
 #include "algorithms/dichotomic_search.hpp"
 #include "algorithms/sequential_value_correction.hpp"
 #include "algorithms/column_generation.hpp"
@@ -373,33 +372,6 @@ void optimize_column_generation(
     column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, pricing_function, cg_parameters);
 }
 
-void optimize_sequential_feasibility(
-        const Instance& instance,
-        const OptimizeParameters& parameters,
-        AlgorithmFormatter& algorithm_formatter)
-{
-    SequentialFeasibilityParameters sf_parameters;
-    sf_parameters.verbosity_level = 0;
-    sf_parameters.timer = parameters.timer;
-    sf_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
-    sf_parameters.optimization_mode = parameters.optimization_mode;
-    sf_parameters.not_anytime_maximum_approximation_ratio
-        = parameters.not_anytime_maximum_approximation_ratio;
-    sf_parameters.not_anytime_tree_search_queue_size
-        = parameters.not_anytime_tree_search_queue_size;
-    sf_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
-    sf_parameters.use_tree_search = parameters.sequential_feasibility_use_tree_search;
-    sf_parameters.use_local_search = parameters.sequential_feasibility_use_local_search;
-    sf_parameters.use_milp_raster = parameters.sequential_feasibility_use_milp_raster;
-    sf_parameters.new_solution_callback = [&algorithm_formatter](
-            const packingsolver::Output<Instance, Solution>& output) {
-        algorithm_formatter.update_solution(
-                output.solution_pool.best(),
-                "Sequential feasibility");
-    };
-    sequential_feasibility(instance, sf_parameters);
-}
-
 void optimize_milp_raster(
         const Instance& instance,
         const OptimizeParameters& parameters,
@@ -438,7 +410,6 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
     bool use_sequential_value_correction = parameters.use_sequential_value_correction;
     bool use_dichotomic_search = parameters.use_dichotomic_search;
     bool use_column_generation = parameters.use_column_generation;
-    bool use_sequential_feasibility = parameters.use_sequential_feasibility;
     bool use_milp_raster = parameters.use_milp_raster;
     if (instance.number_of_bins() <= 1) {
         // Disable algorithms which are not available for this objective.
@@ -446,33 +417,23 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
         use_sequential_value_correction = false;
         use_dichotomic_search = false;
         use_column_generation = false;
-        if (instance.objective() == Objective::OpenDimensionXY)
-            use_tree_search = false;
-        if (instance.objective() == Objective::Knapsack)
-            use_sequential_feasibility = false;
         if (instance.objective() != Objective::Knapsack
                 && instance.objective() != Objective::Feasibility) {
             use_milp_raster = false;
         }
-        if (instance.objective() != Objective::Feasibility) {
+        if (instance.objective() == Objective::Knapsack) {
             use_local_search = false;
         }
         // Automatic selection.
         if (!use_tree_search
                 && !use_local_search
-                && !use_milp_raster
-                && !use_sequential_feasibility) {
-            if (instance.objective() == Objective::OpenDimensionXY) {
-                use_sequential_feasibility = true;
-            } else {
-                use_tree_search = true;
-            }
+                && !use_milp_raster) {
+            use_tree_search = true;
         }
     } else if (instance.objective() == Objective::Knapsack) {
         // Disable algorithms which are not available for this objective.
         use_local_search = false;
         use_dichotomic_search = false;
-        use_sequential_feasibility = false;
         // Automatic selection.
         if (!use_tree_search
                 && !use_milp_raster
@@ -497,7 +458,6 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
     } else if (instance.objective() == Objective::Feasibility) {
         // Disable algorithms which are not available for this objective.
         use_dichotomic_search = false;
-        use_sequential_feasibility = false;
         // Automatic selection.
         if (!use_tree_search
                 && !use_milp_raster
@@ -531,12 +491,10 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
         if (instance.number_of_bin_types() > 1)
             use_column_generation = false;
         use_dichotomic_search = false;
-        use_local_search = false;
         use_milp_raster = false;
         // Automatic selection.
         if (!use_tree_search
                 && !use_milp_raster
-                && !use_sequential_feasibility
                 && !use_sequential_single_knapsack
                 && !use_sequential_value_correction
                 && !use_column_generation) {
@@ -573,7 +531,6 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
                 use_tree_search = true;
             }
         }
-        use_sequential_feasibility = false;
         // Automatic selection.
         if (!use_tree_search
                 && !use_local_search
@@ -722,18 +679,6 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter]() {
             wrapper<decltype(&optimize_column_generation), optimize_column_generation>(
-                    exception_ptr,
-                    instance,
-                    parameters,
-                    algorithm_formatter);
-        });
-    }
-    // Sequential feasibility.
-    if (use_sequential_feasibility) {
-        exception_ptr_list.push_front(std::exception_ptr());
-        std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter]() {
-            wrapper<decltype(&optimize_sequential_feasibility), optimize_sequential_feasibility>(
                     exception_ptr,
                     instance,
                     parameters,

--- a/src/irregular/sequential_feasibility.cpp
+++ b/src/irregular/sequential_feasibility.cpp
@@ -2,7 +2,6 @@
 
 #include "packingsolver/irregular/algorithm_formatter.hpp"
 #include "packingsolver/irregular/instance_builder.hpp"
-#include "packingsolver/irregular/optimize.hpp"
 
 #include "shape/shape.hpp"
 #include "shape/boolean_operations.hpp"
@@ -15,6 +14,7 @@ using namespace packingsolver::irregular;
 
 SequentialFeasibilityOutput packingsolver::irregular::sequential_feasibility(
         const Instance& instance,
+        const SequentialFeasibilitySolver& solver,
         const SequentialFeasibilityParameters& parameters)
 {
     SequentialFeasibilityOutput output(instance);
@@ -67,9 +67,6 @@ SequentialFeasibilityOutput packingsolver::irregular::sequential_feasibility(
             break;
         if (parameters.timer.needs_to_end())
             break;
-        //std::cout << "current_number_of_bins " << current_number_of_bins
-        //    << " x " << x
-        //    << " y " << y << std::endl;
 
         // Build the Feasibility sub-instance.
         InstanceBuilder sub_instance_builder;
@@ -138,23 +135,10 @@ SequentialFeasibilityOutput packingsolver::irregular::sequential_feasibility(
         Instance sub_instance = sub_instance_builder.build();
 
         // Solve the sub-instance.
-        OptimizeParameters sub_parameters;
-        sub_parameters.verbosity_level = 0;
-        sub_parameters.timer = parameters.timer;
-        sub_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
-        sub_parameters.optimization_mode = parameters.optimization_mode;
-        sub_parameters.not_anytime_maximum_approximation_ratio
-            = parameters.not_anytime_maximum_approximation_ratio;
-        sub_parameters.not_anytime_tree_search_queue_size
-            = parameters.not_anytime_tree_search_queue_size;
-        sub_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
-        sub_parameters.use_tree_search = parameters.use_tree_search;
-        sub_parameters.use_local_search = parameters.use_local_search;
-        sub_parameters.use_milp_raster = parameters.use_milp_raster;
-        auto sub_output = optimize(sub_instance, sub_parameters);
+        SolutionPool<Instance, Solution> sub_solution_pool = solver(sub_instance);
 
         // If no feasible solution found, stop.
-        if (!sub_output.solution_pool.best().full())
+        if (!sub_solution_pool.best().full())
             break;
 
         // Transfer the sub-solution to the main instance.
@@ -162,18 +146,18 @@ SequentialFeasibilityOutput packingsolver::irregular::sequential_feasibility(
         if (instance.objective() == Objective::BinPacking
                 || instance.objective() == Objective::BinPackingWithLeftovers) {
             solution.append(
-                    sub_output.solution_pool.best(),
+                    sub_solution_pool.best(),
                     sub_to_orig_bin_type_ids,
                     {});
         } else {
             solution.append(
-                    sub_output.solution_pool.best(),
+                    sub_solution_pool.best(),
                     0,  // bin_pos
                     1,  // copies
                     {0});  // bin_type_ids
         }
         std::stringstream ss;
-        ss << "SF it " << it;
+        ss << "SF it " << it << " " << sub_solution_pool.best_label();
         algorithm_formatter.update_solution(solution, ss.str());
 
         // Update for the next iteration.
@@ -182,22 +166,22 @@ SequentialFeasibilityOutput packingsolver::irregular::sequential_feasibility(
             if (current_number_of_bins == 0)
                 break;
         } else if (instance.objective() == Objective::BinPackingWithLeftovers) {
-            BinTypeId bin_type_id = instance.bin_type_id(solution.number_of_bins() - 1);
-            const BinType& bin_type = instance.bin_type(bin_type_id);
-            x = 0.99 * (solution.x_max() - bin_type.aabb_scaled.x_min)
-                + bin_type.item_bin_minimum_spacing;
+            BinTypeId bin_type_id_last = instance.bin_type_id(solution.number_of_bins() - 1);
+            const BinType& bin_type_last = instance.bin_type(bin_type_id_last);
+            x = 0.99 * (solution.x_max() - bin_type_last.aabb_scaled.x_min)
+                + bin_type_last.item_bin_minimum_spacing;
             if (solution.number_of_bins() < current_number_of_bins) {
                 current_number_of_bins = solution.number_of_bins();
-                BinTypeId bin_type_id = instance.bin_type_id(current_number_of_bins - 1);
-                const BinType& bin_type = instance.bin_type(bin_type_id);
-                x = bin_type.aabb_scaled.x_max;
-            } else if (!strictly_greater(x, bin_type.aabb_scaled.x_min + bin_type.item_bin_minimum_spacing)) {
+                BinTypeId bin_type_id_new = instance.bin_type_id(current_number_of_bins - 1);
+                const BinType& bin_type_new = instance.bin_type(bin_type_id_new);
+                x = bin_type_new.aabb_scaled.x_max;
+            } else if (!strictly_greater(x, bin_type_last.aabb_scaled.x_min + bin_type_last.item_bin_minimum_spacing)) {
                 current_number_of_bins = solution.number_of_bins() - 1;
                 if (current_number_of_bins == 0)
                     break;
-                BinTypeId bin_type_id = instance.bin_type_id(current_number_of_bins - 1);
-                const BinType& bin_type = instance.bin_type(bin_type_id);
-                x = bin_type.aabb_scaled.x_max;
+                BinTypeId bin_type_id_new = instance.bin_type_id(current_number_of_bins - 1);
+                const BinType& bin_type_new = instance.bin_type(bin_type_id_new);
+                x = bin_type_new.aabb_scaled.x_max;
             }
         } else if (instance.objective() == Objective::OpenDimensionX) {
             const BinType& bin_type = instance.bin_type(instance.bin_type_id(0));

--- a/src/irregular/sequential_feasibility.hpp
+++ b/src/irregular/sequential_feasibility.hpp
@@ -1,21 +1,27 @@
 /**
  * Sequential feasibility algorithm
  *
- * The algorithm iteratively solves bin packing sub-problems with a single bin
- * of decreasing size until no feasible packing is found. It is designed for
- * the OpenDimensionXY objective.
+ * Iteratively solves Feasibility sub-problems with a shrinking bin or bin-count
+ * until no feasible packing can be found. Supports objectives BinPacking,
+ * BinPackingWithLeftovers, OpenDimensionX, OpenDimensionY, and OpenDimensionXY.
+ *
+ * The caller supplies the inner feasibility solver as a std::function. Mutable
+ * state (e.g. warm-start penalties) can be captured in the closure to pass
+ * information between consecutive sub-problem calls.
  */
 
 #pragma once
 
 #include "packingsolver/irregular/solution.hpp"
 
-#include "columngenerationsolver/commons.hpp"
+#include <functional>
 
 namespace packingsolver
 {
 namespace irregular
 {
+
+using SequentialFeasibilitySolver = std::function<SolutionPool<Instance, Solution>(const Instance&)>;
 
 struct SequentialFeasibilityOutput: packingsolver::Output<Instance, Solution>
 {
@@ -26,31 +32,11 @@ struct SequentialFeasibilityOutput: packingsolver::Output<Instance, Solution>
 
 struct SequentialFeasibilityParameters: packingsolver::Parameters<Instance, Solution>
 {
-    /** Linear programming solver. */
-    columngenerationsolver::SolverName linear_programming_solver_name
-        = columngenerationsolver::SolverName::CLP;
-
-    /** Optimization mode. */
-    OptimizationMode optimization_mode = OptimizationMode::Anytime;
-
-    /** Maximum approximation ratio (not-anytime mode). */
-    double not_anytime_maximum_approximation_ratio = 0.05;
-
-    /** Size of the queue in the tree search algorithm (not-anytime mode). */
-    NodeId not_anytime_tree_search_queue_size = 512;
-
-    /** Use tree search in sub-problems. */
-    bool use_tree_search = false;
-
-    /** Use local search in sub-problems. */
-    bool use_local_search = false;
-
-    /** Use MILP raster in sub-problems. */
-    bool use_milp_raster = false;
 };
 
 SequentialFeasibilityOutput sequential_feasibility(
         const Instance& instance,
+        const SequentialFeasibilitySolver& solver,
         const SequentialFeasibilityParameters& parameters = {});
 
 }

--- a/src/irregular/tree_search.cpp
+++ b/src/irregular/tree_search.cpp
@@ -1,4 +1,5 @@
 #include "irregular/tree_search.hpp"
+#include "irregular/sequential_feasibility.hpp"
 
 #include "packingsolver/irregular/algorithm_formatter.hpp"
 #include "algorithms/thread_pool.hpp"
@@ -2650,6 +2651,50 @@ const packingsolver::irregular::TreeSearchOutput packingsolver::irregular::tree_
         const Instance& instance,
         const TreeSearchParameters& parameters)
 {
+    if (instance.objective() == Objective::OpenDimensionXY) {
+        TreeSearchOutput output(instance);
+        AlgorithmFormatter algorithm_formatter(instance, parameters, output);
+        algorithm_formatter.start();
+        algorithm_formatter.print_header();
+
+        SequentialFeasibilitySolver solver = [&parameters, &algorithm_formatter](
+                const Instance& sub_instance)
+        {
+            TreeSearchParameters inner_parameters;
+            inner_parameters.verbosity_level = 0;
+            inner_parameters.timer = parameters.timer;
+            inner_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+            inner_parameters.guides = parameters.guides;
+            inner_parameters.optimization_mode = parameters.optimization_mode;
+            inner_parameters.not_anytime_tree_search_queue_size
+                = parameters.not_anytime_tree_search_queue_size;
+            inner_parameters.initial_maximum_approximation_ratio
+                = parameters.initial_maximum_approximation_ratio;
+            inner_parameters.not_anytime_maximum_approximation_ratio
+                = parameters.not_anytime_maximum_approximation_ratio;
+            inner_parameters.maximum_approximation_ratio_factor
+                = parameters.maximum_approximation_ratio_factor;
+            return tree_search(sub_instance, inner_parameters).solution_pool;
+        };
+
+        SequentialFeasibilityParameters sf_parameters;
+        sf_parameters.verbosity_level = 0;
+        sf_parameters.timer = parameters.timer;
+        sf_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+        sf_parameters.new_solution_callback = [&algorithm_formatter](
+                const packingsolver::Output<Instance, Solution>& sf_output)
+        {
+            algorithm_formatter.update_solution(
+                    sf_output.solution_pool.best(),
+                    sf_output.solution_pool.best_label());
+        };
+
+        sequential_feasibility(instance, solver, sf_parameters);
+
+        algorithm_formatter.end();
+        return output;
+    }
+
     TreeSearchOutput output(instance);
     AlgorithmFormatter algorithm_formatter(instance, parameters, output);
     algorithm_formatter.start();


### PR DESCRIPTION
Refactor sequential_feasibility to take a SequentialFeasibilitySolver std::function instead of use_tree_search/use_local_search/use_milp_raster flags, moving the inner-solver choice to the caller.

tree_search now handles OpenDimensionXY directly by running sequential_feasibility with itself as the inner solver. local_search handles BinPacking, BinPackingWithLeftovers, OpenDimensionX/Y/XY the same way. The solution label now includes the inner solver's label (e.g. "SF it 0 g 0 d 0 q 1" for tree_search).

optimize_sequential_feasibility and the four related OptimizeParameters flags (use_sequential_feasibility, sequential_feasibility_use_*) are removed; optimize() for OpenDimensionXY now auto-selects tree_search.