### PR TITLE
rectangleguillotine: add maximum_number_1_cuts instance parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Features:
 * Minimum distance between consecutive 2-cuts
 * Maximum distance between consecutive 2-cuts
 * Minimum distance between cuts
+* Maximum number of consecutive 1-cuts
 * Maximum number of consecutive 2-cuts
 
 Example:

--- a/include/packingsolver/rectangleguillotine/instance.hpp
+++ b/include/packingsolver/rectangleguillotine/instance.hpp
@@ -122,6 +122,9 @@ struct Parameters
     /** Minimum distance between two cuts. */
     Length minimum_waste_length = 0;
 
+    /** Maximum number of 1-cuts in a bin. */
+    Counter maximum_number_1_cuts = -1;
+
     /**
      * Maximum number of 2-cuts in a first-level sub-plate.
      *

--- a/include/packingsolver/rectangleguillotine/instance_builder.hpp
+++ b/include/packingsolver/rectangleguillotine/instance_builder.hpp
@@ -68,6 +68,8 @@ public:
 
     void set_minimum_waste_length(Length minimum_waste_length) { instance_.parameters_.minimum_waste_length = minimum_waste_length; }
 
+    void set_maximum_number_1_cuts(Counter maximum_number_1_cuts) { instance_.parameters_.maximum_number_1_cuts = maximum_number_1_cuts; }
+
     void set_maximum_number_2_cuts(Counter maximum_number_2_cuts) { instance_.parameters_.maximum_number_2_cuts = maximum_number_2_cuts; }
 
     void set_cut_through_defects(bool cut_through_defects) { instance_.parameters_.cut_through_defects = cut_through_defects; }

--- a/include/packingsolver/rectangleguillotine/solution.hpp
+++ b/include/packingsolver/rectangleguillotine/solution.hpp
@@ -126,6 +126,8 @@ public:
 
     bool maximum_distance_2_cuts_feasible() const { return maximum_distance_2_cuts_feasible_; }
 
+    bool maximum_number_1_cuts_feasible() const { return maximum_number_1_cuts_feasible_; }
+
     bool maximum_number_2_cuts_feasible() const { return maximum_number_2_cuts_feasible_; }
 
     bool stacks_feasible() const { return stacks_feasible_; }
@@ -276,6 +278,9 @@ private:
 
     /** Feasibility for the maximum distance between two consecutive 2-cuts. */
     bool maximum_distance_2_cuts_feasible_ = true;
+
+    /** Feasibility for the maximum number of 1-cuts in a bin. */
+    bool maximum_number_1_cuts_feasible_ = true;
 
     /** Feasibility for the maximum number of 2-cuts in a first-level sub-plate. */
     bool maximum_number_2_cuts_feasible_ = true;

--- a/src/rectangleguillotine/instance.cpp
+++ b/src/rectangleguillotine/instance.cpp
@@ -311,6 +311,7 @@ void Instance::write(
         << "minimum_distance_2_cuts," << parameters().minimum_distance_2_cuts << std::endl
         << "maximum_distance_2_cuts," << parameters().maximum_distance_2_cuts << std::endl
         << "minimum_waste_length," << parameters().minimum_waste_length << std::endl
+        << "maximum_number_1_cuts," << parameters().maximum_number_1_cuts << std::endl
         << "maximum_number_2_cuts," << parameters().maximum_number_2_cuts << std::endl
         << "cut_thickness," << parameters().cut_thickness << std::endl;
 }
