### PR TITLE
Add visualization script flags, fix boxstacks data download, trim open-dimension bin shape output, fix circle item crash

### DIFF
--- a/data/irregular/tests/circle.json
+++ b/data/irregular/tests/circle.json
@@ -1,0 +1,16 @@
+{
+    "objective": "feasibility",
+    "bin_types": [
+        {
+            "type": "rectangle",
+            "width": 10,
+            "height": 10
+        }
+    ],
+    "item_types": [
+        {
+            "type": "circle",
+            "radius": 1
+        }
+    ]
+}

--- a/data/irregular/tests/circle_solution.json
+++ b/data/irregular/tests/circle_solution.json
@@ -1,0 +1,17 @@
+{
+    "bins": [
+        {
+            "id": 0,
+            "copies": 1,
+            "items": [
+                {
+                    "id": 0,
+                    "x": 1.0,
+                    "y": 5.0,
+                    "angle": 0.0,
+                    "mirror": false
+                }
+            ]
+        }
+    ]
+}

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -38,7 +38,7 @@ set(SHAPE_BUILD_TEST OFF)
 FetchContent_Declare(
     shape
     GIT_REPOSITORY https://github.com/fontanf/shape.git
-    GIT_TAG 5271e4294c44d04667c07d231be0bf74aee5d2cc
+    GIT_TAG 1809a9c7a1f8734fc8c7330ffe00cc3270ba7d44
     #SOURCE_DIR "${PROJECT_SOURCE_DIR}/../shape/"
     EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(shape)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ plotly
 shapely
 streamlit
 kaleido
+Pillow
 py7zr

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -64,14 +64,12 @@ if args.data is None or "imahori2010" in args.data:
 if args.data is None or "roadef2022_2024-04-25_kp" in args.data:
     download(
         "https://drive.google.com/file/d/1HbK0QJQyDk7fII8jF9nBMP0sD-D1E3N-/view?usp=drive_link",
-        pathlib.Path("data") / "boxstacks",
-        "tar.gz")
+        pathlib.Path("data") / "boxstacks")
 
 if args.data is None or "roadef2022_2024-04-25_bpp" in args.data:
     download(
         "https://drive.google.com/file/d/1U2MefX8UeCWn0ohFCDpxiCNwRHkAPvFP/view?usp=drive_link",
-        pathlib.Path("data") / "boxstacks",
-        "tar.gz")
+        pathlib.Path("data") / "boxstacks")
 
 
 if args.data is None or "irregular" in args.data:

--- a/scripts/visualize_box.py
+++ b/scripts/visualize_box.py
@@ -13,6 +13,9 @@ parser.add_argument('--width', type=int, default=None, help='image width in pixe
 parser.add_argument('--height', type=int, default=None, help='image height in pixels for PNG export')
 parser.add_argument('--columns', type=int, default=None, help='number of columns in the subplot grid')
 parser.add_argument('--scale', type=float, default=1.0, help='scale factor for cell dimensions')
+parser.add_argument('--zoom', type=float, default=1.0, help='camera zoom factor (higher: closer/bigger)')
+parser.add_argument('--autocrop', action='store_true', help='crop exported PNG to its non-white content, with a small margin')
+parser.add_argument('--no-legend', action='store_true', help='hide the legend, freeing up space for the plot itself')
 args = parser.parse_args()
 
 if args.itemcolor not in ["SAME", "ID"]:
@@ -239,6 +242,7 @@ for i in range(0, m):
 fig.update_layout(
         autosize=True,
         font=dict(size=14),
+        showlegend=not args.no_legend,
         legend=dict(font=dict(size=14), itemsizing='constant'))
 fig.update_xaxes(
         rangeslider=dict(visible=False))
@@ -249,12 +253,22 @@ fig.update_scenes(
         aspectmode='data',
         camera=dict(
             center=dict(x=0, y=0, z=-0.25),
-            eye=dict(x=-1.75, y=-1.5, z=0.75)))
+            eye=dict(x=-1.75 / args.zoom, y=-1.5 / args.zoom, z=0.75 / args.zoom)))
 if args.output:
     cell_width = int(max_bin_lx * args.scale)
     cell_height = int(max_bin_ly * args.scale)
     export_width = args.width if args.width is not None else number_of_cols * cell_width + 160
     export_height = args.height if args.height is not None else number_of_rows * cell_height + 170
     fig.write_image(args.output, width=export_width, height=export_height, scale=2)
