### PR TITLE
rectangleguillotine: add waste_cost to the BinPackingCuttingCost objective

### DIFF
--- a/include/packingsolver/rectangleguillotine/instance.hpp
+++ b/include/packingsolver/rectangleguillotine/instance.hpp
@@ -91,20 +91,19 @@ std::ostream& operator<<(
 /**
  * Cost of a cutting stage, for the 'BinPackingCuttingCost' objective.
  *
- * 'fixed' and 'variable' are set to -1 by default to mark them as unset; both
- * must be set to a value >= 0 for every required stage, or
- * 'InstanceBuilder::build' throws.
+ * 'fixed' and 'variable' default to 0, so a stage that is never configured
+ * simply contributes no cost.
  */
 struct CutCost
 {
     /** Fixed cost, paid once per cut (or per bin, for stage 0). */
-    CuttingCost fixed = -1;
+    CuttingCost fixed = 0;
 
     /**
      * Variable cost, paid per unit of cut length (or per unit of bin area,
      * for stage 0).
      */
-    CuttingCost variable = -1;
+    CuttingCost variable = 0;
 };
 
 struct Parameters
@@ -167,6 +166,12 @@ struct Parameters
      * patterns of this cut type may need at their deepest level.
      */
     std::vector<CutCost> cutting_costs;
+
+    /**
+     * Cost per unit of waste area, for the 'BinPackingCuttingCost'
+     * objective. Defaults to 0, so waste is not charged unless configured.
+     */
+    CuttingCost waste_cost = 0;
 };
 
 /**

--- a/include/packingsolver/rectangleguillotine/instance_builder.hpp
+++ b/include/packingsolver/rectangleguillotine/instance_builder.hpp
@@ -95,6 +95,12 @@ public:
             Counter stage_id,
             CuttingCost variable_cost);
 
+    /**
+     * Set the cost per unit of waste area, for the 'BinPackingCuttingCost'
+     * objective.
+     */
+    void set_waste_cost(CuttingCost waste_cost) { instance_.parameters_.waste_cost = waste_cost; }
+
     void set_predefined(std::string str);
 
     void set_roadef2018();

--- a/src/rectangleguillotine/instance.cpp
+++ b/src/rectangleguillotine/instance.cpp
@@ -321,6 +321,10 @@ void Instance::write(
             << "cuts_fixed_cost_" << stage_id << "," << parameters().cutting_costs[stage_id].fixed << std::endl
             << "cuts_variable_cost_" << stage_id << "," << parameters().cutting_costs[stage_id].variable << std::endl;
     }
+    if (objective() == Objective::BinPackingCuttingCost) {
+        f_parameters
+            << "waste_cost," << parameters().waste_cost << std::endl;
+    }
 }
 
 std::ostream& Instance::format(
@@ -510,6 +514,10 @@ std::ostream& Instance::format(
                     << std::setw(16) << cutting_cost.variable
                     << std::endl;
             }
+            os
+                << std::endl
+                << "Waste cost:            " << parameters().waste_cost << std::endl
+                ;
         }
     }
 

--- a/src/rectangleguillotine/instance_builder.cpp
+++ b/src/rectangleguillotine/instance_builder.cpp
@@ -644,6 +644,8 @@ void InstanceBuilder::read_parameters(
         } else if (name.rfind("cuts_variable_cost_", 0) == 0) {
             Counter stage_id = std::stol(name.substr(19));
             set_variable_cutting_cost(stage_id, std::stoll(value));
+        } else if (name == "waste_cost") {
+            set_waste_cost(std::stoll(value));
         }
     }
 }
@@ -1003,33 +1005,6 @@ Instance InstanceBuilder::build()
         throw std::invalid_argument(
                 FUNC_SIGNATURE + ": "
                 "maximum_number_2_cuts must not be 0.");