@@ -336,6 +337,7 @@ std::ostream& Instance::format(
             << "Minimum distance between 2-cuts:       " << parameters().minimum_distance_2_cuts << std::endl
             << "Maximum distance between 2-cuts:       " << parameters().maximum_distance_2_cuts << std::endl
             << "Minimum waste length:                  " << parameters().minimum_waste_length << std::endl
+            << "Maximum number of consecutive 1-cuts:  " << parameters().maximum_number_1_cuts << std::endl
             << "Maximum number of consecutive 2-cuts:  " << parameters().maximum_number_2_cuts << std::endl
             << "Cut through defects:                   " << parameters().cut_through_defects << std::endl
             << "Cut thickness:                         " << parameters().cut_thickness << std::endl

--- a/src/rectangleguillotine/instance_builder.cpp
+++ b/src/rectangleguillotine/instance_builder.cpp
@@ -579,6 +579,8 @@ void InstanceBuilder::read_parameters(
                 || name == "minWaste"
                 || name == "minimum_waste_length") {
             set_minimum_waste_length(std::stol(value));
+        } else if (name == "maximum_number_1_cuts") {
+            set_maximum_number_1_cuts(std::stol(value));
         } else if (name == "maximum_number_2_cuts") {
             set_maximum_number_2_cuts(std::stol(value));
         } else if (name == "cut_through_defects") {
@@ -932,6 +934,18 @@ Instance InstanceBuilder::build()
                     FUNC_SIGNATURE + ": "
                     "maximum_number_2_cuts is not allowed if number_of_stages == 2.");
         }
+    }
+
+    // maximum_number_1_cuts and maximum_number_2_cuts must not be 0.
+    if (instance_.parameters().maximum_number_1_cuts == 0) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "maximum_number_1_cuts must not be 0.");
+    }
+    if (instance_.parameters().maximum_number_2_cuts == 0) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "maximum_number_2_cuts must not be 0.");
     }
 
     // Compute item_type_ids_ and stack_offsets_.

--- a/src/rectangleguillotine/main.cpp
+++ b/src/rectangleguillotine/main.cpp
@@ -90,6 +90,7 @@ int main(int argc, char *argv[])
             ("maximum-distance-2-cuts,", po::value<Length>(), "")
             ("min-waste,", po::value<Length>(), "")
             ("minimum-waste-length,", po::value<Length>(), "")
+            ("maximum-number-1-cuts,", po::value<Counter>(), "")
             ("maximum-number-2-cuts,", po::value<Counter>(), "")
             ("cut-through-defects", po::value<bool>(), "")
             ("cut-thickness", po::value<Length>(), "")
@@ -235,6 +236,8 @@ int main(int argc, char *argv[])
             instance_builder.set_minimum_waste_length(vm["min-waste"].as<Length>());
         if (vm.count("minimum-waste-length"))
             instance_builder.set_minimum_waste_length(vm["minimum-waste-length"].as<Length>());
+        if (vm.count("maximum-number-1-cuts"))
+            instance_builder.set_maximum_number_1_cuts(vm["maximum-number-1-cuts"].as<Counter>());
         if (vm.count("maximum-number-2-cuts"))
             instance_builder.set_maximum_number_2_cuts(vm["maximum-number-2-cuts"].as<Counter>());
         if (vm.count("cut-through-defects"))

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -421,6 +421,7 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
                     && instance.parameters().maximum_distance_1_cuts == -1
                     && instance.parameters().minimum_distance_2_cuts == 0
                     && instance.parameters().maximum_distance_2_cuts == -1