+    if args.autocrop:
+        from PIL import Image, ImageChops
+        margin = 20
+        im = Image.open(args.output).convert("RGB")
+        bbox = ImageChops.difference(im, Image.new("RGB", im.size, (255, 255, 255))).getbbox()
+        if bbox is not None:
+            x1, y1, x2, y2 = bbox
+            x1, y1 = max(0, x1 - margin), max(0, y1 - margin)
+            x2, y2 = min(im.width, x2 + margin), min(im.height, y2 + margin)
+            im.crop((x1, y1, x2, y2)).save(args.output)
 else:
     fig.show()

--- a/scripts/visualize_boxstacks.py
+++ b/scripts/visualize_boxstacks.py
@@ -13,6 +13,10 @@ parser.add_argument('--width', type=int, default=None, help='image width in pixe
 parser.add_argument('--height', type=int, default=None, help='image height in pixels for PNG export')
 parser.add_argument('--columns', type=int, default=None, help='number of columns in the subplot grid')
 parser.add_argument('--scale', type=float, default=1.0, help='scale factor for cell dimensions')
+parser.add_argument('--zoom', type=float, default=1.0, help='camera zoom factor (higher: closer/bigger)')
+parser.add_argument('--expand-copies', action='store_true', help='draw one subplot per bin copy instead of one per bin type')
+parser.add_argument('--autocrop', action='store_true', help='crop exported PNG to its non-white content, with a small margin')
+parser.add_argument('--no-legend', action='store_true', help='hide the legend, freeing up space for the plot itself')
 args = parser.parse_args()
 
 if args.itemcolor not in ["SAME", "ID"]:
@@ -46,6 +50,7 @@ item_ids_z = []
 item_ids = []
 max_bin_lx = 0
 max_bin_ly = 0
+bin_copies = []
 
 with open(args.csvpath, newline='') as csvfile:
     csvreader = csv.DictReader(csvfile, delimiter=',')
@@ -66,6 +71,7 @@ with open(args.csvpath, newline='') as csvfile:
         if type_ == "BIN":
             max_bin_lx = max(max_bin_lx, lx)
             max_bin_ly = max(max_bin_ly, ly)
+            bin_copies.append(int(row["COPIES"]) if "COPIES" in row else 1)
             bins_x.append([])
             bins_y.append([])
             bins_z.append([])
@@ -140,6 +146,39 @@ with open(args.csvpath, newline='') as csvfile:
             item_ids_y[i].append((y1 + y2) / 2)
             item_ids_z[i].append((z1 + z2) / 2)
             item_ids[i].append(id_)
+
+if args.expand_copies:
+    def expand(lst):
+        out = []
+        for v, c in zip(lst, bin_copies):
+            out += [v] * c
+        return out
+    bins_x = expand(bins_x)
+    bins_y = expand(bins_y)
+    bins_z = expand(bins_z)
+    bins_i = expand(bins_i)
+    bins_j = expand(bins_j)
+    bins_k = expand(bins_k)
+    defects_x = expand(defects_x)
+    defects_y = expand(defects_y)
+    defects_z = expand(defects_z)
+    defects_i = expand(defects_i)
+    defects_j = expand(defects_j)
+    defects_k = expand(defects_k)
+    items_x = expand(items_x)
+    items_y = expand(items_y)
+    items_z = expand(items_z)
+    items_i = expand(items_i)
+    items_j = expand(items_j)
+    items_k = expand(items_k)
+    items_colors = expand(items_colors)
+    item_borders_x = expand(item_borders_x)
+    item_borders_y = expand(item_borders_y)
+    item_borders_z = expand(item_borders_z)
+    item_ids_x = expand(item_ids_x)
+    item_ids_y = expand(item_ids_y)
+    item_ids_z = expand(item_ids_z)
+    item_ids = expand(item_ids)
 
 m = len(bins_x)
 colors = px.colors.qualitative.Pastel
@@ -239,6 +278,7 @@ for i in range(0, m):
 fig.update_layout(
         autosize=True,
         font=dict(size=14),
+        showlegend=not args.no_legend,
         legend=dict(font=dict(size=14), itemsizing='constant'))
 fig.update_xaxes(
         rangeslider=dict(visible=False))
@@ -249,12 +289,22 @@ fig.update_scenes(
         aspectmode='data',
         camera=dict(
             center=dict(x=0, y=0, z=-0.25),
-            eye=dict(x=-1.75, y=-1.5, z=0.75)))
+            eye=dict(x=-1.75 / args.zoom, y=-1.5 / args.zoom, z=0.75 / args.zoom)))
 if args.output:
     cell_width = int(max_bin_lx * args.scale)
     cell_height = int(max_bin_ly * args.scale)
     export_width = args.width if args.width is not None else number_of_cols * cell_width + 160
     export_height = args.height if args.height is not None else number_of_rows * cell_height + 170
     fig.write_image(args.output, width=export_width, height=export_height, scale=2)
