### PR TITLE
rectangleguillotine: add maximum_distance_2_cuts and fix its 2-staged mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Features:
 * Minimum distance between consecutive 1-cuts
 * Maximum distance between consecutive 1-cuts
 * Minimum distance between consecutive 2-cuts
+* Maximum distance between consecutive 2-cuts
 * Minimum distance between cuts
 * Maximum number of consecutive 2-cuts
 

--- a/include/packingsolver/rectangleguillotine/instance.hpp
+++ b/include/packingsolver/rectangleguillotine/instance.hpp
@@ -105,14 +105,27 @@ struct Parameters
     /** Maximum distance between two consecutive 1-cuts. */
     Length maximum_distance_1_cuts = -1;
 
-    /** Minimum distance between two consecutive 2-cuts. */
+    /**
+     * Minimum distance between two consecutive 2-cuts.
+     *
+     * Not allowed if number_of_stages == 2.
+     */
     Length minimum_distance_2_cuts = 0;
+
+    /**
+     * Maximum distance between two consecutive 2-cuts.
+     *
+     * Not allowed if number_of_stages == 2.
+     */
+    Length maximum_distance_2_cuts = -1;
 
     /** Minimum distance between two cuts. */
     Length minimum_waste_length = 0;
 
     /**
      * Maximum number of 2-cuts in a first-level sub-plate.
+     *
+     * Not allowed if number_of_stages == 2.
      */
     Counter maximum_number_2_cuts = -1;
 

--- a/include/packingsolver/rectangleguillotine/instance_builder.hpp
+++ b/include/packingsolver/rectangleguillotine/instance_builder.hpp
@@ -64,6 +64,8 @@ public:
 
     void set_minimum_distance_2_cuts(Length minimum_distance_2_cuts) { instance_.parameters_.minimum_distance_2_cuts = minimum_distance_2_cuts; }
 
+    void set_maximum_distance_2_cuts(Length maximum_distance_2_cuts) { instance_.parameters_.maximum_distance_2_cuts = maximum_distance_2_cuts; }
+
     void set_minimum_waste_length(Length minimum_waste_length) { instance_.parameters_.minimum_waste_length = minimum_waste_length; }
 
     void set_maximum_number_2_cuts(Counter maximum_number_2_cuts) { instance_.parameters_.maximum_number_2_cuts = maximum_number_2_cuts; }

--- a/include/packingsolver/rectangleguillotine/solution.hpp
+++ b/include/packingsolver/rectangleguillotine/solution.hpp
@@ -124,6 +124,8 @@ public:
 
     bool minimum_distance_2_cuts_feasible() const { return minimum_distance_2_cuts_feasible_; }
 
+    bool maximum_distance_2_cuts_feasible() const { return maximum_distance_2_cuts_feasible_; }
+
     bool maximum_number_2_cuts_feasible() const { return maximum_number_2_cuts_feasible_; }
 
     bool stacks_feasible() const { return stacks_feasible_; }
@@ -271,6 +273,9 @@ private:
 
     /** Feasibility for the minimum distance between two consecutive 2-cuts. */
     bool minimum_distance_2_cuts_feasible_ = true;
+
+    /** Feasibility for the maximum distance between two consecutive 2-cuts. */
+    bool maximum_distance_2_cuts_feasible_ = true;
 
     /** Feasibility for the maximum number of 2-cuts in a first-level sub-plate. */
     bool maximum_number_2_cuts_feasible_ = true;