+                    && instance.parameters().maximum_number_1_cuts == -1
                     && instance.parameters().maximum_number_2_cuts == -1
                     ) {
                 use_tree_search_maximal_spaces = true;
@@ -432,6 +433,7 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
                     && instance.number_of_defects() == 0
                     && instance.number_of_stacks() == instance.number_of_item_types()
                     && instance.parameters().minimum_waste_length == 0
+                    && instance.parameters().maximum_number_1_cuts == -1
                     && instance.parameters().maximum_number_2_cuts == -1
                     ) {
                 use_column_generation_strips = true;

--- a/src/rectangleguillotine/solution.cpp
+++ b/src/rectangleguillotine/solution.cpp
@@ -57,6 +57,14 @@ void Solution::update_indicators(
 
     width_ = 0;
     height_ = 0;
+    Counter bincurr_number_of_1_cuts = 0;
+    Length bincurr_end = (bin.first_cut_orientation == CutOrientation::Vertical)?
+        ((bin_type.right_trim_type == TrimType::Soft)?
+            bin_type.rect.w:
+            bin_type.rect.w - bin_type.right_trim):
+        ((bin_type.top_trim_type == TrimType::Soft)?
+            bin_type.rect.h:
+            bin_type.rect.h - bin_type.top_trim);
     Counter subplate1curr_number_of_2_cuts = 0;
     Length subpalte1curr_end = -1;
     for (const SolutionNode& node: bin.nodes) {
@@ -166,6 +174,24 @@ void Solution::update_indicators(
                     //std::cout << "maximum_distance_2_cuts = false" << std::endl;
                     maximum_distance_2_cuts_feasible_ = false;
                     feasible_ = false;
+                }
+            }
+        }
+
+        // Check maximum number of 1-cuts.
+        if (instance().parameters().maximum_number_1_cuts >= 0) {
+            if (node.d == 1) {
+                if ((bin.first_cut_orientation == CutOrientation::Vertical
+                            && node.r != bincurr_end)
+                        || (bin.first_cut_orientation == CutOrientation::Horizontal
+                            && node.t != bincurr_end)) {
+                    bincurr_number_of_1_cuts++;
+                    if (bincurr_number_of_1_cuts
+                            > instance().parameters().maximum_number_1_cuts) {
+                        //std::cout << "maximum_number_1_cuts = false" << std::endl;
+                        maximum_number_1_cuts_feasible_ = false;
+                        feasible_ = false;
+                    }
                 }
             }
         }
@@ -552,6 +578,7 @@ nlohmann::json Solution::to_json() const
             {"MaximumDistance1Cuts", maximum_distance_1_cuts_feasible()},
             {"MinimumDistance2Cuts", minimum_distance_2_cuts_feasible()},
             {"MaximumDistance2Cuts", maximum_distance_2_cuts_feasible()},
+            {"MaximumNumber1Cuts", maximum_number_1_cuts_feasible()},
             {"MaximumNumber2Cuts", maximum_number_2_cuts_feasible()},
             {"Stacks", stacks_feasible()},
             {"Defects", defects_feasible()},
@@ -587,6 +614,7 @@ void Solution::format(
             << "    Max. dist. 1-cuts:     " << maximum_distance_1_cuts_feasible() << std::endl
             << "    Min. dist. 2-cuts:     " << minimum_distance_2_cuts_feasible() << std::endl
             << "    Max. dist. 2-cuts:     " << maximum_distance_2_cuts_feasible() << std::endl
+            << "    Max. no. 1-cuts:       " << maximum_number_1_cuts_feasible() << std::endl
             << "    Max. no. 2-cuts:       " << maximum_number_2_cuts_feasible() << std::endl
             << "    Stacks:                " << stacks_feasible() << std::endl
             << "    Defects:               " << defects_feasible() << std::endl

--- a/src/rectangleguillotine/tree_search.cpp
+++ b/src/rectangleguillotine/tree_search.cpp
@@ -51,6 +51,13 @@ BranchingScheme::BranchingScheme(
         maximum_distance_2_cuts_ = instance.parameters().maximum_distance_2_cuts;
     }
 
+    // Compute maximum_number_2_cuts_.
+    if (instance.parameters().number_of_stages == 2) {
+        maximum_number_2_cuts_ = instance.parameters().maximum_number_1_cuts;
+    } else {
+        maximum_number_2_cuts_ = instance.parameters().maximum_number_2_cuts;
+    }
+
     // Compute no_oriented_items_;
     no_oriented_items_ = true;
     for (ItemTypeId item_type_id = 0;
@@ -437,6 +444,31 @@ BranchingScheme::Node BranchingScheme::child_tmp(
         node.profit += item_type.profit;
     }
     assert(node.item_area <= instance.bin_area());
+
+    // Compute bincurr_number_of_1_cuts.
+    if (node.df < 0) {
+        if (node.x1_curr == w) {
+            node.bincurr_number_of_1_cuts = 0;
+        } else {
+            node.bincurr_number_of_1_cuts = 1;
+        }
+    } else if (node.df == 0) {
+        if (node.x1_curr == w) {
+            node.bincurr_number_of_1_cuts = parent.bincurr_number_of_1_cuts;
+        } else {
+            node.bincurr_number_of_1_cuts = parent.bincurr_number_of_1_cuts + 1;
+        }
+    } else { // node.df > 0
+        if (node.x1_curr == w) {
+            if (parent.x1_curr == w) {
+                node.bincurr_number_of_1_cuts = parent.bincurr_number_of_1_cuts;
+            } else {
+                node.bincurr_number_of_1_cuts = parent.bincurr_number_of_1_cuts - 1;
+            }
+        } else {
+            node.bincurr_number_of_1_cuts = parent.bincurr_number_of_1_cuts;
+        }
+    }
 
     // Compute subplate1curr_number_of_2_cuts.
     if (node.df < 1) {
@@ -1122,11 +1154,26 @@ void BranchingScheme::update(
         }
     }
 
+    // Update insertion.x1 and insertion.z1 with respect to one1cut()
+    //std::cout << "- update maximum_number_1_cuts  " << insertion << std::endl;
+    if (instance.parameters().maximum_number_1_cuts != -1
+            && insertion.df == 0
+            && parent.bincurr_number_of_1_cuts == instance.parameters().maximum_number_1_cuts
+            && insertion.x1 != w) {
+        if (insertion.z1 == 0) {
+            if (insertion.x1 + cut_thickness + min_waste > w_physical)
+                return;
+            insertion.x1 = w_physical;
+        } else { // insertion.z1 == 1
+            insertion.x1 = w_physical;
+        }
+    }
+
     // Update insertion.y2 and insertion.z2 with respect to one2cut()
     //std::cout << "- update maximum_number_2_cuts  " << insertion << std::endl;
-    if (instance.parameters().maximum_number_2_cuts != -1
+    if (maximum_number_2_cuts_ != -1
             && insertion.df == 1
-            && parent.subplate1curr_number_of_2_cuts == instance.parameters().maximum_number_2_cuts
+            && parent.subplate1curr_number_of_2_cuts == maximum_number_2_cuts_
             && insertion.y2 != h) {
         if (insertion.z2 == 0) {
             if (insertion.y2 + cut_thickness + min_waste > h_physical)

--- a/src/rectangleguillotine/tree_search.hpp
+++ b/src/rectangleguillotine/tree_search.hpp
@@ -209,6 +209,9 @@ public:
         /** Profit of the partial solution. */
         Profit profit = 0;
 
+        /** Number of 1-cuts in the current bin. */
+        Counter bincurr_number_of_1_cuts = 0;
+
         /** Number of 2-cuts in the current 1-level sub-plate. */
         Counter subplate1curr_number_of_2_cuts = 0;
 
@@ -422,6 +425,17 @@ private:
      * separate).
      */
     Length maximum_distance_2_cuts_ = -1;
+
+    /**
+     * Effective maximum number of 2-cuts in a first-level sub-plate.
+     *
+     * For 2-staged instances, depth-2 cuts are the only cuts left once the
+     * (possibly flipped) first-stage decision is made, so they are the ones
+     * effectively bounded by maximum_number_1_cuts; maximum_number_2_cuts
+     * has no independent meaning there (there is no 3rd stage for it to
+     * separate) and is not allowed.
+     */
+    Counter maximum_number_2_cuts_ = -1;
 
     bool no_oriented_items_;
 


### PR DESCRIPTION
Bounds the number of 1-cuts (column boundaries) in a bin, mirroring maximum_number_2_cuts one level up. For 2-staged instances, it is the only way to bound the number of real cuts in a bin, since maximum_number_2_cuts is not allowed there; the tree search flips it onto the internal 2-cuts axis in that case, matching how maximum_distance_1_cuts/maximum_distance_2_cuts already behave.