### PR TITLE
rectangle, box, rectangleguillotine: add Feasibility support to tree_search_maximal_spaces

### DIFF
--- a/src/box/optimize.cpp
+++ b/src/box/optimize.cpp
@@ -305,12 +305,14 @@ packingsolver::box::Output packingsolver::box::optimize(
         use_sequential_value_correction = false;
         use_dichotomic_search = false;
         use_column_generation = false;
-        if (instance.objective() != Objective::Knapsack)
+        if (instance.objective() != Objective::Knapsack
+                && instance.objective() != Objective::Feasibility)
             use_tree_search_maximal_spaces = false;
         // Automatic selection.
         if (!use_tree_search
                 && !use_tree_search_maximal_spaces) {
-            if (instance.objective() == Objective::Knapsack
+            if ((instance.objective() == Objective::Knapsack
+                        || instance.objective() == Objective::Feasibility)
                     && mean_number_of_items_in_bins > parameters.many_items_in_bins_threshold_2) {
                 use_tree_search_maximal_spaces = true;
             } else {

--- a/src/box/tree_search_maximal_spaces.cpp
+++ b/src/box/tree_search_maximal_spaces.cpp
@@ -646,7 +646,24 @@ bool BranchingSchemeMaximalSpaces::bound(
         const std::shared_ptr<Node>& node_1,
         const std::shared_ptr<Node>& node_2) const
 {
-    return false;
+    switch (instance().objective()) {
+    case Objective::Knapsack: {
+        if (leaf(node_2))
+            return true;
+        return false;
+    } case Objective::Feasibility: {
+        if (leaf(node_2))
+            return true;
+        return false;
+    } default: {
+        std::stringstream ss;
+        ss << FUNC_SIGNATURE << ": "
+            << "Branching scheme 'box::BranchingSchemeMaximalSpaces' "
+            << "does not support objective '" << instance().objective() << "'.";
+        throw std::logic_error(ss.str());
+        return false;
+    }
+    }
 }
 
 Solution BranchingSchemeMaximalSpaces::to_solution(const std::shared_ptr<Node>& node_orig) const

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -330,13 +330,15 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
         use_sequential_value_correction = false;
         use_dichotomic_search = false;
         use_column_generation = false;
-        if (instance.objective() != Objective::Knapsack)
+        if (instance.objective() != Objective::Knapsack
+                && instance.objective() != Objective::Feasibility)
             use_tree_search_maximal_spaces = false;
         // Automatic selection.
         if (!use_tree_search
                 && !use_tree_search_maximal_spaces
                 && !use_benders_decomposition) {
-            if (instance.objective() == Objective::Knapsack
+            if ((instance.objective() == Objective::Knapsack
+                        || instance.objective() == Objective::Feasibility)
                     && mean_number_of_items_in_bins > parameters.many_items_in_bins_threshold_2
                     && instance.parameters().unloading_constraint == UnloadingConstraint::None) {
                 use_tree_search_maximal_spaces = true;

--- a/src/rectangle/tree_search_maximal_spaces.cpp
+++ b/src/rectangle/tree_search_maximal_spaces.cpp
@@ -494,7 +494,24 @@ bool BranchingSchemeMaximalSpaces::bound(
         const std::shared_ptr<Node>& node_1,
         const std::shared_ptr<Node>& node_2) const
 {
-    return false;
+    switch (instance().objective()) {
+    case Objective::Knapsack: {
+        if (leaf(node_2))
+            return true;
+        return false;
+    } case Objective::Feasibility: {
+        if (leaf(node_2))
+            return true;
+        return false;
+    } default: {
+        std::stringstream ss;
+        ss << FUNC_SIGNATURE << ": "
+            << "Branching scheme 'rectangle::BranchingSchemeMaximalSpaces' "
+            << "does not support objective '" << instance().objective() << "'.";
+        throw std::logic_error(ss.str());
+        return false;
+    }
+    }
 }
 
 Solution BranchingSchemeMaximalSpaces::to_solution(const std::shared_ptr<Node>& node_orig) const

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -401,7 +401,8 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
         use_sequential_value_correction = false;
         use_dichotomic_search = false;
         use_column_generation = false;
-        if (instance.objective() != Objective::Knapsack)
+        if (instance.objective() != Objective::Knapsack
+                && instance.objective() != Objective::Feasibility)
             use_tree_search_maximal_spaces = false;
         // Automatic selection.
         if (!use_tree_search
@@ -409,7 +410,8 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
                 && !use_column_generation_strips
                 && !use_dynamic_programming_infinite_copies_array
                 && !use_labeling) {
-            if (instance.objective() == Objective::Knapsack
+            if ((instance.objective() == Objective::Knapsack
+                        || instance.objective() == Objective::Feasibility)
                     //&& mean_number_of_items_in_bins > parameters.many_items_in_bins_threshold_2
                     && instance.number_of_stages_unlimited()
                     && instance.number_of_defects() == 0

--- a/src/rectangleguillotine/tree_search_maximal_spaces.cpp
+++ b/src/rectangleguillotine/tree_search_maximal_spaces.cpp
@@ -337,14 +337,44 @@ bool BranchingSchemeMaximalSpaces::better(
         const std::shared_ptr<Node>& node_1,
         const std::shared_ptr<Node>& node_2) const
 {
-    return node_1->profit > node_2->profit;
+    switch (instance_.objective()) {
+    case Objective::Knapsack: {
+        return node_1->profit > node_2->profit;
+    } case Objective::Feasibility: {
+        return node_1->profit > node_2->profit;
+    } default: {
+        std::stringstream ss;
+        ss << FUNC_SIGNATURE << ": "
+            << "Branching scheme 'rectangleguillotine::BranchingSchemeMaximalSpaces' "
+            << "does not support objective '" << instance_.objective() << "'.";
+        throw std::logic_error(ss.str());
+        return false;
+    }
+    }
 }
 
 bool BranchingSchemeMaximalSpaces::bound(
         const std::shared_ptr<Node>& node_1,
         const std::shared_ptr<Node>& node_2) const
 {
-    return false;
+    switch (instance_.objective()) {
+    case Objective::Knapsack: {
+        if (leaf(node_2))
+            return true;
+        return false;
+    } case Objective::Feasibility: {
+        if (leaf(node_2))
+            return true;
+        return false;
+    } default: {
+        std::stringstream ss;
+        ss << FUNC_SIGNATURE << ": "
+            << "Branching scheme 'rectangleguillotine::BranchingSchemeMaximalSpaces' "
+            << "does not support objective '" << instance_.objective() << "'.";
+        throw std::logic_error(ss.str());
+        return false;
+    }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- bound(): add Knapsack and Feasibility cases that prune when node_2 is a leaf (all items packed, maximum profit already achieved); add throwing default for unsupported objectives
- better(): add throwing default for unsupported objectives (rectangleguillotine only, rectangle and box already had it)
- optimize.cpp: allow Feasibility in the disable guard and auto-selection for use_tree_search_maximal_spaces