--- a/src/rectangleguillotine/instance.cpp
+++ b/src/rectangleguillotine/instance.cpp
@@ -309,6 +309,7 @@ void Instance::write(
         << "minimum_distance_1_cuts," << parameters().minimum_distance_1_cuts << std::endl
         << "maximum_distance_1_cuts," << parameters().maximum_distance_1_cuts << std::endl
         << "minimum_distance_2_cuts," << parameters().minimum_distance_2_cuts << std::endl
+        << "maximum_distance_2_cuts," << parameters().maximum_distance_2_cuts << std::endl
         << "minimum_waste_length," << parameters().minimum_waste_length << std::endl
         << "maximum_number_2_cuts," << parameters().maximum_number_2_cuts << std::endl
         << "cut_thickness," << parameters().cut_thickness << std::endl;
@@ -333,6 +334,7 @@ std::ostream& Instance::format(
             << "Minimum distance between 1-cuts:       " << parameters().minimum_distance_1_cuts << std::endl
             << "Maximum distance between 1-cuts:       " << parameters().maximum_distance_1_cuts << std::endl
             << "Minimum distance between 2-cuts:       " << parameters().minimum_distance_2_cuts << std::endl
+            << "Maximum distance between 2-cuts:       " << parameters().maximum_distance_2_cuts << std::endl
             << "Minimum waste length:                  " << parameters().minimum_waste_length << std::endl
             << "Maximum number of consecutive 2-cuts:  " << parameters().maximum_number_2_cuts << std::endl
             << "Cut through defects:                   " << parameters().cut_through_defects << std::endl

--- a/src/rectangleguillotine/instance_builder.cpp
+++ b/src/rectangleguillotine/instance_builder.cpp
@@ -570,6 +570,10 @@ void InstanceBuilder::read_parameters(
                 || name == "min2Cut"
                 || name == "minimum_distance_2_cuts") {
             set_minimum_distance_2_cuts(std::stol(value));
+        } else if (name == "max2cut"
+                || name == "max2Cut"
+                || name == "maximum_distance_2_cuts") {
+            set_maximum_distance_2_cuts(std::stol(value));
         } else if (name == "min_waste"
                 || name == "minwaste"
                 || name == "minWaste"
@@ -910,6 +914,26 @@ void InstanceBuilder::build_stacks()
 
 Instance InstanceBuilder::build()
 {
+    // minimum_distance_2_cuts, maximum_distance_2_cuts and
+    // maximum_number_2_cuts are not allowed for 2-staged instances.
+    if (instance_.parameters().number_of_stages == 2) {
+        if (instance_.parameters().minimum_distance_2_cuts != 0) {
+            throw std::invalid_argument(
+                    FUNC_SIGNATURE + ": "
+                    "minimum_distance_2_cuts is not allowed if number_of_stages == 2.");
+        }
+        if (instance_.parameters().maximum_distance_2_cuts != -1) {
+            throw std::invalid_argument(
+                    FUNC_SIGNATURE + ": "
+                    "maximum_distance_2_cuts is not allowed if number_of_stages == 2.");
+        }
+        if (instance_.parameters().maximum_number_2_cuts != -1) {
+            throw std::invalid_argument(
+                    FUNC_SIGNATURE + ": "
+                    "maximum_number_2_cuts is not allowed if number_of_stages == 2.");
+        }
+    }
+
     // Compute item_type_ids_ and stack_offsets_.
     build_stacks();
 

--- a/src/rectangleguillotine/solution.cpp
+++ b/src/rectangleguillotine/solution.cpp
@@ -153,6 +153,23 @@ void Solution::update_indicators(
             }
         }
 
+        // Check maximum distance between 2-cuts.
+        if (instance().parameters().maximum_distance_2_cuts >= 0) {
+            if (node.d == 2
+                    && node.item_type_id == -2) {
+                if ((bin.first_cut_orientation == CutOrientation::Vertical
+                            && node.t - node.b
+                            > instance().parameters().maximum_distance_2_cuts)
+                        || (bin.first_cut_orientation == CutOrientation::Horizontal
+                            && node.r - node.l
+                            > instance().parameters().maximum_distance_2_cuts)) {
+                    //std::cout << "maximum_distance_2_cuts = false" << std::endl;
+                    maximum_distance_2_cuts_feasible_ = false;
+                    feasible_ = false;
+                }
+            }
+        }
+
         // Check maximum number of 2-cuts.
         if (instance().parameters().maximum_number_2_cuts >= 0) {
             if (node.d == 1) {
@@ -534,6 +551,7 @@ nlohmann::json Solution::to_json() const
             {"MinimumDistance1Cuts", minimum_distance_1_cuts_feasible()},
             {"MaximumDistance1Cuts", maximum_distance_1_cuts_feasible()},
             {"MinimumDistance2Cuts", minimum_distance_2_cuts_feasible()},
+            {"MaximumDistance2Cuts", maximum_distance_2_cuts_feasible()},
             {"MaximumNumber2Cuts", maximum_number_2_cuts_feasible()},
             {"Stacks", stacks_feasible()},
             {"Defects", defects_feasible()},
@@ -568,6 +586,7 @@ void Solution::format(
             << "    Min. dist. 1-cuts:     " << minimum_distance_1_cuts_feasible() << std::endl
             << "    Max. dist. 1-cuts:     " << maximum_distance_1_cuts_feasible() << std::endl
             << "    Min. dist. 2-cuts:     " << minimum_distance_2_cuts_feasible() << std::endl
+            << "    Max. dist. 2-cuts:     " << maximum_distance_2_cuts_feasible() << std::endl
             << "    Max. no. 2-cuts:       " << maximum_number_2_cuts_feasible() << std::endl
             << "    Stacks:                " << stacks_feasible() << std::endl
             << "    Defects:               " << defects_feasible() << std::endl

--- a/src/rectangleguillotine/tree_search.cpp
+++ b/src/rectangleguillotine/tree_search.cpp
@@ -42,6 +42,15 @@ BranchingScheme::BranchingScheme(
         minimum_distance_2_cuts_ = instance.parameters().minimum_distance_2_cuts;
     }
 
+    // Compute maximum_distance_1_cuts_ and maximum_distance_2_cuts_.
+    if (instance.parameters().number_of_stages == 2) {
+        maximum_distance_1_cuts_ = -1;
+        maximum_distance_2_cuts_ = instance.parameters().maximum_distance_1_cuts;
+    } else {
+        maximum_distance_1_cuts_ = instance.parameters().maximum_distance_1_cuts;
+        maximum_distance_2_cuts_ = instance.parameters().maximum_distance_2_cuts;
+    }
+
     // Compute no_oriented_items_;
     no_oriented_items_ = true;
     for (ItemTypeId item_type_id = 0;
@@ -804,9 +813,9 @@ Length BranchingScheme::x1_max(const Node& node, Depth df) const
         Length x = (bin_type.right_trim_type == TrimType::Hard)?
             bin_type.rect.w - bin_type.right_trim:
             bin_type.rect.w;
-        if (instance.parameters().maximum_distance_1_cuts != -1)
-            if (x > x1_prev(node, df) + instance.parameters().maximum_distance_1_cuts)
-                x = x1_prev(node, df) + instance.parameters().maximum_distance_1_cuts;
+        if (maximum_distance_1_cuts_ != -1)
+            if (x > x1_prev(node, df) + maximum_distance_1_cuts_)
+                x = x1_prev(node, df) + maximum_distance_1_cuts_;
         return x;
     } case 1: {
         BinPos i = node.number_of_bins - 1;
@@ -833,9 +842,9 @@ Length BranchingScheme::x1_max(const Node& node, Depth df) const
         Length x = (bin_type.right_trim_type == TrimType::Hard)?
             bin_type.rect.w - bin_type.right_trim:
             bin_type.rect.w;
-        if (instance.parameters().maximum_distance_1_cuts != -1)
-            if (x > x1_prev(node, df) + instance.parameters().maximum_distance_1_cuts)
-                x = x1_prev(node, df) + instance.parameters().maximum_distance_1_cuts;
+        if (maximum_distance_1_cuts_ != -1)
+            if (x > x1_prev(node, df) + maximum_distance_1_cuts_)
+                x = x1_prev(node, df) + maximum_distance_1_cuts_;
         return x;
     }
     }
@@ -863,6 +872,9 @@ Length BranchingScheme::y2_max(
                 if (defect.bottom() >= y2_prev(node, df))
                     if (y > defect.bottom() - instance.parameters().cut_thickness)
                         y = defect.bottom() - instance.parameters().cut_thickness;
+    if (maximum_distance_2_cuts_ != -1)
+        if (y > y2_prev(node, df) + maximum_distance_2_cuts_)
+            y = y2_prev(node, df) + maximum_distance_2_cuts_;
     return y;
 }
 

--- a/src/rectangleguillotine/tree_search.hpp
+++ b/src/rectangleguillotine/tree_search.hpp
@@ -402,6 +402,27 @@ private:
      */
     Length minimum_distance_2_cuts_ = 0;
 
+    /**
+     * Effective maximum distance between two consecutive 1-cuts.
+     *
+     * For 2-staged instances, insertion.x1 does not correspond to a real
+     * 1-cut (see minimum_distance_1_cuts_ above), so this is set to -1
+     * (unconstrained) in that case; maximum_distance_1_cuts is enforced
+     * instead through maximum_distance_2_cuts_, see below.
+     */
+    Length maximum_distance_1_cuts_ = -1;
+
+    /**
+     * Effective maximum distance between two consecutive 2-cuts.
+     *
+     * For 2-staged instances, depth-2 cuts are the only cuts left once the
+     * (possibly flipped) first-stage decision is made, so they are the ones
+     * effectively bounded by maximum_distance_1_cuts; maximum_distance_2_cuts
+     * has no independent meaning there (there is no 3rd stage for it to
+     * separate).
+     */
+    Length maximum_distance_2_cuts_ = -1;
+
     bool no_oriented_items_;
 
     /**

--- a/test/rectangleguillotine/tree_search/insertion_test.cpp
+++ b/test/rectangleguillotine/tree_search/insertion_test.cpp
@@ -1360,6 +1360,7 @@ TEST(RectangleGuillotineBranchingScheme, InsertionTwoStagedMinWasteI)
     instance_builder.set_objective(Objective::BinPackingWithLeftovers);
     instance_builder.set_roadef2018();
     instance_builder.set_number_of_stages(2);
+    instance_builder.set_minimum_distance_2_cuts(0);
     instance_builder.add_item_type(500, 3200, -1, 1, false, 0);
     instance_builder.add_item_type(500, 3200, -1, 1, false, 0);
     instance_builder.add_bin_type(6000, 3210);
@@ -1369,7 +1370,7 @@ TEST(RectangleGuillotineBranchingScheme, InsertionTwoStagedMinWasteI)
     auto root = branching_scheme.root();
 
     std::vector<BranchingScheme::Insertion> is {
-        {0, -1, -2, 3210, 3200, 500, 3210, 6000, 0, 0},
+        {0, -1, -2, 3210, 3200, 500, 3210, 3500, 0, 0},
     };
 
     EXPECT_EQ(branching_scheme.insertions(branching_scheme.children(root)), is);
@@ -1404,6 +1405,7 @@ TEST(RectangleGuillotineBranchingScheme, InsertionTwoStagedMinWasteII)
     instance_builder.set_objective(Objective::BinPackingWithLeftovers);
     instance_builder.set_roadef2018();
     instance_builder.set_number_of_stages(2);
+    instance_builder.set_minimum_distance_2_cuts(0);
     instance_builder.add_item_type(250, 3200, -1, 1, false, 0);
     instance_builder.add_bin_type(6000, 3210);
     instance_builder.add_defect(0, 240, 3190, 10, 10);
@@ -1413,7 +1415,7 @@ TEST(RectangleGuillotineBranchingScheme, InsertionTwoStagedMinWasteII)
     auto root = branching_scheme.root();
 
     std::vector<BranchingScheme::Insertion> is {
-        {0, -1, -2, 3210, 3200, 250, 3210, 6000, 0, 0},
+        {0, -1, -2, 3210, 3200, 250, 3210, 3500, 0, 0},
         //{-1, -1, -2, 3210, 250, 3200, 3210, 6000, 1, 1},
     };
 

--- a/test/rectangleguillotine/tree_search/integration_test.cpp
+++ b/test/rectangleguillotine/tree_search/integration_test.cpp
@@ -35,6 +35,7 @@ TEST(RectangleGuillotineBranchingScheme, ConvertionDefect)
     instance_builder.set_objective(Objective::BinPackingWithLeftovers);
     instance_builder.set_roadef2018();
     instance_builder.set_number_of_stages(2);
+    instance_builder.set_minimum_distance_2_cuts(0);
     instance_builder.add_item_type(3000, 3210, -1, 1, false, 0);
     instance_builder.add_item_type(3000, 500, -1, 1, false, 1);
     instance_builder.add_bin_type(6000, 3210);
@@ -45,7 +46,7 @@ TEST(RectangleGuillotineBranchingScheme, ConvertionDefect)
     BranchingScheme branching_scheme(instance, branching_scheme_parameters);
     auto root = branching_scheme.root();
 
-    BranchingScheme::Insertion i0 = {0, -1, -2, 3210, 3000, 3210, 3210, 6000, 0, 0};
+    BranchingScheme::Insertion i0 = {0, -1, -2, 3210, 3000, 3210, 3210, 3500, 0, 0};
     std::vector<BranchingScheme::Insertion> is0 = branching_scheme.insertions(branching_scheme.children(root));
     EXPECT_NE(std::find(is0.begin(), is0.end(), i0), is0.end());
     auto node_1 = branching_scheme.child(root, i0);


### PR DESCRIPTION
maximum_distance_1_cuts was never enforced against the real width axis for 2-staged instances: BranchingScheme::x1_max() capped insertion.x1, but for 2-staged instances (via the internal first-stage flip) insertion.y2 is the axis that corresponds to the real 1-cuts, so the constraint was silently unenforced there, letting the search build solutions that violated it and crash later in to_solution() with "solution doesn't satisfy maximum distance between 1-cuts".

- Added maximum_distance_2_cuts as a new Instance::Parameters field (parsing, writing, format() output, and a matching maximum_distance_2_cuts_feasible() solution-level check), mirroring the existing minimum_distance_2_cuts.
- BranchingScheme now precomputes maximum_distance_1_cuts_ and maximum_distance_2_cuts_ once in its constructor, exactly like the existing minimum_distance_1_cuts_/minimum_distance_2_cuts_ pair: for 2-staged instances, maximum_distance_1_cuts_ is unconstrained and maximum_distance_2_cuts_ takes over the instance's maximum_distance_1_cuts value (the real axis); otherwise each member reads its own matching instance parameter directly. y2_max() now applies maximum_distance_2_cuts_ the same way x1_max() already applied maximum_distance_1_cuts_.
- InstanceBuilder::build() now throws if minimum_distance_2_cuts, maximum_distance_2_cuts, or maximum_number_2_cuts are set on a 2-staged instance, since none of them are meaningful there (their role is served by the corresponding _1_cuts parameter instead).
- Updated 3 unit tests (InsertionTwoStagedMinWasteI/II, ConvertionDefect) that combined set_roadef2018() (which sets maximum_distance_1_cuts = 3500 and minimum_distance_2_cuts = 100) with a 2-staged override: their hardcoded expected y2_max values reflected the previously-unenforced constraint and are updated to the correct, now-capped value, and the now invalid minimum_distance_2_cuts default is reset to 0.