+    if args.autocrop:
+        from PIL import Image, ImageChops
+        margin = 20
+        im = Image.open(args.output).convert("RGB")
+        bbox = ImageChops.difference(im, Image.new("RGB", im.size, (255, 255, 255))).getbbox()
+        if bbox is not None:
+            x1, y1, x2, y2 = bbox
+            x1, y1 = max(0, x1 - margin), max(0, y1 - margin)
+            x2, y2 = min(im.width, x2 + margin), min(im.height, y2 + margin)
+            im.crop((x1, y1, x2, y2)).save(args.output)
 else:
     fig.show()

--- a/scripts/visualize_onedimensional.py
+++ b/scripts/visualize_onedimensional.py
@@ -11,6 +11,7 @@ parser.add_argument('-o', '--output', help='save image to file instead of openin
 parser.add_argument('--width', type=int, default=None, help='image width in pixels for PNG export')
 parser.add_argument('--height', type=int, default=None, help='image height in pixels for PNG export')
 parser.add_argument('--scale', type=float, default=1.0, help='scale factor for cell dimensions')
+parser.add_argument('--expand-copies', action='store_true', help='draw one subplot per bin copy instead of one per bin type')
 args = parser.parse_args()
 
 if args.itemcolor not in ["SAME", "ID"]:
@@ -24,6 +25,7 @@ item_ids_x = []
 item_ids_y = []
 item_ids = []
 max_bin_lx = 0
+bin_copies = []
 
 with open(args.csvpath, newline='') as csvfile:
     csvreader = csv.DictReader(csvfile, delimiter=',')
@@ -40,6 +42,7 @@ with open(args.csvpath, newline='') as csvfile:
 
         if type_ == "BIN":
             max_bin_lx = max(max_bin_lx, w)
+            bin_copies.append(int(row["COPIES"]) if "COPIES" in row else 1)
             bins_x.append([])
             bins_y.append([])
             items_x.append([])
@@ -59,6 +62,20 @@ with open(args.csvpath, newline='') as csvfile:
             item_ids_x[i].append((x1 + x2) / 2)
             item_ids_y[i].append((y1 + y2) / 2)
             item_ids[i].append(id_)
+
+if args.expand_copies:
+    def expand(lst):
+        out = []
+        for v, c in zip(lst, bin_copies):
+            out += [v] * c
+        return out
+    bins_x = expand(bins_x)
+    bins_y = expand(bins_y)
+    items_x = expand(items_x)
+    items_y = expand(items_y)
+    item_ids_x = expand(item_ids_x)
+    item_ids_y = expand(item_ids_y)
+    item_ids = expand(item_ids)
 
 m = len(bins_x)
 colors = px.colors.qualitative.Pastel

--- a/src/irregular/solution.cpp
+++ b/src/irregular/solution.cpp
@@ -1,5 +1,6 @@
 #include "packingsolver/irregular/solution.hpp"
 
+#include "shape/boolean_operations.hpp"
 #include "shape/intersection_tree.hpp"
 
 #include "optimizationtools/utils/utils.hpp"
@@ -490,10 +491,31 @@ void Solution::write(
         json["bins"][bin_pos]["copies"] = bin.copies;
         json["bins"][bin_pos]["id"] = bin.bin_type_id;
         // Bin shape.
+        // For open-dimension objectives, only the used part of the bin in the
+        // open dimension(s) is written, instead of the full input bin.
+        Shape bin_shape = bin_type.shape_orig;
+        if ((instance().objective() == Objective::OpenDimensionX
+                || instance().objective() == Objective::OpenDimensionY
+                || instance().objective() == Objective::OpenDimensionXY)
+                && !bin.items.empty()) {
+            AxisAlignedBoundingBox restricting_aabb = bin_type.aabb_orig;
+            if (instance().objective() == Objective::OpenDimensionX
+                    || instance().objective() == Objective::OpenDimensionXY) {
+                restricting_aabb.x_max = bin.x_max;
+            }
+            if (instance().objective() == Objective::OpenDimensionY
+                    || instance().objective() == Objective::OpenDimensionXY) {
+                restricting_aabb.y_max = bin.y_max;
+            }
+            const Shape restricting_rect = shape::build_rectangle(restricting_aabb);
+            const std::vector<shape::ShapeWithHoles> intersection = shape::compute_intersection(
+                    {{bin_type.shape_orig}, {restricting_rect}});
+            bin_shape = intersection[0].shape;
+        }
         for (Counter element_pos = 0;
-                element_pos < (Counter)bin_type.shape_orig.elements.size();
+                element_pos < (Counter)bin_shape.elements.size();
                 ++element_pos) {
-            const ShapeElement& element = bin_type.shape_orig.elements[element_pos];
+            const ShapeElement& element = bin_shape.elements[element_pos];
             json["bins"][bin_pos]["shape"][element_pos]["type"] = element2str(element.type);
             json["bins"][bin_pos]["shape"][element_pos]["xs"] = element.start.x;
             json["bins"][bin_pos]["shape"][element_pos]["ys"] = element.start.y;

--- a/test/irregular/tree_search_test.cpp
+++ b/test/irregular/tree_search_test.cpp
@@ -201,4 +201,7 @@ INSTANTIATE_TEST_SUITE_P(
             }, {
                 fs::path("data") / "irregular" / "tests" / "fixed_item.json",
                 fs::path("data") / "irregular" / "tests" / "fixed_item_solution.json"
+            }, {
+                fs::path("data") / "irregular" / "tests" / "circle.json",
+                fs::path("data") / "irregular" / "tests" / "circle_solution.json"
             }}));


### PR DESCRIPTION
Add --zoom, --autocrop, --no-legend and --expand-copies (boxstacks/ onedimensional) to visualize_box.py/visualize_boxstacks.py/ visualize_onedimensional.py, used to produce consistently sized, cropped-to-content doc example images; add the Pillow dependency these need for --autocrop.

Drop the incorrect "tar.gz" format argument from the boxstacks dataset downloads in download_data.py (the archives aren't tar.gz).

irregular: for open-dimension objectives, write only the used part of the bin shape (intersected with the actual bin bounding box) to the solution JSON instead of the full input bin shape.

Bump the pinned fontanf/shape commit to pull in a fix for flatten_arcs misdetecting full circles (orientation Full, start == end) as flat and collapsing them into zero-length line segments, which crashed compute_approximation_cost with "angle_prev == 0.0" whenever a circle item type went through the tree search's directional branching schemes (OpenDimensionX/Y, single-bin BinPackingWithLeftovers/knapsack). Add a regression test (data/irregular/tests/circle.json) to IrregularTreeSearchTest covering this case.