### PR TITLE
rectangleguillotine: add BinPackingCuttingCost objective

### DIFF
--- a/include/packingsolver/algorithms/common.hpp
+++ b/include/packingsolver/algorithms/common.hpp
@@ -139,6 +139,7 @@ enum class Objective
     VariableSizedBinPacking,
     SequentialOneDimensionalRectangleSubproblem,
     Feasibility,
+    BinPackingCuttingCost,
 };
 
 std::istream& operator>>(

--- a/include/packingsolver/rectangleguillotine/instance.hpp
+++ b/include/packingsolver/rectangleguillotine/instance.hpp
@@ -88,6 +88,25 @@ std::ostream& operator<<(
 ///////////////////////// Item type, Bin type, Defect //////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * Cost of a cutting stage, for the 'BinPackingCuttingCost' objective.
+ *
+ * 'fixed' and 'variable' are set to -1 by default to mark them as unset; both
+ * must be set to a value >= 0 for every required stage, or
+ * 'InstanceBuilder::build' throws.
+ */
+struct CutCost
+{
+    /** Fixed cost, paid once per cut (or per bin, for stage 0). */
+    Profit fixed = -1;
+
+    /**
+     * Variable cost, paid per unit of cut length (or per unit of bin area,
+     * for stage 0).
+     */
+    Profit variable = -1;
+};
+
 struct Parameters
 {
     /** Number of stages. */
@@ -137,6 +156,17 @@ struct Parameters
 
     /** Cut thickness. */
     Length cut_thickness = 0;
+
+    /**
+     * Costs for the 'BinPackingCuttingCost' objective, indexed by stage
+     * number: index 0 is the cost of a bin (fixed cost per bin, variable
+     * cost per unit of bin area); index s (1 <= s <= number_of_stages) is
+     * the cost of an s-cut (fixed cost per cut, variable cost per unit of
+     * cut length). If cut_type is NonExact or Roadef2018, one extra index
+     * (number_of_stages + 1) is required, for the optional extra cut some
+     * patterns of this cut type may need at their deepest level.
+     */
+    std::vector<CutCost> cutting_costs;
 };
 
 /**

--- a/include/packingsolver/rectangleguillotine/instance_builder.hpp
+++ b/include/packingsolver/rectangleguillotine/instance_builder.hpp
@@ -41,7 +41,7 @@ public:
     /** Set parameters. */
     void set_parameters(const Parameters& parameters) { instance_.parameters_ = parameters; }
 
-    void set_number_of_stages(Counter number_of_stages) { instance_.parameters_.number_of_stages = number_of_stages; }
+    void set_number_of_stages(Counter number_of_stages);
 
     /**
      * Set the number of stages to an unlimited value.
@@ -54,7 +54,7 @@ public:
     void set_number_of_stages_unlimited();
 
 
-    void set_cut_type(CutType cut_type) { instance_.parameters_.cut_type = cut_type; }
+    void set_cut_type(CutType cut_type);
 
     void set_first_stage_orientation(CutOrientation first_stage_orientation) { instance_.parameters_.first_stage_orientation = first_stage_orientation; }
 
@@ -76,6 +76,24 @@ public:
 
     /** Set cut thickness. */
     void set_cut_thickness(Length cut_thickness) { instance_.parameters_.cut_thickness = cut_thickness; }
+
+    /**
+     * Set the fixed cost of stage 'stage_id' (0 for the bin, 1 to
+     * number_of_stages + 1 for cuts), for the 'BinPackingCuttingCost'
+     * objective. Grows 'cutting_costs' if needed.
+     */
+    void set_fixed_cutting_cost(
+            Counter stage_id,
+            Profit fixed_cost);
+
+    /**
+     * Set the variable cost of stage 'stage_id' (0 for the bin, 1 to
+     * number_of_stages + 1 for cuts), for the 'BinPackingCuttingCost'
+     * objective. Grows 'cutting_costs' if needed.
+     */
+    void set_variable_cutting_cost(
+            Counter stage_id,
+            Profit variable_cost);
 
     void set_predefined(std::string str);
 
@@ -221,6 +239,13 @@ private:
 
     /** Build stack_offsets_ and item_type_ids_ in the instance. */
     void build_stacks();
+
+    /**
+     * Resize 'cutting_costs' to match the current 'number_of_stages' and
+     * 'cut_type' (called whenever either is set), preserving already-set
+     * values.
+     */
+    void resize_cutting_costs();
 
     /*
      * Private attributes

--- a/include/packingsolver/rectangleguillotine/solution.hpp
+++ b/include/packingsolver/rectangleguillotine/solution.hpp
@@ -166,6 +166,12 @@ public:
     /** Get the cost of the solution. */
     inline Profit cost() const { return cost_; }
 
+    /**
+     * Get the cutting cost of the solution, for the
+     * 'BinPackingCuttingCost' objective (bins + 1/2/3/4-cuts).
+     */
+    inline Profit cutting_cost() const { return cutting_cost_; }
+
     /*
      * Getters: items
      */
@@ -315,6 +321,9 @@ private:
 
     /** Cost of the solution. */
     Profit cost_ = 0;
+
+    /** Cutting cost of the solution, for the 'BinPackingCuttingCost' objective. */
+    Profit cutting_cost_ = 0;
 
     /*
      * Private attributes: items

--- a/src/algorithms/common.cpp
+++ b/src/algorithms/common.cpp
@@ -161,6 +161,10 @@ std::istream& packingsolver::operator>>(
             || token == "SequentialOneDimensionalRectangleSubproblem"
             || token == "BDRS") {
         objective = Objective::SequentialOneDimensionalRectangleSubproblem;
+    } else if (token == "bin-packing-cutting-cost"
+            || token == "BinPackingCuttingCost"
+            || token == "BPPCC") {
+        objective = Objective::BinPackingCuttingCost;
     } else  {
         in.setstate(std::ios_base::failbit);
     }
@@ -204,6 +208,9 @@ std::ostream& packingsolver::operator<<(
         break;
     } case Objective::SequentialOneDimensionalRectangleSubproblem: {
         os << "SequentialOneDimensionalRectangleSubproblem";
+        break;
+    } case Objective::BinPackingCuttingCost: {
+        os << "BinPackingCuttingCost";
         break;
     }
     }

--- a/src/rectangleguillotine/algorithm_formatter.cpp
+++ b/src/rectangleguillotine/algorithm_formatter.cpp
@@ -76,6 +76,19 @@ void AlgorithmFormatter::print_header()
                 << std::setw(32) << "-------"
                 << std::endl;
         break;
+    } case Objective::BinPackingCuttingCost: {
+        *os_
+                << std::setw(12) << "Time"
+                << std::setw(8) << "Bins"
+                << std::setw(14) << "Cutting cost"
+                << std::setw(32) << "Comment"
+                << std::endl
+                << std::setw(12) << "----"
+                << std::setw(8) << "----"
+                << std::setw(14) << "------------"
+                << std::setw(32) << "-------"
+                << std::endl;
+        break;
     } case Objective::OpenDimensionX: {
         *os_
                 << std::setw(12) << "Time"
@@ -180,6 +193,14 @@ void AlgorithmFormatter::print(
                 << std::setw(12) << output_.solution_pool.best().number_of_bins()
                 << std::setw(12) << output_.solution_pool.best().waste()
                 << std::setw(12) << std::fixed << std::setprecision(2) << 100 * output_.solution_pool.best().waste_percentage() << std::defaultfloat << std::setprecision(precision)
+                << std::setw(32) << s
+                << std::endl;
+        break;
+    } case Objective::BinPackingCuttingCost: {
+        *os_
+                << std::setw(12) << std::fixed << std::setprecision(3) << output_.time << std::defaultfloat << std::setprecision(precision)
+                << std::setw(8) << output_.solution_pool.best().number_of_bins()
+                << std::setw(14) << output_.solution_pool.best().cutting_cost()
                 << std::setw(32) << s
                 << std::endl;
         break;

--- a/src/rectangleguillotine/instance.cpp
+++ b/src/rectangleguillotine/instance.cpp
@@ -314,6 +314,13 @@ void Instance::write(
         << "maximum_number_1_cuts," << parameters().maximum_number_1_cuts << std::endl
         << "maximum_number_2_cuts," << parameters().maximum_number_2_cuts << std::endl
         << "cut_thickness," << parameters().cut_thickness << std::endl;
+    for (Counter stage_id = 0;
+            stage_id < (Counter)parameters().cutting_costs.size();
+            ++stage_id) {
+        f_parameters
+            << "cuts_fixed_cost_" << stage_id << "," << parameters().cutting_costs[stage_id].fixed << std::endl
+            << "cuts_variable_cost_" << stage_id << "," << parameters().cutting_costs[stage_id].variable << std::endl;
+    }
 }
 
 std::ostream& Instance::format(

--- a/src/rectangleguillotine/instance_builder.cpp
+++ b/src/rectangleguillotine/instance_builder.cpp
@@ -104,6 +104,55 @@ void InstanceBuilder::set_predefined(std::string str)
     }
 }
 
+void InstanceBuilder::set_number_of_stages(Counter number_of_stages)
+{
+    instance_.parameters_.number_of_stages = number_of_stages;
+    resize_cutting_costs();
+}
+
+void InstanceBuilder::set_cut_type(CutType cut_type)
+{
+    instance_.parameters_.cut_type = cut_type;
+    resize_cutting_costs();
+}
+
+void InstanceBuilder::resize_cutting_costs()
+{
+    Counter number_of_required_cutting_costs = 1 + instance_.parameters_.number_of_stages
+        + ((instance_.parameters_.cut_type == CutType::NonExact
+                    || instance_.parameters_.cut_type == CutType::Roadef2018)? 1: 0);
+    if ((Counter)instance_.parameters_.cutting_costs.size() < number_of_required_cutting_costs)
+        instance_.parameters_.cutting_costs.resize(number_of_required_cutting_costs);
+}
+
+void InstanceBuilder::set_fixed_cutting_cost(
+        Counter stage_id,
+        Profit fixed_cost)
+{
+    if (stage_id < 0 || stage_id >= (Counter)instance_.parameters_.cutting_costs.size()) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "invalid 'stage_id'; "
+                "stage_id: " + std::to_string(stage_id) + "; "
+                "cutting_costs.size(): " + std::to_string(instance_.parameters_.cutting_costs.size()) + ".");
+    }
+    instance_.parameters_.cutting_costs[stage_id].fixed = fixed_cost;
+}
+
+void InstanceBuilder::set_variable_cutting_cost(
+        Counter stage_id,
+        Profit variable_cost)
+{
+    if (stage_id < 0 || stage_id >= (Counter)instance_.parameters_.cutting_costs.size()) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "invalid 'stage_id'; "
+                "stage_id: " + std::to_string(stage_id) + "; "
+                "cutting_costs.size(): " + std::to_string(instance_.parameters_.cutting_costs.size()) + ".");
+    }
+    instance_.parameters_.cutting_costs[stage_id].variable = variable_cost;
+}
+
 void InstanceBuilder::set_number_of_stages_unlimited()
 {
     Counter max_stages = 0;
@@ -116,6 +165,7 @@ void InstanceBuilder::set_number_of_stages_unlimited()
     instance_.parameters_.number_of_stages = max_stages;
     instance_.parameters_.cut_type = CutType::Exact;
     instance_.parameters_.first_stage_orientation = CutOrientation::Any;
+    resize_cutting_costs();
 }
 
 void InstanceBuilder::set_roadef2018()
@@ -128,6 +178,7 @@ void InstanceBuilder::set_roadef2018()
     instance_.parameters_.minimum_distance_2_cuts = 100;
     instance_.parameters_.minimum_waste_length = 20;
     instance_.parameters_.cut_through_defects = false;
+    resize_cutting_costs();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -587,6 +638,12 @@ void InstanceBuilder::read_parameters(
             set_cut_through_defects(std::stol(value));
         } else if (name == "cut_thickness") {
             set_cut_thickness(std::stol(value));
+        } else if (name.rfind("cuts_fixed_cost_", 0) == 0) {
+            Counter stage_id = std::stol(name.substr(16));
+            set_fixed_cutting_cost(stage_id, std::stod(value));
+        } else if (name.rfind("cuts_variable_cost_", 0) == 0) {
+            Counter stage_id = std::stol(name.substr(19));
+            set_variable_cutting_cost(stage_id, std::stod(value));
         }
     }
 }
@@ -946,6 +1003,33 @@ Instance InstanceBuilder::build()
         throw std::invalid_argument(
                 FUNC_SIGNATURE + ": "
                 "maximum_number_2_cuts must not be 0.");
+    }
+
+    // For the 'BinPackingCuttingCost' objective, 'cutting_costs' must contain
+    // a valid (fixed >= 0, variable >= 0) entry for stage 0 (the bin) and for
+    // stages 1 to number_of_stages, plus one extra stage if cut_type is
+    // NonExact or Roadef2018.
+    if (instance_.objective() == Objective::BinPackingCuttingCost) {
+        Counter number_of_required_cutting_costs = 1 + instance_.parameters().number_of_stages
+            + ((instance_.parameters().cut_type == CutType::NonExact
+                        || instance_.parameters().cut_type == CutType::Roadef2018)? 1: 0);
+        if ((Counter)instance_.parameters().cutting_costs.size() < number_of_required_cutting_costs) {
+            throw std::invalid_argument(
+                    FUNC_SIGNATURE + ": "
+                    "missing cutting costs; "
+                    "cutting_costs.size(): " + std::to_string(instance_.parameters().cutting_costs.size()) + "; "
+                    "number_of_required_cutting_costs: " + std::to_string(number_of_required_cutting_costs) + ".");
+        }
+        for (Counter stage_id = 0;
+                stage_id < number_of_required_cutting_costs;
+                ++stage_id) {
+            const CutCost& cutting_cost = instance_.parameters().cutting_costs[stage_id];
+            if (cutting_cost.fixed == -1 || cutting_cost.variable == -1) {
+                throw std::invalid_argument(
+                        FUNC_SIGNATURE + ": "
+                        "missing cutting cost for stage " + std::to_string(stage_id) + ".");
+            }
+        }
     }
 
     // Compute item_type_ids_ and stack_offsets_.

--- a/src/rectangleguillotine/main.cpp
+++ b/src/rectangleguillotine/main.cpp
@@ -94,6 +94,8 @@ int main(int argc, char *argv[])
             ("maximum-number-2-cuts,", po::value<Counter>(), "")
             ("cut-through-defects", po::value<bool>(), "")
             ("cut-thickness", po::value<Length>(), "")
+            ("fixed-cutting-costs", po::value<std::vector<Profit>>()->multitoken(), "")
+            ("variable-cutting-costs", po::value<std::vector<Profit>>()->multitoken(), "")
 
             ("output,o", po::value<std::string>(), "Output path")
             ("certificate,c", po::value<std::string>(), "Certificate path")
@@ -245,6 +247,22 @@ int main(int argc, char *argv[])
             instance_builder.set_cut_through_defects(vm["cut-through-defects"].as<bool>());
         if (vm.count("cut-thickness"))
             instance_builder.set_cut_thickness(vm["cut-thickness"].as<Length>());
+        if (vm.count("fixed-cutting-costs")) {
+            const auto& fixed_cutting_costs = vm["fixed-cutting-costs"].as<std::vector<Profit>>();
+            for (Counter stage_id = 0;
+                    stage_id < (Counter)fixed_cutting_costs.size();
+                    ++stage_id) {
+                instance_builder.set_fixed_cutting_cost(stage_id, fixed_cutting_costs[stage_id]);
+            }
+        }
+        if (vm.count("variable-cutting-costs")) {
+            const auto& variable_cutting_costs = vm["variable-cutting-costs"].as<std::vector<Profit>>();
+            for (Counter stage_id = 0;
+                    stage_id < (Counter)variable_cutting_costs.size();
+                    ++stage_id) {
+                instance_builder.set_variable_cutting_cost(stage_id, variable_cutting_costs[stage_id]);
+            }
+        }
 
         Instance instance = instance_builder.build();
 

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -576,6 +576,18 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
                 }
             }
         }
+    } else if (instance.objective() == Objective::BinPackingCuttingCost) {
+        // Only tree_search supports this objective.
+        use_tree_search = true;
+        use_tree_search_maximal_spaces = false;
+        use_column_generation_strips = false;
+        use_sequential_strips_onedimensional = false;
+        use_dynamic_programming_infinite_copies_array = false;
+        use_labeling = false;
+        use_sequential_single_knapsack = false;
+        use_sequential_value_correction = false;
+        use_dichotomic_search = false;
+        use_column_generation = false;
     }
 
     if (instance.objective() == Objective::BinPacking) {

--- a/src/rectangleguillotine/solution.cpp
+++ b/src/rectangleguillotine/solution.cpp
@@ -51,6 +51,10 @@ void Solution::update_indicators(
     number_of_bins_ += bin.copies;
     bin_copies_[bin.bin_type_id] += bin.copies;
     cost_ += bin.copies * bin_type.cost;
+    if (instance().objective() == Objective::BinPackingCuttingCost) {
+        const CutCost& bin_cutting_cost = instance().parameters().cutting_costs[0];
+        cutting_cost_ += bin.copies * (bin_cutting_cost.fixed + bin_cutting_cost.variable * bin_type.area());
+    }
     full_area_ += bin.copies * bin_type.area();
     area_ = full_area_;
     second_leftover_value_ = 0;
@@ -217,6 +221,28 @@ void Solution::update_indicators(
                         feasible_ = false;
                     }
                 }
+            }
+        }
+
+        // Update cutting_cost_ for the 'BinPackingCuttingCost' objective.
+        // Odd depths (1, 3) are cuts along the width axis (checked/measured
+        // like 1-cuts); even depths (2, 4) are cuts along the height axis
+        // (checked/measured like 2-cuts). A cut is only real (chargeable)
+        // if it doesn't just extend to its parent's own boundary.
+        if (instance().objective() == Objective::BinPackingCuttingCost
+                && node.d >= 1 && node.d <= 4) {
+            const CutCost& node_cutting_cost = (node.d < (Counter)instance().parameters().cutting_costs.size())?
+                instance().parameters().cutting_costs[node.d]:
+                CutCost();
+            bool is_odd_depth = (node.d % 2 == 1);
+            bool is_real_cut = (is_odd_depth)?
+                (node.r != bin.nodes[node.f].r):
+                (node.t != bin.nodes[node.f].t);
+            if (is_real_cut) {
+                Length length = (is_odd_depth)?
+                    (node.t - node.b):
+                    (node.r - node.l);
+                cutting_cost_ += bin.copies * (node_cutting_cost.fixed + node_cutting_cost.variable * length);
             }
         }
 
@@ -477,6 +503,12 @@ bool Solution::operator<(const Solution& solution) const
         if (!full())
             return true;
         return solution.height() < height();
+    } case Objective::BinPackingCuttingCost: {
+        if (!solution.full())
+            return false;
+        if (!full())
+            return true;
+        return solution.cutting_cost() < cutting_cost();
     } case Objective::Knapsack: {
         return strictly_greater(solution.profit(), profit());
     } case Objective::Feasibility: {
@@ -562,6 +594,7 @@ nlohmann::json Solution::to_json() const
         {"NumberOfDifferentBins", number_of_different_bins()},
         {"BinArea", full_area()},
         {"BinCost", cost()},
+        {"CuttingCost", cutting_cost()},
         {"Waste", waste()},
         {"WastePercentage", waste_percentage()},
         {"FullWaste", full_waste()},
@@ -601,6 +634,7 @@ void Solution::format(
             << "Number of different bins:  " << number_of_different_bins() << std::endl
             << "Bin area:                  " << optimizationtools::Ratio<BinPos>(full_area(), instance().bin_area()) << std::endl
             << "Bin cost:                  " << cost() << std::endl
+            << "Cutting cost:              " << cutting_cost() << std::endl
             << "Waste:                     " << waste() << " (" << 100 * waste_percentage() << "%)" << std::endl
             << "Full waste:                " << full_waste() << " (" << 100 * full_waste_percentage() << "%)" << std::endl
             << "Width:                     " << width() << std::endl

--- a/src/rectangleguillotine/tree_search.cpp
+++ b/src/rectangleguillotine/tree_search.cpp
@@ -58,6 +58,28 @@ BranchingScheme::BranchingScheme(
         maximum_number_2_cuts_ = instance.parameters().maximum_number_2_cuts;
     }
 
+    // Compute cutting_costs_.
+    if (instance.objective() == Objective::BinPackingCuttingCost) {
+        const auto& cutting_costs = instance.parameters().cutting_costs;
+        auto cutting_cost = [&cutting_costs](Counter stage_id) {
+            return (stage_id >= 0 && stage_id < (Counter)cutting_costs.size())?
+                cutting_costs[stage_id]:
+                CutCost();
+        };
+        cutting_costs_[0] = cutting_cost(0);
+        if (instance.parameters().number_of_stages == 2) {
+            cutting_costs_[1] = CutCost();
+            cutting_costs_[2] = cutting_cost(1);
+            cutting_costs_[3] = cutting_cost(2);
+            cutting_costs_[4] = cutting_cost(3);
+        } else {
+            cutting_costs_[1] = cutting_cost(1);
+            cutting_costs_[2] = cutting_cost(2);
+            cutting_costs_[3] = cutting_cost(3);
+            cutting_costs_[4] = cutting_cost(4);
+        }
+    }
+
     // Compute no_oriented_items_;
     no_oriented_items_ = true;
     for (ItemTypeId item_type_id = 0;
@@ -167,6 +189,10 @@ bool BranchingScheme::bound(
                 (node_1->waste + instance().item_area() - 1)
                 / instance().bin_type(0).rect.w + 1)
             >= height(*node_2);
+    } case Objective::BinPackingCuttingCost: {
+        if (!leaf(node_2))
+            return false;
+        return node_1->cutting_cost >= node_2->cutting_cost;
     } default: {
         std::stringstream ss;
         ss << FUNC_SIGNATURE << ": "
@@ -219,6 +245,12 @@ bool BranchingScheme::better(
         return node_2->profit < node_1->profit;
     } case Objective::Feasibility: {
         return node_2->profit < node_1->profit;
+    } case Objective::BinPackingCuttingCost: {
+        if (!leaf(node_1))
+            return false;
+        if (!leaf(node_2))
+            return true;
+        return node_2->cutting_cost > node_1->cutting_cost;
     } default: {
         std::stringstream ss;
         ss << FUNC_SIGNATURE << ": "
@@ -406,12 +438,15 @@ BranchingScheme::Node BranchingScheme::child_tmp(
     }
 
     Length w_j = node.x3_curr - x3_prev(parent, node.df);
-    //bool rotate_j1 = (insertion.item_type_id_1 == -1)? false: (instance().width(instance().item(insertion.item_type_id_1), true, o) == w_j);
+    bool rotate_j1 = (node.item_type_id_1 == -1)?
+        false:
+        (instance.item_type(node.item_type_id_1).rect.h == w_j);
     bool rotate_j2 = (node.item_type_id_2 == -1)?
         false:
         (instance.item_type(node.item_type_id_2).rect.h == w_j);
-    //Length h_j1 = (insertion.item_type_id_1 == -1)? -1: instance().height(instance().item_type(insertion.item_type_id_1), rotate_j1, o);
-    //Length h_j2 = (insertion.item_type_id_2 == -1)? -1: instance().height(instance().item_type(insertion.item_type_id_2), rotate_j2, o);
+    Length h_j1 = (node.item_type_id_1 == -1)?
+        -1:
+        instance.item_type(node.item_type_id_1).height(rotate_j1);
 
     // Compute subplate2curr_items_above_defect.
     if (node.df == 2)
@@ -492,6 +527,100 @@ BranchingScheme::Node BranchingScheme::child_tmp(
             }
         } else {
             node.subplate1curr_number_of_2_cuts = parent.subplate1curr_number_of_2_cuts;
+        }
+    }
+
+    // Update cutting_cost (for the 'BinPackingCuttingCost' objective).
+    // Mirrors the bincurr_number_of_1_cuts / subplate1curr_number_of_2_cuts
+    // cascades above, extended down to depths 3 and 4, and combining each
+    // cut's fixed and variable cost into a single running total (rather
+    // than tracking count and length separately) since the per-depth rates
+    // are constant throughout the search.
+    if (instance.objective() == Objective::BinPackingCuttingCost) {
+        node.cutting_cost = parent.cutting_cost;
+
+        // 4-cut cost. A potential 4-cut (single item not reaching the
+        // 2-level sub-plate's target height) only becomes chargeable once
+        // another 3-level sub-plate is added above it (df == 2 and y2
+        // increases); until then it stays in subplate2curr_potential_cost_of_4_cuts.
+        node.subplate2curr_potential_cost_of_4_cuts = (node.df != 2)?
+            0: parent.subplate2curr_potential_cost_of_4_cuts;
+        if (node.df == 2 && node.y2_curr > parent.y2_curr) {
+            node.cutting_cost += node.subplate2curr_potential_cost_of_4_cuts;
+            node.subplate2curr_potential_cost_of_4_cuts = 0;
+        }
+        if (node.item_type_id_1 != -1 && node.item_type_id_2 == -1) { // 1 item.
+            if (node.y2_curr != node.y2_prev + h_j1) {
+                node.cutting_cost += cutting_costs_[4].fixed + cutting_costs_[4].variable * w_j;
+            } else {
+                node.subplate2curr_potential_cost_of_4_cuts += cutting_costs_[4].fixed + cutting_costs_[4].variable * w_j;
+            }
+        } else if (node.item_type_id_1 == -1 && node.item_type_id_2 != -1) { // 1 item above a defect.
+            node.cutting_cost += cutting_costs_[4].fixed + cutting_costs_[4].variable * w_j;
+        } else if (node.item_type_id_1 != -1 && node.item_type_id_2 != -1) { // 2 items.
+            node.cutting_cost += cutting_costs_[4].fixed + cutting_costs_[4].variable * w_j;
+        }
+
+        // 3-cut cost. Same principle as 2-cut below, one level deeper: a
+        // potential 3-cut (when the current 2-cut coincides with the
+        // current 1-cut) only becomes chargeable once the 1-cut's position
+        // actually moves further.
+        if (node.df == 2) {
+            node.cutting_cost += (node.y2_curr - parent.y2_curr) * parent.subplate2curr_number_of_3_cuts * cutting_costs_[3].variable;
+            node.subplate2curr_number_of_3_cuts = parent.subplate2curr_number_of_3_cuts;
+        } else {
+            node.subplate2curr_number_of_3_cuts = 0;
+        }
+        node.subplate1curr_potential_cost_of_3_cuts = parent.subplate1curr_potential_cost_of_3_cuts;
+        if (node.df == 1 && parent.x3_curr == parent.x1_curr) {
+            node.subplate1curr_potential_cost_of_3_cuts
+                += cutting_costs_[3].fixed + cutting_costs_[3].variable * (parent.y2_curr - parent.y2_prev);
+        }
+        if (node.df <= 0) {
+            node.subplate1curr_potential_cost_of_3_cuts = 0;
+        }
+        if (node.df >= 1 && node.x1_curr > parent.x1_curr) {
+            node.cutting_cost += node.subplate1curr_potential_cost_of_3_cuts;
+            node.subplate1curr_potential_cost_of_3_cuts = 0;
+        }
+        if ((node.df == 2 && parent.x3_curr == parent.x1_curr) || (node.x3_curr != node.x1_curr)) {
+            node.subplate2curr_number_of_3_cuts++;
+            node.cutting_cost
+                += cutting_costs_[3].fixed + cutting_costs_[3].variable * (node.y2_curr - node.y2_prev);
+        }
+
+        // 2-cut cost. If the current 1-level sub-plate widens, every 2-cut
+        // already placed in it grows accordingly (its length is the
+        // sub-plate's width), hence the scaling by
+        // parent.subplate1curr_number_of_2_cuts.
+        if (node.df >= 1) {
+            node.cutting_cost
+                += (node.x1_curr - parent.x1_curr) * parent.subplate1curr_number_of_2_cuts * cutting_costs_[2].variable;
+        }
+        if (node.df <= 1) { // New 2-level sub-plate.
+            if (node.y2_curr != h) {
+                node.cutting_cost += cutting_costs_[2].fixed + cutting_costs_[2].variable * (node.x1_curr - node.x1_prev);
+            }
+        } else { // Same 2-level sub-plate.
+            if (parent.y2_curr != h && node.y2_curr == h) {
+                node.cutting_cost -= cutting_costs_[2].fixed + cutting_costs_[2].variable * (node.x1_curr - node.x1_prev);
+            }
+        }
+
+        // 1-cut cost.
+        if (node.df <= 0) { // New 1-level sub-plate.
+            if (node.x1_curr != w) {
+                node.cutting_cost += cutting_costs_[1].fixed + cutting_costs_[1].variable * h;
+            }
+        } else { // Same 1-level sub-plate.
+            if (parent.x1_curr != w && node.x1_curr == w) {
+                node.cutting_cost -= cutting_costs_[1].fixed + cutting_costs_[1].variable * h;
+            }
+        }
+
+        // Bin cost (stage 0), charged once per new bin.
+        if (node.df < 0) {
+            node.cutting_cost += cutting_costs_[0].fixed + cutting_costs_[0].variable * bin_type.area();
         }
     }
 

--- a/src/rectangleguillotine/tree_search.hpp
+++ b/src/rectangleguillotine/tree_search.hpp
@@ -9,6 +9,8 @@
 
 #include "treesearchsolver/common.hpp"
 
+#include <array>
+
 namespace packingsolver
 {
 namespace rectangleguillotine
@@ -214,6 +216,30 @@ public:
 
         /** Number of 2-cuts in the current 1-level sub-plate. */
         Counter subplate1curr_number_of_2_cuts = 0;
+
+        /**
+         * Cumulated cutting cost of the partial solution, for the
+         * 'BinPackingCuttingCost' objective (bins + confirmed 1/2/3/4-cuts).
+         */
+        Profit cutting_cost = 0;
+
+        /**
+         * Cost of the potential 3-cuts of the current 1-level sub-plate (not
+         * yet confirmed, see 'cutting_cost' above).
+         */
+        Profit subplate1curr_potential_cost_of_3_cuts = 0;
+
+        /**
+         * Number of 3-cuts in the current 2-level sub-plate, used to scale
+         * their cost when the 2-level sub-plate's height increases.
+         */
+        Counter subplate2curr_number_of_3_cuts = 0;
+
+        /**
+         * Cost of the potential 4-cuts of the current 2-level sub-plate (not
+         * yet confirmed, see 'cutting_cost' above).
+         */
+        Profit subplate2curr_potential_cost_of_4_cuts = 0;
 
         /**
          * Contains the list of items (id, rotate, left cut position) inserted
@@ -436,6 +462,18 @@ private:
      * separate) and is not allowed.
      */
     Counter maximum_number_2_cuts_ = -1;
+
+    /**
+     * Effective cutting costs, for the 'BinPackingCuttingCost' objective:
+     * cutting_costs_[0] is the cost of the bin, cutting_costs_[1..4] are the
+     * costs of the 1/2/3/4-cuts, matching the depths actually used by this
+     * branching scheme (which never exceed depth 4). For 2-staged instances,
+     * depth 1 (x1) does not correspond to a real cut (see
+     * maximum_distance_1_cuts_ above), so cutting_costs_[1] is left at
+     * {0, 0} and instance().parameters().cutting_costs[1..3] (stages 1 to 3)
+     * are shifted into cutting_costs_[2..4] instead.
+     */
+    std::array<CutCost, 5> cutting_costs_;
 
     bool no_oriented_items_;
 

--- a/test/rectangleguillotine/CMakeLists.txt
+++ b/test/rectangleguillotine/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(PackingSolver_rectangleguillotine_test PRIVATE
     tree_search/cut_thickness_test.cpp
     tree_search/integration_test.cpp
     tree_search/tree_search_test.cpp
+    tree_search/cutting_cost_test.cpp
     column_generation_strips_test.cpp
     sequential_strips_onedimensional_test.cpp
     dynamic_programming_infinite_copies_array_test.cpp

--- a/test/rectangleguillotine/tree_search/cutting_cost_test.cpp
+++ b/test/rectangleguillotine/tree_search/cutting_cost_test.cpp
@@ -1,0 +1,81 @@
+#include "packingsolver/rectangleguillotine/instance_builder.hpp"
+#include "rectangleguillotine/tree_search.hpp"
+
+#include "treesearchsolver/iterative_beam_search_2.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace packingsolver;
+using namespace packingsolver::rectangleguillotine;
+
+TEST(RectangleGuillotineBranchingScheme, CuttingCostSingleItem)
+{
+    /**
+     * A single item exactly filling the bin: no cuts needed, only the bin
+     * cost applies.
+     */
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPackingCuttingCost);
+    instance_builder.set_number_of_stages(3);
+    instance_builder.set_cut_type(CutType::NonExact);
+    instance_builder.add_item_type(100, 100, -1, 1, false, 0);
+    instance_builder.add_bin_type(100, 100, 1, -1, 0);
+    instance_builder.set_fixed_cutting_cost(0, 10);
+    instance_builder.set_variable_cutting_cost(0, 1);
+    for (Counter stage_id = 1; stage_id <= 4; ++stage_id) {
+        instance_builder.set_fixed_cutting_cost(stage_id, 5);
+        instance_builder.set_variable_cutting_cost(stage_id, 0.01);
+    }
+    Instance instance = instance_builder.build();
+
+    BranchingScheme::Parameters branching_scheme_parameters;
+    BranchingScheme branching_scheme(instance, branching_scheme_parameters);
+    auto output = treesearchsolver::iterative_beam_search_2(branching_scheme);
+    Solution solution = branching_scheme.to_solution(output.solution_pool.best());
+
+    EXPECT_TRUE(solution.full());
+    // Bin cost only: fixed + variable * area = 10 + 1 * (100 * 100).
+    EXPECT_DOUBLE_EQ(solution.cutting_cost(), 10 + 1 * 100 * 100);
+}
+
+TEST(RectangleGuillotineBranchingScheme, CuttingCostTwoColumns)
+{
+    /**
+     * Two items exactly filling one column each: one real 1-cut splits the
+     * bin into the two columns, each item exactly fills its column (no
+     * further 2-cut/3-cut needed).
+     *
+     * |-----------------|-----------------|
+     * |                 |                 |
+     * |        0        |        1        | 100
+     * |                 |                 |
+     * |-----------------|-----------------|
+     *                 100               200
+     */
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPackingCuttingCost);
+    instance_builder.set_number_of_stages(3);
+    instance_builder.set_cut_type(CutType::NonExact);
+    instance_builder.add_item_type(100, 100, -1, 2, false, 0);
+    instance_builder.add_bin_type(200, 100, 1, -1, 0);
+    instance_builder.set_fixed_cutting_cost(0, 10);
+    instance_builder.set_variable_cutting_cost(0, 0.001);
+    instance_builder.set_fixed_cutting_cost(1, 5);
+    instance_builder.set_variable_cutting_cost(1, 0.01);
+    for (Counter stage_id = 2; stage_id <= 4; ++stage_id) {
+        instance_builder.set_fixed_cutting_cost(stage_id, 5);
+        instance_builder.set_variable_cutting_cost(stage_id, 0.01);
+    }
+    Instance instance = instance_builder.build();
+
+    BranchingScheme::Parameters branching_scheme_parameters;
+    BranchingScheme branching_scheme(instance, branching_scheme_parameters);
+    auto output = treesearchsolver::iterative_beam_search_2(branching_scheme);
+    Solution solution = branching_scheme.to_solution(output.solution_pool.best());
+
+    EXPECT_TRUE(solution.full());
+    // Bin cost: 10 + 0.001 * (200 * 100) = 30.
+    // One real 1-cut: 5 + 0.01 * 100 (bin height) = 6.
+    // No 2-cut/3-cut: each item exactly fills its column.
+    EXPECT_DOUBLE_EQ(solution.cutting_cost(), 30 + 6);
+}


### PR DESCRIPTION
New objective minimizing total cutting cost (a fixed cost plus a cost proportional to length, per cutting stage, plus a bin cost proportional to area) instead of number of bins. Only the tree_search algorithm supports it; other algorithms are explicitly disabled for this objective in optimize().

Costs are stored in Parameters::cutting_costs, indexed by stage number (index 0 is the bin, index s is the s-cut), sized to number_of_stages + 1 (bin) + 1 more if cut_type is NonExact or Roadef2018 (which allow an extra cut at the deepest level). InstanceBuilder::build() validates that every required entry has been set.

tree_search's Node::cutting_cost mirrors the existing bincurr_number_of_1_cuts / subplate1curr_number_of_2_cuts cascades, extended to depths 3 and 4 with the same potential/confirmed cut tracking, combining each cut's fixed and variable cost into a running total instead of tracking count and length separately. For 2-staged instances, the existing x1-pinned-to-full-width trick means depth 1 doesn't correspond to a real cut, so the effective cutting costs are shifted accordingly.

Solution::cutting_cost() independently recomputes the same total from the final guillotine tree for reporting.