-    }
-
-    // For the 'BinPackingCuttingCost' objective, 'cutting_costs' must contain
-    // a valid (fixed >= 0, variable >= 0) entry for stage 0 (the bin) and for
-    // stages 1 to number_of_stages, plus one extra stage if cut_type is
-    // NonExact or Roadef2018.
-    if (instance_.objective() == Objective::BinPackingCuttingCost) {
-        Counter number_of_required_cutting_costs = 1 + instance_.parameters().number_of_stages
-            + ((instance_.parameters().cut_type == CutType::NonExact
-                        || instance_.parameters().cut_type == CutType::Roadef2018)? 1: 0);
-        if ((Counter)instance_.parameters().cutting_costs.size() < number_of_required_cutting_costs) {
-            throw std::invalid_argument(
-                    FUNC_SIGNATURE + ": "
-                    "missing cutting costs; "
-                    "cutting_costs.size(): " + std::to_string(instance_.parameters().cutting_costs.size()) + "; "
-                    "number_of_required_cutting_costs: " + std::to_string(number_of_required_cutting_costs) + ".");
-        }
-        for (Counter stage_id = 0;
-                stage_id < number_of_required_cutting_costs;
-                ++stage_id) {
-            const CutCost& cutting_cost = instance_.parameters().cutting_costs[stage_id];
-            if (cutting_cost.fixed == -1 || cutting_cost.variable == -1) {
-                throw std::invalid_argument(
-                        FUNC_SIGNATURE + ": "
-                        "missing cutting cost for stage " + std::to_string(stage_id) + ".");
-            }
-        }
     }
 
     // Compute item_type_ids_ and stack_offsets_.

--- a/src/rectangleguillotine/main.cpp
+++ b/src/rectangleguillotine/main.cpp
@@ -96,6 +96,7 @@ int main(int argc, char *argv[])
             ("cut-thickness", po::value<Length>(), "")
             ("fixed-cutting-costs", po::value<std::vector<CuttingCost>>()->multitoken(), "")
             ("variable-cutting-costs", po::value<std::vector<CuttingCost>>()->multitoken(), "")
+            ("waste-cost", po::value<CuttingCost>(), "")
 
             ("output,o", po::value<std::string>(), "Output path")
             ("certificate,c", po::value<std::string>(), "Certificate path")
@@ -263,6 +264,8 @@ int main(int argc, char *argv[])
                 instance_builder.set_variable_cutting_cost(stage_id, variable_cutting_costs[stage_id]);
             }
         }
+        if (vm.count("waste-cost"))
+            instance_builder.set_waste_cost(vm["waste-cost"].as<CuttingCost>());
 
         Instance instance = instance_builder.build();
 

--- a/src/rectangleguillotine/solution.cpp
+++ b/src/rectangleguillotine/solution.cpp
@@ -47,6 +47,7 @@ void Solution::update_indicators(
 {
     SolutionBin& bin = bins_[bin_pos];
     const BinType& bin_type = instance().bin_type(bin.bin_type_id);
+    Area waste_before_bin = waste();
 
     number_of_bins_ += bin.copies;
     bin_copies_[bin.bin_type_id] += bin.copies;
@@ -411,6 +412,8 @@ void Solution::update_indicators(
         write("solution_rectangleguillotine.csv");
         exit(1);
     }
+
+    cutting_cost_ += instance().parameters().waste_cost * (waste() - waste_before_bin);
 }
 
 void Solution::append(

--- a/src/rectangleguillotine/tree_search.cpp
+++ b/src/rectangleguillotine/tree_search.cpp
@@ -655,6 +655,8 @@ BranchingScheme::Node BranchingScheme::child_tmp(
                 "node.y2_curr: " + std::to_string(node.y2_curr) + "; "
                 "node.x3_curr: " + std::to_string(node.x3_curr) + ".");
     }
+    node.cutting_cost += instance.parameters().waste_cost * (node.waste - parent.waste);
+
     return node;
 }
 

--- a/test/rectangleguillotine/tree_search/cutting_cost_test.cpp
+++ b/test/rectangleguillotine/tree_search/cutting_cost_test.cpp
@@ -24,7 +24,7 @@ TEST(RectangleGuillotineBranchingScheme, CuttingCostSingleItem)
     instance_builder.set_variable_cutting_cost(0, 1);
     for (Counter stage_id = 1; stage_id <= 4; ++stage_id) {
         instance_builder.set_fixed_cutting_cost(stage_id, 5);
-        instance_builder.set_variable_cutting_cost(stage_id, 0.01);
+        instance_builder.set_variable_cutting_cost(stage_id, 1);
     }
     Instance instance = instance_builder.build();
 
