### PR TITLE
rectangleguillotine: add sequential_feasibility and fix solution append root node

### DIFF
--- a/src/irregular/sequential_feasibility.cpp
+++ b/src/irregular/sequential_feasibility.cpp
@@ -39,16 +39,42 @@ SequentialFeasibilityOutput packingsolver::irregular::sequential_feasibility(
     LengthDbl x = 0;
     LengthDbl y = 0;
     if (instance.objective() == Objective::BinPacking) {
-        current_number_of_bins = std::min(
-                (BinPos)instance.number_of_items(),
-                instance.number_of_bins());
+        AreaDbl total_bin_aabb_area = 0;
+        for (BinTypeId bin_type_id = 0;
+                bin_type_id < instance.number_of_bin_types();
+                ++bin_type_id) {
+            const BinType& bin_type = instance.bin_type(bin_type_id);
+            LengthDbl bx = bin_type.aabb_scaled.x_max - bin_type.aabb_scaled.x_min;
+            LengthDbl by = bin_type.aabb_scaled.y_max - bin_type.aabb_scaled.y_min;
+            AreaDbl bin_aabb_area = bx * by;
+            AreaDbl remaining = 2.0 * total_item_aabb_area - total_bin_aabb_area;
+            BinPos copies_needed = (BinPos)std::ceil(remaining / bin_aabb_area);
+            BinPos copies_used = std::min(copies_needed, bin_type.copies);
+            total_bin_aabb_area += copies_used * bin_aabb_area;
+            current_number_of_bins += copies_used;
+            if (total_bin_aabb_area >= 2.0 * total_item_aabb_area)
+                break;
+        }
     } else if (instance.objective() == Objective::BinPackingWithLeftovers) {
-        current_number_of_bins = std::min(
-                (BinPos)instance.number_of_items(),
-                instance.number_of_bins());
-        BinTypeId bin_type_id = instance.bin_type_id(current_number_of_bins - 1);
-        const BinType& bin_type = instance.bin_type(bin_type_id);
-        x = bin_type.aabb_scaled.x_max - bin_type.aabb_scaled.x_min;
+        AreaDbl total_bin_aabb_area = 0;
+        for (BinTypeId bin_type_id = 0;
+                bin_type_id < instance.number_of_bin_types();
+                ++bin_type_id) {
+            const BinType& bin_type = instance.bin_type(bin_type_id);
+            LengthDbl bx = bin_type.aabb_scaled.x_max - bin_type.aabb_scaled.x_min;
+            LengthDbl by = bin_type.aabb_scaled.y_max - bin_type.aabb_scaled.y_min;
+            AreaDbl bin_aabb_area = bx * by;
+            AreaDbl remaining = 2.0 * total_item_aabb_area - total_bin_aabb_area;
+            BinPos copies_needed = (BinPos)std::ceil(remaining / bin_aabb_area);
+            BinPos copies_used = std::min(copies_needed, bin_type.copies);
+            total_bin_aabb_area += copies_used * bin_aabb_area;
+            current_number_of_bins += copies_used;
+            if (total_bin_aabb_area >= 2.0 * total_item_aabb_area)
+                break;
+        }
+        BinTypeId last_bin_type_id = instance.bin_type_id(current_number_of_bins - 1);
+        const BinType& last_bin_type = instance.bin_type(last_bin_type_id);
+        x = last_bin_type.aabb_scaled.x_max - last_bin_type.aabb_scaled.x_min;
     } else if (instance.objective() == Objective::OpenDimensionX) {
         const BinType& bin_type = instance.bin_type(instance.bin_type_id(0));
         y = bin_type.aabb_scaled.y_max - bin_type.aabb_scaled.y_min;

--- a/src/rectangleguillotine/CMakeLists.txt
+++ b/src/rectangleguillotine/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(PackingSolver_rectangleguillotine PRIVATE
     algorithm_formatter.cpp
     optimize.cpp
     post_process.cpp
+    sequential_feasibility.cpp
     tree_search.cpp
     tree_search_maximal_spaces.cpp
     column_generation_strips.cpp

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -401,19 +401,14 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
         use_sequential_value_correction = false;
         use_dichotomic_search = false;
         use_column_generation = false;
-        if (instance.objective() != Objective::Knapsack
-                && instance.objective() != Objective::Feasibility)
-            use_tree_search_maximal_spaces = false;
         // Automatic selection.
         if (!use_tree_search
                 && !use_tree_search_maximal_spaces
                 && !use_column_generation_strips
                 && !use_dynamic_programming_infinite_copies_array
                 && !use_labeling) {
-            if ((instance.objective() == Objective::Knapsack
-                        || instance.objective() == Objective::Feasibility)
+            if (instance.number_of_stages_unlimited()
                     //&& mean_number_of_items_in_bins > parameters.many_items_in_bins_threshold_2
-                    && instance.number_of_stages_unlimited()
                     && instance.number_of_defects() == 0
                     && instance.number_of_stacks() == instance.number_of_item_types()
                     && instance.parameters().minimum_waste_length == 0

--- a/src/rectangleguillotine/sequential_feasibility.cpp
+++ b/src/rectangleguillotine/sequential_feasibility.cpp
@@ -1,0 +1,201 @@
+#include "rectangleguillotine/sequential_feasibility.hpp"
+
+#include "packingsolver/rectangleguillotine/algorithm_formatter.hpp"
+#include "packingsolver/rectangleguillotine/instance_builder.hpp"
+
+#include <sstream>
+
+using namespace packingsolver;
+using namespace packingsolver::rectangleguillotine;
+
+SequentialFeasibilityOutput packingsolver::rectangleguillotine::sequential_feasibility(
+        const Instance& instance,
+        const SequentialFeasibilitySolver& solver,
+        const SequentialFeasibilityParameters& parameters)
+{
+    SequentialFeasibilityOutput output(instance);
+    AlgorithmFormatter algorithm_formatter(instance, parameters, output);
+    algorithm_formatter.start();
+    algorithm_formatter.print_header();
+
+    BinTypeId bin_type_id = instance.bin_type_id(0);
+    const BinType& bin_type = instance.bin_type(bin_type_id);
+
+    Area total_item_area = instance.item_area();
+
+    BinPos current_number_of_bins = 0;
+    Length current_x = 0;
+    Length current_y = 0;
+    if (instance.objective() == Objective::BinPacking) {
+        Area total_bin_area = 0;
+        for (BinTypeId bin_type_id_iter = 0;
+                bin_type_id_iter < instance.number_of_bin_types();
+                ++bin_type_id_iter) {
+            const BinType& bin_type_iter = instance.bin_type(bin_type_id_iter);
+            Area bin_area = bin_type_iter.rect.w * bin_type_iter.rect.h;
+            Area remaining = 2 * total_item_area - total_bin_area;
+            BinPos copies_needed = (BinPos)((remaining + bin_area - 1) / bin_area);
+            BinPos copies_used = std::min(copies_needed, bin_type_iter.copies);
+            total_bin_area += copies_used * bin_area;
+            current_number_of_bins += copies_used;
+            if (total_bin_area >= 2 * total_item_area)
+                break;
+        }
+    } else if (instance.objective() == Objective::BinPackingWithLeftovers) {
+        Area total_bin_area = 0;
+        for (BinTypeId bin_type_id_iter = 0;
+                bin_type_id_iter < instance.number_of_bin_types();
+                ++bin_type_id_iter) {
+            const BinType& bin_type_iter = instance.bin_type(bin_type_id_iter);
+            Area bin_area = bin_type_iter.rect.w * bin_type_iter.rect.h;
+            Area remaining = 2 * total_item_area - total_bin_area;
+            BinPos copies_needed = (BinPos)((remaining + bin_area - 1) / bin_area);
+            BinPos copies_used = std::min(copies_needed, bin_type_iter.copies);
+            total_bin_area += copies_used * bin_area;
+            current_number_of_bins += copies_used;
+            if (total_bin_area >= 2 * total_item_area)
+                break;
+        }
+        BinTypeId last_bin_type_id = instance.bin_type_id(current_number_of_bins - 1);
+        const BinType& last_bin_type = instance.bin_type(last_bin_type_id);
+        current_x = last_bin_type.rect.w;
+    } else if (instance.objective() == Objective::OpenDimensionX) {
+        current_x = std::min(
+                (2 * total_item_area + bin_type.rect.h - 1) / bin_type.rect.h,
+                bin_type.rect.w);
+    } else {  // OpenDimensionY
+        current_y = std::min(
+                (2 * total_item_area + bin_type.rect.w - 1) / bin_type.rect.w,
+                bin_type.rect.h);
+    }
+
+    for (Counter it = 0;; ++it) {
+        if (algorithm_formatter.end_boolean())
+            break;
+        if (parameters.timer.needs_to_end())
+            break;
+
+        // Build the Feasibility sub-instance.
+        InstanceBuilder sub_instance_builder;
+        sub_instance_builder.set_objective(Objective::Feasibility);
+        sub_instance_builder.set_parameters(instance.parameters());
+        std::vector<BinTypeId> sub_to_orig_bin_type_ids;
+        if (instance.objective() == Objective::BinPacking) {
+            BinPos remaining_bins = current_number_of_bins;
+            for (BinTypeId bin_type_id_iter = 0;
+                    bin_type_id_iter < instance.number_of_bin_types() && remaining_bins > 0;
+                    ++bin_type_id_iter) {
+                const BinType& bin_type_iter = instance.bin_type(bin_type_id_iter);
+                BinPos copies = std::min(bin_type_iter.copies, remaining_bins);
+                sub_instance_builder.add_bin_type(
+                        bin_type_iter.rect.w,
+                        bin_type_iter.rect.h,
+                        bin_type_iter.cost,
+                        copies);
+                sub_to_orig_bin_type_ids.push_back(bin_type_id_iter);
+                remaining_bins -= copies;
+            }
+        } else if (instance.objective() == Objective::BinPackingWithLeftovers) {
+            BinPos remaining_bins = current_number_of_bins;
+            for (BinTypeId bin_type_id_iter = 0;
+                    bin_type_id_iter < instance.number_of_bin_types() && remaining_bins > 0;
+                    ++bin_type_id_iter) {
+                const BinType& bin_type_iter = instance.bin_type(bin_type_id_iter);
+                BinPos copies = std::min(bin_type_iter.copies, remaining_bins);
+                sub_instance_builder.add_bin_type(
+                        current_x,
+                        bin_type_iter.rect.h,
+                        bin_type_iter.cost,
+                        copies);
+                sub_to_orig_bin_type_ids.push_back(bin_type_id_iter);
+                remaining_bins -= copies;
+            }
+        } else if (instance.objective() == Objective::OpenDimensionX) {
+            sub_instance_builder.add_bin_type(
+                    current_x,
+                    bin_type.rect.h,
+                    bin_type.cost);
+        } else {  // OpenDimensionY
+            sub_instance_builder.add_bin_type(
+                    bin_type.rect.w,
+                    current_y,
+                    bin_type.cost);
+        }
+        for (ItemTypeId item_type_id = 0;
+                item_type_id < instance.number_of_item_types();
+                ++item_type_id) {
+            const ItemType& item_type = instance.item_type(item_type_id);
+            sub_instance_builder.add_item_type(
+                    instance,
+                    item_type_id,
+                    item_type.profit,
+                    item_type.copies);
+        }
+        Instance sub_instance = sub_instance_builder.build();
+
+        // Solve the sub-instance.
+        SolutionPool<Instance, Solution> sub_solution_pool = solver(sub_instance);
+
+        // If no feasible solution found, stop.
+        if (!sub_solution_pool.best().full())
+            break;
+
+        // Transfer the sub-solution to the main instance.
+        Solution solution(instance);
+        if (instance.objective() == Objective::BinPacking
+                || instance.objective() == Objective::BinPackingWithLeftovers) {
+            solution.append(
+                    sub_solution_pool.best(),
+                    sub_to_orig_bin_type_ids,
+                    {});
+        } else {
+            solution.append(
+                    sub_solution_pool.best(),
+                    0,  // bin_pos
+                    1,  // copies
+                    {0});  // bin_type_ids
+        }
+        std::stringstream ss;
+        ss << "SF it " << it << " " << sub_solution_pool.best_label();
+        algorithm_formatter.update_solution(solution, ss.str());
+
+        // Update for the next iteration.
+        if (instance.objective() == Objective::BinPacking) {
+            current_number_of_bins = sub_solution_pool.best().number_of_bins() - 1;
+            if (current_number_of_bins == 0)
+                break;
+        } else if (instance.objective() == Objective::BinPackingWithLeftovers) {
+            current_x = std::min(
+                    (Length)(0.99 * sub_solution_pool.best().width()),
+                    sub_solution_pool.best().width() - 1);
+            if (sub_solution_pool.best().number_of_bins() < current_number_of_bins) {
+                current_number_of_bins = sub_solution_pool.best().number_of_bins();
+                BinTypeId bin_type_id_new = instance.bin_type_id(current_number_of_bins - 1);
+                const BinType& bin_type_new = instance.bin_type(bin_type_id_new);
+                current_x = bin_type_new.rect.w;
+            } else if (current_x <= 0) {
+                current_number_of_bins--;
+                if (current_number_of_bins == 0)
+                    break;
+                BinTypeId bin_type_id_new = instance.bin_type_id(current_number_of_bins - 1);
+                const BinType& bin_type_new = instance.bin_type(bin_type_id_new);
+                current_x = bin_type_new.rect.w;
+            }
+        } else if (instance.objective() == Objective::OpenDimensionX) {
+            current_x = std::min(
+                    (Length)(0.99 * sub_solution_pool.best().width()),
+                    sub_solution_pool.best().width() - 1);
+            if (current_x <= 0)
+                break;
+        } else {  // OpenDimensionY
+            current_y = std::min(
+                    (Length)(0.99 * sub_solution_pool.best().height()),
+                    sub_solution_pool.best().height() - 1);
+            if (current_y <= 0)
+                break;
+        }
+    }
+
+    algorithm_formatter.end();
+    return output;
+}

--- a/src/rectangleguillotine/sequential_feasibility.hpp
+++ b/src/rectangleguillotine/sequential_feasibility.hpp
@@ -1,0 +1,41 @@
+/**
+ * Sequential feasibility algorithm for rectangleguillotine.
+ *
+ * Iteratively solves Feasibility sub-problems with a shrinking bin until no
+ * feasible packing can be found. Supports objectives OpenDimensionX,
+ * OpenDimensionY, and BinPackingWithLeftovers (single bin).
+ *
+ * The caller supplies the inner feasibility solver as a std::function.
+ */
+
+#pragma once
+
+#include "packingsolver/rectangleguillotine/solution.hpp"
+
+#include <functional>
+
+namespace packingsolver
+{
+namespace rectangleguillotine
+{
+
+using SequentialFeasibilitySolver = std::function<SolutionPool<Instance, Solution>(const Instance&)>;
+
+struct SequentialFeasibilityOutput: packingsolver::Output<Instance, Solution>
+{
+    /** Constructor. */
+    SequentialFeasibilityOutput(const Instance& instance):
+        packingsolver::Output<Instance, Solution>(instance) { }
+};
+
+struct SequentialFeasibilityParameters: packingsolver::Parameters<Instance, Solution>
+{
+};
+
+SequentialFeasibilityOutput sequential_feasibility(
+        const Instance& instance,
+        const SequentialFeasibilitySolver& solver,
+        const SequentialFeasibilityParameters& parameters = {});
+
+}
+}

--- a/src/rectangleguillotine/solution.cpp
+++ b/src/rectangleguillotine/solution.cpp
@@ -370,6 +370,9 @@ void Solution::append(
         if (node.t == -4) {
         } else if (node.f == -1) {
             node.item_type_id = bin_type_id;
+            const BinType& new_bin_type = instance().bin_type(bin_type_id);
+            node.r = new_bin_type.rect.w;
+            node.t = new_bin_type.rect.h;
         } else if (node.item_type_id >= 0) {
             node.item_type_id = (item_type_ids.empty())?
                 node.item_type_id:

--- a/src/rectangleguillotine/tree_search_maximal_spaces.cpp
+++ b/src/rectangleguillotine/tree_search_maximal_spaces.cpp
@@ -1,5 +1,6 @@
 #include "rectangleguillotine/tree_search_maximal_spaces.hpp"
 
+#include "rectangleguillotine/sequential_feasibility.hpp"
 #include "rectangleguillotine/solution_builder.hpp"
 #include "packingsolver/rectangleguillotine/algorithm_formatter.hpp"
 #include "algorithms/thread_pool.hpp"
@@ -804,6 +805,60 @@ const packingsolver::rectangleguillotine::TreeSearchMaximalSpacesOutput packings
         const Instance& instance,
         const TreeSearchMaximalSpacesParameters& parameters)
 {
+    if (instance.number_of_bins() > 1) {
+        std::stringstream ss;
+        ss << FUNC_SIGNATURE << ": "
+            << "algorithm 'rectangleguillotine::tree_search_maximal_spaces' "
+            << "does not support instances with more than one bin.";
+        throw std::logic_error(ss.str());
+    }
+    if (instance.objective() == Objective::VariableSizedBinPacking) {
+        std::stringstream ss;
+        ss << FUNC_SIGNATURE << ": "
+            << "algorithm 'rectangleguillotine::tree_search_maximal_spaces' "
+            << "does not support objective '" << instance.objective() << "'.";
+        throw std::logic_error(ss.str());
+    }
+
+    if (instance.objective() == Objective::OpenDimensionX
+            || instance.objective() == Objective::OpenDimensionY
+            || instance.objective() == Objective::BinPackingWithLeftovers
+            || instance.objective() == Objective::BinPacking) {
+        TreeSearchMaximalSpacesOutput output(instance);
+        AlgorithmFormatter algorithm_formatter(instance, parameters, output);
+        algorithm_formatter.start();
+        algorithm_formatter.print_header();
+
+        SequentialFeasibilitySolver solver = [&parameters, &algorithm_formatter](
+                const Instance& sub_instance)
+        {
+            TreeSearchMaximalSpacesParameters inner_parameters;
+            inner_parameters.verbosity_level = 0;
+            inner_parameters.timer = parameters.timer;
+            inner_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+            inner_parameters.optimization_mode = parameters.optimization_mode;
+            inner_parameters.not_anytime_tree_search_queue_size
+                = parameters.not_anytime_tree_search_queue_size;
+            return tree_search_maximal_spaces(sub_instance, inner_parameters).solution_pool;
+        };
+
+        SequentialFeasibilityParameters sf_parameters;
+        sf_parameters.verbosity_level = 0;
+        sf_parameters.timer = parameters.timer;
+        sf_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+        sf_parameters.new_solution_callback = [&algorithm_formatter](
+                const packingsolver::Output<Instance, Solution>& sf_output)
+        {
+            algorithm_formatter.update_solution(
+                    sf_output.solution_pool.best(),
+                    sf_output.solution_pool.best_label());
+        };
+
+        sequential_feasibility(instance, solver, sf_parameters);
+        algorithm_formatter.end();
+        return output;
+    }
+
     TreeSearchMaximalSpacesOutput output(instance);
     AlgorithmFormatter algorithm_formatter(instance, parameters, output);
     algorithm_formatter.start();


### PR DESCRIPTION
- Implement sequential_feasibility for rectangleguillotine supporting BinPacking, BinPackingWithLeftovers, OpenDimensionX, and OpenDimensionY via tree_search_maximal_spaces as the inner solver
- Fix Solution::append to update root node coordinates when remapping bin types, so the root node matches the target bin type dimensions
- Initialize current_x/y in sequential_feasibility from item area (2 * total_item_area / fixed_dimension) instead of the full bin size, and current_number_of_bins from an area-based bin accumulation loop
- Apply the same area-based initialization to irregular sequential_feasibility for BinPacking and BinPackingWithLeftovers