@@ -78,4 +78,62 @@ TEST(RectangleGuillotineBranchingScheme, CuttingCostTwoColumns)
     // One real 1-cut: 5 + 1 * 100 (bin height) = 105.
     // No 2-cut/3-cut: each item exactly fills its column.
     EXPECT_EQ(solution.cutting_cost(), 20010 + 105);
+}
+
+TEST(RectangleGuillotineBranchingScheme, CuttingCostUnsetIsZero)
+{
+    /**
+     * None of the cutting costs are set: the instance builder must not
+     * throw, and the resulting cutting cost must be 0.
+     */
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPackingCuttingCost);
+    instance_builder.set_number_of_stages(3);
+    instance_builder.set_cut_type(CutType::NonExact);
+    instance_builder.add_item_type(100, 100, -1, 1, false, 0);
+    instance_builder.add_bin_type(100, 100, 1, -1, 0);
+    Instance instance = instance_builder.build();
+
+    BranchingScheme::Parameters branching_scheme_parameters;
+    BranchingScheme branching_scheme(instance, branching_scheme_parameters);
+    auto output = treesearchsolver::iterative_beam_search_2(branching_scheme);
+    Solution solution = branching_scheme.to_solution(output.solution_pool.best());
+
+    EXPECT_TRUE(solution.full());
+    EXPECT_EQ(solution.cutting_cost(), 0);
+}
+
+TEST(RectangleGuillotineBranchingScheme, CuttingCostWasteCost)
+{
+    /**
+     * Two items, each leaving waste on the side of its own bin: only the
+     * waste cost applies (bin/cut costs left at their default of 0). The
+     * trailing open strip of the very last bin is "residual" (not yet
+     * consumed stock) rather than waste, so only the first bin's leftover
+     * is actually charged.
+     *
+     * |-------------|---------|
+     * |             |         |
+     * |      0      |  waste  | 100
+     * |             |         |
+     * |-------------|---------|
+     *              100       150
+     */
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPackingCuttingCost);
+    instance_builder.set_number_of_stages(3);
+    instance_builder.set_cut_type(CutType::NonExact);
+    instance_builder.add_item_type(100, 100, -1, 2, false, 0);
+    instance_builder.add_bin_type(150, 100, 1, -1, 0);
+    instance_builder.set_waste_cost(2);
+    Instance instance = instance_builder.build();
+
+    BranchingScheme::Parameters branching_scheme_parameters;
+    BranchingScheme branching_scheme(instance, branching_scheme_parameters);
+    auto output = treesearchsolver::iterative_beam_search_2(branching_scheme);
+    Solution solution = branching_scheme.to_solution(output.solution_pool.best());
+
+    EXPECT_TRUE(solution.full());
+    // First bin's waste: (150 * 100) - (100 * 100) = 5000. Cost: 2 * 5000 = 10000.
+    EXPECT_EQ(solution.cutting_cost(), 10000);
 }


### PR DESCRIPTION
Port the waste_cost concept from the old codebase: a per-unit-area cost charged on a solution's waste, added on top of the existing bin/cut costs. Included directly in Solution::cutting_cost_ (accumulated per bin in update_indicators, using the marginal change in waste() rather than an absolute value, since the trailing open strip of the very last bin is "residual" stock rather than waste) and in the branching scheme's Node::cutting_cost (using the same node.waste field already tracked for other purposes), so the search's guides/dominance/bound comparisons see the complete cost during the search too.

Also switch CutCost::fixed/variable and the new waste_cost to default to 0 instead of the previous -1 "unset" sentinel, and drop InstanceBuilder::build()'s validation that threw when a cutting cost was left unset for the BinPackingCuttingCost objective: an unconfigured cost now simply contributes nothing instead of requiring every stage to be explicitly set.