### PR TITLE
Move Output bound fields to each problem type's derived Output

### DIFF
--- a/include/packingsolver/algorithms/common.hpp
+++ b/include/packingsolver/algorithms/common.hpp
@@ -271,21 +271,6 @@ struct Output: optimizationtools::Output
     /** Solution pool. */
     SolutionPool<Instance, Solution> solution_pool;
 
-    /** Knapsack bound. */
-    Profit knapsack_bound = std::numeric_limits<Profit>::infinity();
-
-    /** Bin packing bound. */
-    BinPos bin_packing_bound = 0;
-
-    /** Bin packing bound. */
-    Profit variable_sized_bin_packing_bound = 0;
-
-    /** Open dimension X bound. */
-    Length open_dimension_x_bound = 0;
-
-    /** Open dimension Y bound. */
-    Length open_dimension_y_bound = 0;
-
     /** Elapsed time. */
     double time = 0.0;
 
@@ -309,17 +294,17 @@ struct Output: optimizationtools::Output
     }
 };
 
-template <typename Instance, typename Solution>
-using NewSolutionCallback = std::function<void(const Output<Instance, Solution>&)>;
+template <typename Instance, typename Solution, typename Output = packingsolver::Output<Instance, Solution>>
+using NewSolutionCallback = std::function<void(const Output&)>;
 
-template <typename Instance, typename Solution>
+template <typename Instance, typename Solution, typename Output = packingsolver::Output<Instance, Solution>>
 struct Parameters: optimizationtools::Parameters
 {
     /** Maximum size of the solution pool. */
     Counter maximum_size_of_the_solution_pool = 1;
 
     /** New solution callback. */
-    NewSolutionCallback<Instance, Solution> new_solution_callback = [](const Output<Instance, Solution>&) { };
+    NewSolutionCallback<Instance, Solution, Output> new_solution_callback = [](const Output&) { };
 
     /** JSON search tree path. */
     std::string json_search_tree_path;

--- a/include/packingsolver/box/algorithm_formatter.hpp
+++ b/include/packingsolver/box/algorithm_formatter.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "packingsolver/box/solution.hpp"
+#include "packingsolver/box/optimize.hpp"
 
 #include <mutex>
 
@@ -17,8 +17,8 @@ public:
     /** Constructor. */
     AlgorithmFormatter(
             const Instance& instance,
-            const packingsolver::Parameters<Instance, Solution>& parameters,
-            packingsolver::Output<Instance, Solution>& output):
+            const packingsolver::Parameters<Instance, Solution, Output>& parameters,
+            Output& output):
         instance_(instance),
         parameters_(parameters),
         output_(output),
@@ -58,7 +58,7 @@ public:
 
     /** Update all applicable bounds from another output. */
     void update_bounds(
-            const packingsolver::Output<Instance, Solution>& output);
+            const Output& output);
 
     /** Method to call at the end of the algorithm. */
     void end();
@@ -72,10 +72,10 @@ private:
     const Instance& instance_;
 
     /** Parameters. */
-    const packingsolver::Parameters<Instance, Solution>& parameters_;
+    const packingsolver::Parameters<Instance, Solution, Output>& parameters_;
 
     /** Output. */
-    packingsolver::Output<Instance, Solution>& output_;
+    Output& output_;
 
     /** Output stream. */
     std::unique_ptr<optimizationtools::ComposeStream> os_;

--- a/include/packingsolver/box/optimize.hpp
+++ b/include/packingsolver/box/optimize.hpp
@@ -13,9 +13,38 @@ struct Output: packingsolver::Output<Instance, Solution>
 {
     Output(const Instance& instance):
         packingsolver::Output<Instance, Solution>(instance) { }
+
+    /** Knapsack bound. */
+    Profit knapsack_bound = std::numeric_limits<Profit>::infinity();
+
+    /** Bin packing bound. */
+    BinPos bin_packing_bound = 0;
+
+    /** Variable-sized bin packing bound. */
+    Profit variable_sized_bin_packing_bound = 0;
+
+    virtual nlohmann::json to_json() const override
+    {
+        nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();
+        json["KnapsackBound"] = knapsack_bound;
+        json["BinPackingBound"] = bin_packing_bound;
+        json["VariableSizedBinPackingBound"] = variable_sized_bin_packing_bound;
+        return json;
+    }
+
+    virtual void format(std::ostream& os) const override
+    {
+        packingsolver::Output<Instance, Solution>::format(os);
+        int width = format_width();
+        os
+            << std::setw(width) << std::left << "Knapsack bound: " << knapsack_bound << std::endl
+            << std::setw(width) << std::left << "Bin packing bound: " << bin_packing_bound << std::endl
+            << std::setw(width) << std::left << "Variable-sized bin packing bound: " << variable_sized_bin_packing_bound << std::endl
+            ;
+    }
 };
 
-struct OptimizeParameters: packingsolver::Parameters<Instance, Solution>
+struct OptimizeParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     /** Optimization mode. */
     OptimizationMode optimization_mode = OptimizationMode::Anytime;

--- a/include/packingsolver/boxstacks/algorithm_formatter.hpp
+++ b/include/packingsolver/boxstacks/algorithm_formatter.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "packingsolver/boxstacks/solution.hpp"
+#include "packingsolver/boxstacks/optimize.hpp"
 
 #include <mutex>
 
@@ -17,8 +17,8 @@ public:
     /** Constructor. */
     AlgorithmFormatter(
             const Instance& instance,
-            const packingsolver::Parameters<Instance, Solution>& parameters,
-            packingsolver::Output<Instance, Solution>& output):
+            const packingsolver::Parameters<Instance, Solution, Output>& parameters,
+            Output& output):
         instance_(instance),
         parameters_(parameters),
         output_(output),
@@ -60,10 +60,10 @@ private:
     const Instance& instance_;
 
     /** Parameters. */
-    const packingsolver::Parameters<Instance, Solution>& parameters_;
+    const packingsolver::Parameters<Instance, Solution, Output>& parameters_;
 
     /** Output. */
-    packingsolver::Output<Instance, Solution>& output_;
+    Output& output_;
 
     /** Output stream. */
     std::unique_ptr<optimizationtools::ComposeStream> os_;

--- a/include/packingsolver/boxstacks/optimize.hpp
+++ b/include/packingsolver/boxstacks/optimize.hpp
@@ -14,6 +14,25 @@ struct Output: packingsolver::Output<Instance, Solution>
     Output(const Instance& instance):
         packingsolver::Output<Instance, Solution>(instance) { }
 
+    /** Bin packing bound. */
+    BinPos bin_packing_bound = 0;
+
+    virtual nlohmann::json to_json() const override
+    {
+        nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();
+        json["BinPackingBound"] = bin_packing_bound;
+        return json;
+    }
+
+    virtual void format(std::ostream& os) const override
+    {
+        packingsolver::Output<Instance, Solution>::format(os);
+        int width = format_width();
+        os
+            << std::setw(width) << std::left << "Bin packing bound: " << bin_packing_bound << std::endl
+            ;
+    }
+
 
     /**
      * Number of items in the solution found by the Sequential onedimensional
@@ -78,7 +97,7 @@ struct Output: packingsolver::Output<Instance, Solution>
     Counter number_of_tree_search_better = 0;
 };
 
-struct OptimizeParameters: packingsolver::Parameters<Instance, Solution>
+struct OptimizeParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     /** Optimization mode. */
     OptimizationMode optimization_mode = OptimizationMode::Anytime;

--- a/include/packingsolver/irregular/algorithm_formatter.hpp
+++ b/include/packingsolver/irregular/algorithm_formatter.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "packingsolver/irregular/solution.hpp"
+#include "packingsolver/irregular/optimize.hpp"
 
 #include <mutex>
 
@@ -17,8 +17,8 @@ public:
     /** Constructor. */
     AlgorithmFormatter(
             const Instance& instance,
-            const packingsolver::Parameters<Instance, Solution>& parameters,
-            packingsolver::Output<Instance, Solution>& output):
+            const packingsolver::Parameters<Instance, Solution, Output>& parameters,
+            Output& output):
         instance_(instance),
         parameters_(parameters),
         output_(output),
@@ -66,7 +66,7 @@ public:
 
     /** Update all applicable bounds from another output. */
     void update_bounds(
-            const packingsolver::Output<Instance, Solution>& output);
+            const Output& output);
 
     /** Method to call at the end of the algorithm. */
     void end();
@@ -80,10 +80,10 @@ private:
     const Instance& instance_;
 
     /** Parameters. */
-    const packingsolver::Parameters<Instance, Solution>& parameters_;
+    const packingsolver::Parameters<Instance, Solution, Output>& parameters_;
 
     /** Output. */
-    packingsolver::Output<Instance, Solution>& output_;
+    Output& output_;
 
     /** Output stream. */
     std::unique_ptr<optimizationtools::ComposeStream> os_;

--- a/include/packingsolver/irregular/optimize.hpp
+++ b/include/packingsolver/irregular/optimize.hpp
@@ -13,9 +13,38 @@ struct Output: packingsolver::Output<Instance, Solution>
 {
     Output(const Instance& instance):
         packingsolver::Output<Instance, Solution>(instance) { }
+
+    /** Knapsack bound. */
+    Profit knapsack_bound = std::numeric_limits<Profit>::infinity();
+
+    /** Bin packing bound. */
+    BinPos bin_packing_bound = 0;
+
+    /** Variable-sized bin packing bound. */
+    Profit variable_sized_bin_packing_bound = 0;
+
+    virtual nlohmann::json to_json() const override
+    {
+        nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();
+        json["KnapsackBound"] = knapsack_bound;
+        json["BinPackingBound"] = bin_packing_bound;
+        json["VariableSizedBinPackingBound"] = variable_sized_bin_packing_bound;
+        return json;
+    }
+
+    virtual void format(std::ostream& os) const override
+    {
+        packingsolver::Output<Instance, Solution>::format(os);
+        int width = format_width();
+        os
+            << std::setw(width) << std::left << "Knapsack bound: " << knapsack_bound << std::endl
+            << std::setw(width) << std::left << "Bin packing bound: " << bin_packing_bound << std::endl
+            << std::setw(width) << std::left << "Variable-sized bin packing bound: " << variable_sized_bin_packing_bound << std::endl
+            ;
+    }
 };
 
-struct OptimizeParameters: packingsolver::Parameters<Instance, Solution>
+struct OptimizeParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     /** Optimization mode. */
     OptimizationMode optimization_mode = OptimizationMode::Anytime;

--- a/include/packingsolver/onedimensional/algorithm_formatter.hpp
+++ b/include/packingsolver/onedimensional/algorithm_formatter.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "packingsolver/onedimensional/solution.hpp"
+#include "packingsolver/onedimensional/optimize.hpp"
 
 #include <mutex>
 
@@ -17,8 +17,8 @@ public:
     /** Constructor. */
     AlgorithmFormatter(
             const Instance& instance,
-            const packingsolver::Parameters<Instance, Solution>& parameters,
-            packingsolver::Output<Instance, Solution>& output):
+            const packingsolver::Parameters<Instance, Solution, Output>& parameters,
+            Output& output):
         instance_(instance),
         parameters_(parameters),
         output_(output),
@@ -71,7 +71,7 @@ public:
 
     /** Update all applicable bounds from another output. */
     void update_bounds(
-            const packingsolver::Output<Instance, Solution>& output);
+            const Output& output);
 
     /** Method to call at the end of the algorithm. */
     void end();
@@ -85,10 +85,10 @@ private:
     const Instance& instance_;
 
     /** Parameters. */
-    const packingsolver::Parameters<Instance, Solution>& parameters_;
+    const packingsolver::Parameters<Instance, Solution, Output>& parameters_;
 
     /** Output. */
-    packingsolver::Output<Instance, Solution>& output_;
+    Output& output_;
 
     /** Output stream. */
     std::unique_ptr<optimizationtools::ComposeStream> os_;

--- a/include/packingsolver/onedimensional/optimize.hpp
+++ b/include/packingsolver/onedimensional/optimize.hpp
@@ -13,9 +13,38 @@ struct Output: packingsolver::Output<Instance, Solution>
 {
     Output(const Instance& instance):
         packingsolver::Output<Instance, Solution>(instance) { }
+
+    /** Knapsack bound. */
+    Profit knapsack_bound = std::numeric_limits<Profit>::infinity();
+
+    /** Bin packing bound. */
+    BinPos bin_packing_bound = 0;
+
+    /** Variable-sized bin packing bound. */
+    Profit variable_sized_bin_packing_bound = 0;
+
+    virtual nlohmann::json to_json() const override
+    {
+        nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();
+        json["KnapsackBound"] = knapsack_bound;
+        json["BinPackingBound"] = bin_packing_bound;
+        json["VariableSizedBinPackingBound"] = variable_sized_bin_packing_bound;
+        return json;
+    }
+
+    virtual void format(std::ostream& os) const override
+    {
+        packingsolver::Output<Instance, Solution>::format(os);
+        int width = format_width();
+        os
+            << std::setw(width) << std::left << "Knapsack bound: " << knapsack_bound << std::endl
+            << std::setw(width) << std::left << "Bin packing bound: " << bin_packing_bound << std::endl
+            << std::setw(width) << std::left << "Variable-sized bin packing bound: " << variable_sized_bin_packing_bound << std::endl
+            ;
+    }
 };
 
-struct OptimizeParameters: packingsolver::Parameters<Instance, Solution>
+struct OptimizeParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     /** Optimization mode. */
     OptimizationMode optimization_mode = OptimizationMode::Anytime;

--- a/include/packingsolver/rectangle/algorithm_formatter.hpp
+++ b/include/packingsolver/rectangle/algorithm_formatter.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "packingsolver/rectangle/solution.hpp"
+#include "packingsolver/rectangle/optimize.hpp"
 
 #include <mutex>
 
@@ -17,8 +17,8 @@ public:
     /** Constructor. */
     AlgorithmFormatter(
             const Instance& instance,
-            const packingsolver::Parameters<Instance, Solution>& parameters,
-            packingsolver::Output<Instance, Solution>& output):
+            const packingsolver::Parameters<Instance, Solution, Output>& parameters,
+            Output& output):
         instance_(instance),
         parameters_(parameters),
         output_(output),
@@ -49,7 +49,7 @@ public:
 
     /** Update all applicable bounds from another output. */
     void update_bounds(
-            const packingsolver::Output<Instance, Solution>& output);
+            const Output& output);
 
     /** Method to call at the end of the algorithm. */
     void end();
@@ -63,10 +63,10 @@ private:
     const Instance& instance_;
 
     /** Parameters. */
-    const packingsolver::Parameters<Instance, Solution>& parameters_;
+    const packingsolver::Parameters<Instance, Solution, Output>& parameters_;
 
     /** Output. */
-    packingsolver::Output<Instance, Solution>& output_;
+    Output& output_;
 
     /** Output stream. */
     std::unique_ptr<optimizationtools::ComposeStream> os_;

--- a/include/packingsolver/rectangle/optimize.hpp
+++ b/include/packingsolver/rectangle/optimize.hpp
@@ -13,9 +13,38 @@ struct Output: packingsolver::Output<Instance, Solution>
 {
     Output(const Instance& instance):
         packingsolver::Output<Instance, Solution>(instance) { }
+
+    /** Knapsack bound. */
+    Profit knapsack_bound = std::numeric_limits<Profit>::infinity();
+
+    /** Bin packing bound. */
+    BinPos bin_packing_bound = 0;
+
+    /** Variable-sized bin packing bound. */
+    Profit variable_sized_bin_packing_bound = 0;
+
+    virtual nlohmann::json to_json() const override
+    {
+        nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();
+        json["KnapsackBound"] = knapsack_bound;
+        json["BinPackingBound"] = bin_packing_bound;
+        json["VariableSizedBinPackingBound"] = variable_sized_bin_packing_bound;
+        return json;
+    }
+
+    virtual void format(std::ostream& os) const override
+    {
+        packingsolver::Output<Instance, Solution>::format(os);
+        int width = format_width();
+        os
+            << std::setw(width) << std::left << "Knapsack bound: " << knapsack_bound << std::endl
+            << std::setw(width) << std::left << "Bin packing bound: " << bin_packing_bound << std::endl
+            << std::setw(width) << std::left << "Variable-sized bin packing bound: " << variable_sized_bin_packing_bound << std::endl
+            ;
+    }
 };
 
-struct OptimizeParameters: packingsolver::Parameters<Instance, Solution>
+struct OptimizeParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     /** Optimization mode. */
     OptimizationMode optimization_mode = OptimizationMode::Anytime;

--- a/include/packingsolver/rectangleguillotine/algorithm_formatter.hpp
+++ b/include/packingsolver/rectangleguillotine/algorithm_formatter.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "packingsolver/rectangleguillotine/solution.hpp"
+#include "packingsolver/rectangleguillotine/optimize.hpp"
 
 #include <mutex>
 
@@ -17,8 +17,8 @@ public:
     /** Constructor. */
     AlgorithmFormatter(
             const Instance& instance,
-            const packingsolver::Parameters<Instance, Solution>& parameters,
-            packingsolver::Output<Instance, Solution>& output):
+            const packingsolver::Parameters<Instance, Solution, Output>& parameters,
+            Output& output):
         instance_(instance),
         parameters_(parameters),
         output_(output),
@@ -70,7 +70,7 @@ public:
 
     /** Update all applicable bounds from another output. */
     void update_bounds(
-            const packingsolver::Output<Instance, Solution>& output);
+            const Output& output);
 
     /** Method to call at the end of the algorithm. */
     void end();
@@ -78,7 +78,7 @@ public:
     /** Get end boolean. */
     bool& end_boolean() { return end_; };
 
-    const packingsolver::Output<Instance, Solution>& output() const { return output_; }
+    const Output& output() const { return output_; }
 
 private:
 
@@ -86,10 +86,10 @@ private:
     const Instance& instance_;
 
     /** Parameters. */
-    const packingsolver::Parameters<Instance, Solution>& parameters_;
+    const packingsolver::Parameters<Instance, Solution, Output>& parameters_;
 
     /** Output. */
-    packingsolver::Output<Instance, Solution>& output_;
+    Output& output_;
 
     /** Output stream. */
     std::unique_ptr<optimizationtools::ComposeStream> os_;

--- a/include/packingsolver/rectangleguillotine/optimize.hpp
+++ b/include/packingsolver/rectangleguillotine/optimize.hpp
@@ -13,9 +13,48 @@ struct Output: packingsolver::Output<Instance, Solution>
 {
     Output(const Instance& instance):
         packingsolver::Output<Instance, Solution>(instance) { }
+
+    /** Knapsack bound. */
+    Profit knapsack_bound = std::numeric_limits<Profit>::infinity();
+
+    /** Bin packing bound. */
+    BinPos bin_packing_bound = 0;
+
+    /** Variable-sized bin packing bound. */
+    Profit variable_sized_bin_packing_bound = 0;
+
+    /** Open dimension X bound. */
+    Length open_dimension_x_bound = 0;
+
+    /** Open dimension Y bound. */
+    Length open_dimension_y_bound = 0;
+
+    virtual nlohmann::json to_json() const override
+    {
+        nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();
+        json["KnapsackBound"] = knapsack_bound;
+        json["BinPackingBound"] = bin_packing_bound;
+        json["VariableSizedBinPackingBound"] = variable_sized_bin_packing_bound;
+        json["OpenDimensionXBound"] = open_dimension_x_bound;
+        json["OpenDimensionYBound"] = open_dimension_y_bound;
+        return json;
+    }
+
+    virtual void format(std::ostream& os) const override
+    {
+        packingsolver::Output<Instance, Solution>::format(os);
+        int width = format_width();
+        os
+            << std::setw(width) << std::left << "Knapsack bound: " << knapsack_bound << std::endl
+            << std::setw(width) << std::left << "Bin packing bound: " << bin_packing_bound << std::endl
+            << std::setw(width) << std::left << "Variable-sized bin packing bound: " << variable_sized_bin_packing_bound << std::endl
+            << std::setw(width) << std::left << "Open dimension X bound: " << open_dimension_x_bound << std::endl
+            << std::setw(width) << std::left << "Open dimension Y bound: " << open_dimension_y_bound << std::endl
+            ;
+    }
 };
 
-struct OptimizeParameters: packingsolver::Parameters<Instance, Solution>
+struct OptimizeParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     /** Optimization mode. */
     OptimizationMode optimization_mode = OptimizationMode::Anytime;

--- a/src/algorithms/column_generation.hpp
+++ b/src/algorithms/column_generation.hpp
@@ -57,10 +57,10 @@ using Value = columngenerationsolver::Value;
 using Column = columngenerationsolver::Column;
 using PricingOutput = columngenerationsolver::PricingSolver::PricingOutput;
 
-template <typename Instance, typename InstanceBuilder, typename Solution>
-using ColumnGenerationPricingFunction = std::function<Output<Instance, Solution>(const Instance&)>;
+template <typename Instance, typename InstanceBuilder, typename Solution, typename Output = packingsolver::Output<Instance, Solution>>
+using ColumnGenerationPricingFunction = std::function<Output(const Instance&)>;
 
-template <typename Instance, typename InstanceBuilder, typename Solution>
+template <typename Instance, typename InstanceBuilder, typename Solution, typename Output = packingsolver::Output<Instance, Solution>>
 class ColumnGenerationPricingSolver: public columngenerationsolver::PricingSolver
 {
 
@@ -68,7 +68,7 @@ public:
 
     ColumnGenerationPricingSolver(
             const Instance& instance,
-            const ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution>& pricing_function):
+            const ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, Output>& pricing_function):
         instance_(instance),
         pricing_function_(pricing_function),
         fixed_bin_types_(instance.number_of_bin_types()),
@@ -86,7 +86,7 @@ private:
 
     const Instance& instance_;
 
-    ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution> pricing_function_;
+    ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, Output> pricing_function_;
 
     std::vector<BinPos> fixed_bin_types_;
 
@@ -97,10 +97,10 @@ private:
 
 };
 
-template <typename Instance, typename InstanceBuilder, typename Solution>
+template <typename Instance, typename InstanceBuilder, typename Solution, typename Output>
 columngenerationsolver::Model get_model(
         const Instance& instance,
-        const ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution>& pricing_function)
+        const ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, Output>& pricing_function)
 {
     columngenerationsolver::Model model;
 
@@ -149,12 +149,12 @@ columngenerationsolver::Model get_model(
 
     // Pricing solver.
     model.pricing_solver = std::unique_ptr<columngenerationsolver::PricingSolver>(
-            new ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution>(instance, pricing_function));
+            new ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>(instance, pricing_function));
     return model;
 }
 
-template <typename Instance, typename InstanceBuilder, typename Solution>
-std::vector<std::shared_ptr<const Column>> ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution>::initialize_pricing(
+template <typename Instance, typename InstanceBuilder, typename Solution, typename Output>
+std::vector<std::shared_ptr<const Column>> ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>::initialize_pricing(
         const std::vector<std::pair<std::shared_ptr<const Column>, Value>>& fixed_columns)
 {
     //std::cout << "initialize_pricing " << fixed_columns.size() << std::endl;
@@ -222,8 +222,8 @@ std::vector<std::shared_ptr<const Column>> solution_to_columns(
     return columns;
 }
 
-template <typename Instance, typename InstanceBuilder, typename Solution>
-PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution>::solve_pricing(
+template <typename Instance, typename InstanceBuilder, typename Solution, typename Output>
+PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>::solve_pricing(
             const std::vector<Value>& duals)
 {
     double multiplier_cost = largest_power_of_two_lesser_or_equal(instance_.largest_bin_cost());
@@ -359,15 +359,8 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution>
     return output;
 }
 
-template <typename Instance, typename Solution>
-struct ColumnGenerationOutput: packingsolver::Output<Instance, Solution>
-{
-    ColumnGenerationOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
-};
-
-template <typename Instance, typename Solution>
-struct ColumnGenerationParameters: packingsolver::Parameters<Instance, Solution>
+template <typename Instance, typename Solution, typename Output = packingsolver::Output<Instance, Solution>>
+struct ColumnGenerationParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     OptimizationMode optimization_mode = OptimizationMode::Anytime;
     int internal_diving = 1;
@@ -375,19 +368,19 @@ struct ColumnGenerationParameters: packingsolver::Parameters<Instance, Solution>
         = columngenerationsolver::SolverName::CLP;
 };
 
-template <typename Instance, typename InstanceBuilder, typename Solution, typename AlgorithmFormatter>
-ColumnGenerationOutput<Instance, Solution> column_generation(
+template <typename Instance, typename InstanceBuilder, typename Solution, typename AlgorithmFormatter, typename Output = packingsolver::Output<Instance, Solution>>
+Output column_generation(
         const Instance& instance,
-        const ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution>& pricing_function,
-        const ColumnGenerationParameters<Instance, Solution>& parameters = {})
+        const ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, Output>& pricing_function,
+        const ColumnGenerationParameters<Instance, Solution, Output>& parameters = {})
 {
-    ColumnGenerationOutput<Instance, Solution> output(instance);
+    Output output(instance);
     AlgorithmFormatter algorithm_formatter(instance, parameters, output);
     algorithm_formatter.start();
     algorithm_formatter.print_header();
 
     columngenerationsolver::Model cgs_model
-        = get_model<Instance, InstanceBuilder, Solution>(instance, pricing_function);
+        = get_model<Instance, InstanceBuilder, Solution, Output>(instance, pricing_function);
     columngenerationsolver::LimitedDiscrepancySearchParameters cgslds_parameters;
     cgslds_parameters.verbosity_level = 0;
     cgslds_parameters.timer = parameters.timer;

--- a/src/algorithms/dichotomic_search.hpp
+++ b/src/algorithms/dichotomic_search.hpp
@@ -51,12 +51,12 @@ double mean_item_type_copies(const Instance& instance)
 template <typename Instance, typename Solution>
 using DichotomicSearchFunction = std::function<SolutionPool<Instance, Solution>(const Instance&)>;
 
-template <typename Instance, typename Solution>
-struct DichotomicSearchOutput: Output<Instance, Solution>
+template <typename Instance, typename Solution, typename Output = packingsolver::Output<Instance, Solution>>
+struct DichotomicSearchOutput: Output
 {
     /** Constructor. */
     DichotomicSearchOutput(const Instance& instance):
-        Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 
 
     /** Lower bound on the waste percentage. */
@@ -69,8 +69,8 @@ struct DichotomicSearchOutput: Output<Instance, Solution>
     double waste_percentage_upper_bound = std::numeric_limits<double>::infinity();
 };
 
-template <typename Instance, typename Solution>
-struct DichotomicSearchParameters: Parameters<Instance, Solution>
+template <typename Instance, typename Solution, typename Output = packingsolver::Output<Instance, Solution>>
+struct DichotomicSearchParameters: Parameters<Instance, Solution, Output>
 {
     /** Initial waste percentage. */
     double initial_waste_percentage = 0.1;
@@ -79,13 +79,13 @@ struct DichotomicSearchParameters: Parameters<Instance, Solution>
     double initial_waste_percentage_upper_bound = std::numeric_limits<double>::infinity();
 };
 
-template <typename Instance, typename InstanceBuilder, typename Solution, typename AlgorithmFormatter>
-DichotomicSearchOutput<Instance, Solution> dichotomic_search(
+template <typename Instance, typename InstanceBuilder, typename Solution, typename AlgorithmFormatter, typename Output = packingsolver::Output<Instance, Solution>>
+DichotomicSearchOutput<Instance, Solution, Output> dichotomic_search(
         const Instance& instance,
         const DichotomicSearchFunction<Instance, Solution>& function,
-        const DichotomicSearchParameters<Instance, Solution>& parameters)
+        const DichotomicSearchParameters<Instance, Solution, Output>& parameters)
 {
-    DichotomicSearchOutput<Instance, Solution> output(instance);
+    DichotomicSearchOutput<Instance, Solution, Output> output(instance);
     AlgorithmFormatter algorithm_formatter(instance, parameters, output);
     algorithm_formatter.start();
     algorithm_formatter.print_header();

--- a/src/algorithms/sequential_value_correction.hpp
+++ b/src/algorithms/sequential_value_correction.hpp
@@ -47,12 +47,12 @@ namespace packingsolver
 template <typename Instance, typename Solution>
 using SequentialValueCorrectionFunction = std::function<SolutionPool<Instance, Solution>(const Instance&)>;
 
-template <typename Instance, typename Solution>
-struct SequentialValueCorrectionOutput: packingsolver::Output<Instance, Solution>
+template <typename Instance, typename Solution, typename Output = packingsolver::Output<Instance, Solution>>
+struct SequentialValueCorrectionOutput: Output
 {
     /** Constructor. */
     SequentialValueCorrectionOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 
 
     /** Number of iterations. */
@@ -62,8 +62,8 @@ struct SequentialValueCorrectionOutput: packingsolver::Output<Instance, Solution
     std::vector<Solution> all_patterns;
 };
 
-template <typename Instance, typename Solution>
-struct SequentialValueCorrectionParameters: packingsolver::Parameters<Instance, Solution>
+template <typename Instance, typename Solution, typename Output = packingsolver::Output<Instance, Solution>>
+struct SequentialValueCorrectionParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     /** Maximum number of iterations. */
     Counter maximum_number_of_iterations = -1;
@@ -79,13 +79,13 @@ struct SequentialValueCorrectionParameters: packingsolver::Parameters<Instance, 
     BinPos bin_packing_goal = 2;
 };
 
-template <typename Instance, typename InstanceBuilder, typename Solution, typename AlgorithmFormatter>
-SequentialValueCorrectionOutput<Instance, Solution> sequential_value_correction(
+template <typename Instance, typename InstanceBuilder, typename Solution, typename AlgorithmFormatter, typename Output = packingsolver::Output<Instance, Solution>>
+SequentialValueCorrectionOutput<Instance, Solution, Output> sequential_value_correction(
         const Instance& instance,
         const SequentialValueCorrectionFunction<Instance, Solution>& function,
-        const SequentialValueCorrectionParameters<Instance, Solution>& parameters)
+        const SequentialValueCorrectionParameters<Instance, Solution, Output>& parameters)
 {
-    SequentialValueCorrectionOutput<Instance, Solution> output(instance);
+    SequentialValueCorrectionOutput<Instance, Solution, Output> output(instance);
     AlgorithmFormatter algorithm_formatter(instance, parameters, output);
     algorithm_formatter.start();
     algorithm_formatter.print_header();

--- a/src/box/algorithm_formatter.cpp
+++ b/src/box/algorithm_formatter.cpp
@@ -296,7 +296,7 @@ void AlgorithmFormatter::update_bin_packing_bound(
 }
 
 void AlgorithmFormatter::update_bounds(
-        const packingsolver::Output<Instance, Solution>& output)
+        const Output& output)
 {
     switch (instance_.objective()) {
     case Objective::Knapsack:

--- a/src/box/main.cpp
+++ b/src/box/main.cpp
@@ -11,7 +11,7 @@ namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
 void read_args(
-        packingsolver::Parameters<Instance, Solution>& parameters,
+        packingsolver::Parameters<Instance, Solution, box::Output>& parameters,
         const po::variables_map& vm)
 {
     parameters.timer.set_sigint_handler();

--- a/src/box/optimize.cpp
+++ b/src/box/optimize.cpp
@@ -19,7 +19,7 @@ void optimize_tree_search(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        box::Output* local_output)
 {
     TreeSearchParameters ts_parameters;
     ts_parameters.verbosity_level = 0;
@@ -30,7 +30,7 @@ void optimize_tree_search(
     ts_parameters.not_anytime_tree_search_queue_size = parameters.not_anytime_tree_search_queue_size;
     ts_parameters.json_search_tree_path = parameters.json_search_tree_path;
     ts_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ts_output)
+            const box::Output& ts_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
@@ -46,7 +46,7 @@ void optimize_tree_search_maximal_spaces(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        box::Output* local_output)
 {
     TreeSearchMaximalSpacesParameters ts_ms_parameters;
     ts_ms_parameters.verbosity_level = 0;
@@ -55,7 +55,7 @@ void optimize_tree_search_maximal_spaces(
     ts_ms_parameters.optimization_mode = parameters.optimization_mode;
     ts_ms_parameters.not_anytime_tree_search_queue_size = parameters.not_anytime_tree_search_maximal_spaces_queue_size;
     ts_ms_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ts_output)
+            const box::Output& ts_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ts_output.solution_pool.best(), "TSMS " + ts_output.solution_pool.best_label());
@@ -70,7 +70,7 @@ void optimize_sequential_single_knapsack(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        box::Output* local_output)
 {
     for (Counter queue_size = 1;;) {
         NodeId queue_size_ms = queue_size;
@@ -96,17 +96,17 @@ void optimize_sequential_single_knapsack(
                 auto kp_output = optimize(kp_instance, kp_parameters);
                 return kp_output.solution_pool;
             };
-        SequentialValueCorrectionParameters<Instance, Solution> svc_parameters;
+        SequentialValueCorrectionParameters<Instance, Solution, box::Output> svc_parameters;
         svc_parameters.verbosity_level = 0;
         svc_parameters.timer = parameters.timer;
         svc_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
         svc_parameters.maximum_number_of_iterations = 1;
         svc_parameters.new_solution_callback = [
             &algorithm_formatter, local_output, &queue_size](
-                    const packingsolver::Output<Instance, Solution>& ps_output)
+                    const box::Output& ps_output)
             {
-                const SequentialValueCorrectionOutput<Instance, Solution>& pssvc_output
-                    = static_cast<const SequentialValueCorrectionOutput<Instance, Solution>&>(ps_output);
+                const SequentialValueCorrectionOutput<Instance, Solution, box::Output>& pssvc_output
+                    = static_cast<const SequentialValueCorrectionOutput<Instance, Solution, box::Output>&>(ps_output);
                 std::stringstream ss;
                 ss << "SSK q " << queue_size;
                 if (local_output != nullptr) {
@@ -115,7 +115,7 @@ void optimize_sequential_single_knapsack(
                     algorithm_formatter.update_solution(pssvc_output.solution_pool.best(), ss.str());
                 }
             };
-        sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, kp_solve, svc_parameters);
+        sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter, box::Output>(instance, kp_solve, svc_parameters);
 
         // Check end.
         if (algorithm_formatter.end_boolean())
@@ -136,7 +136,7 @@ void optimize_sequential_value_correction(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        box::Output* local_output)
 {
     SequentialValueCorrectionFunction<Instance, Solution> kp_solve
         = [&algorithm_formatter, &parameters](const Instance& kp_instance)
@@ -157,17 +157,17 @@ void optimize_sequential_value_correction(
             auto kp_output = optimize(kp_instance, kp_parameters);
             return kp_output.solution_pool;
         };
-    SequentialValueCorrectionParameters<Instance, Solution> svc_parameters;
+    SequentialValueCorrectionParameters<Instance, Solution, box::Output> svc_parameters;
     svc_parameters.verbosity_level = 0;
     svc_parameters.timer = parameters.timer;
     svc_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     if (parameters.optimization_mode != OptimizationMode::Anytime)
         svc_parameters.maximum_number_of_iterations = parameters.not_anytime_sequential_value_correction_number_of_iterations;
     svc_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const box::Output& ps_output)
     {
-        const SequentialValueCorrectionOutput<Instance, Solution>& pssvc_output
-            = static_cast<const SequentialValueCorrectionOutput<Instance, Solution>&>(ps_output);
+        const SequentialValueCorrectionOutput<Instance, Solution, box::Output>& pssvc_output
+            = static_cast<const SequentialValueCorrectionOutput<Instance, Solution, box::Output>&>(ps_output);
         std::stringstream ss;
         ss << "SVC it " << pssvc_output.number_of_iterations;
         if (local_output != nullptr) {
@@ -176,14 +176,14 @@ void optimize_sequential_value_correction(
             algorithm_formatter.update_solution(pssvc_output.solution_pool.best(), ss.str());
         }
     };
-    sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, kp_solve, svc_parameters);
+    sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter, box::Output>(instance, kp_solve, svc_parameters);
 }
 
 void optimize_dichotomic_search(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        box::Output* local_output)
 {
     double waste_percentage_upper_bound = std::numeric_limits<double>::infinity();
     for (Counter queue_size = 1;;) {
@@ -208,17 +208,17 @@ void optimize_dichotomic_search(
                 auto bpp_output = optimize(bpp_instance, bpp_parameters);
                 return bpp_output.solution_pool;
             };
-        DichotomicSearchParameters<Instance, Solution> ds_parameters;
+        DichotomicSearchParameters<Instance, Solution, box::Output> ds_parameters;
         ds_parameters.verbosity_level = 0;
         ds_parameters.timer = parameters.timer;
         ds_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
         ds_parameters.initial_waste_percentage_upper_bound = waste_percentage_upper_bound;
         ds_parameters.new_solution_callback = [
             &algorithm_formatter, local_output, &queue_size](
-                    const packingsolver::Output<Instance, Solution>& ps_output)
+                    const box::Output& ps_output)
             {
-                const DichotomicSearchOutput<Instance, Solution>& psds_output
-                    = static_cast<const DichotomicSearchOutput<Instance, Solution>&>(ps_output);
+                const DichotomicSearchOutput<Instance, Solution, box::Output>& psds_output
+                    = static_cast<const DichotomicSearchOutput<Instance, Solution, box::Output>&>(ps_output);
                 std::stringstream ss;
                 ss << "DS q " << queue_size
                     << " w " << psds_output.waste_percentage;
@@ -228,7 +228,7 @@ void optimize_dichotomic_search(
                     algorithm_formatter.update_solution(psds_output.solution_pool.best(), ss.str());
                 }
             };
-        auto ds_output = dichotomic_search<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, bpp_solve, ds_parameters);
+        auto ds_output = dichotomic_search<Instance, InstanceBuilder, Solution, AlgorithmFormatter, box::Output>(instance, bpp_solve, ds_parameters);
 
         // Check end.
         if (algorithm_formatter.end_boolean())
@@ -250,9 +250,9 @@ void optimize_column_generation(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        box::Output* local_output)
 {
-    ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution> pricing_function
+    ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, box::Output> pricing_function
         = [&algorithm_formatter, &parameters](const Instance& kp_instance)
         {
             OptimizeParameters kp_parameters;
@@ -271,14 +271,14 @@ void optimize_column_generation(
             return optimize(kp_instance, kp_parameters);
         };
 
-    ColumnGenerationParameters<Instance, Solution> cg_parameters;
+    ColumnGenerationParameters<Instance, Solution, box::Output> cg_parameters;
     cg_parameters.verbosity_level = 0;
     cg_parameters.timer = parameters.timer;
     cg_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     cg_parameters.optimization_mode = parameters.optimization_mode;
     cg_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
     cg_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const box::Output& ps_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
@@ -287,7 +287,7 @@ void optimize_column_generation(
         }
         algorithm_formatter.update_bounds(ps_output);
     };
-    column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, pricing_function, cg_parameters);
+    column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter, box::Output>(instance, pricing_function, cg_parameters);
 }
 
 }
@@ -296,7 +296,7 @@ packingsolver::box::Output packingsolver::box::optimize(
         const Instance& instance,
         const OptimizeParameters& parameters)
 {
-    Output output(instance);
+    box::Output output(instance);
     AlgorithmFormatter algorithm_formatter(instance, parameters, output);
     algorithm_formatter.start();
     algorithm_formatter.print_header();
@@ -463,16 +463,16 @@ packingsolver::box::Output packingsolver::box::optimize(
     // 'local_outputs' owns these; a 'unique_ptr' is used so that it growing
     // does not invalidate the raw pointers captured by the tasks below.
     bool deterministic = (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic);
-    std::vector<std::unique_ptr<packingsolver::Output<Instance, Solution>>> local_outputs;
+    std::vector<std::unique_ptr<box::Output>> local_outputs;
     std::vector<std::function<void()>> tasks;
     std::forward_list<std::exception_ptr> exception_ptr_list;
     // Tree search.
     if (use_tree_search) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<box::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<box::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_tree_search), optimize_tree_search>(
                     exception_ptr,
@@ -487,9 +487,9 @@ packingsolver::box::Output packingsolver::box::optimize(
     if (use_tree_search_maximal_spaces) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<box::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<box::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_tree_search_maximal_spaces), optimize_tree_search_maximal_spaces>(
                     exception_ptr,
@@ -504,9 +504,9 @@ packingsolver::box::Output packingsolver::box::optimize(
     if (use_sequential_single_knapsack) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<box::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<box::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_sequential_single_knapsack), optimize_sequential_single_knapsack>(
                     exception_ptr,
@@ -521,9 +521,9 @@ packingsolver::box::Output packingsolver::box::optimize(
     if (use_sequential_value_correction) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<box::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<box::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_sequential_value_correction), optimize_sequential_value_correction>(
                     exception_ptr,
@@ -538,9 +538,9 @@ packingsolver::box::Output packingsolver::box::optimize(
     if (use_dichotomic_search) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<box::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<box::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_dichotomic_search), optimize_dichotomic_search>(
                     exception_ptr,
@@ -555,9 +555,9 @@ packingsolver::box::Output packingsolver::box::optimize(
     if (use_column_generation) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<box::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<box::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_column_generation), optimize_column_generation>(
                     exception_ptr,

--- a/src/box/tree_search.hpp
+++ b/src/box/tree_search.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "packingsolver/box/solution.hpp"
+#include "packingsolver/box/optimize.hpp"
 #include "box/instance_flipper.hpp"
 
 #include "optimizationtools/utils/utils.hpp"
@@ -532,13 +532,13 @@ namespace packingsolver
 namespace box
 {
 
-struct TreeSearchOutput: packingsolver::Output<Instance, Solution>
+struct TreeSearchOutput: Output
 {
     TreeSearchOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution>
+struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     std::vector<GuideId> guides;
 

--- a/src/box/tree_search_maximal_spaces.hpp
+++ b/src/box/tree_search_maximal_spaces.hpp
@@ -633,20 +633,20 @@ inline bool BranchingSchemeMaximalSpaces::operator()(
 } // namespace box
 } // namespace packingsolver
 
-#include "packingsolver/box/solution.hpp"
+#include "packingsolver/box/optimize.hpp"
 
 namespace packingsolver
 {
 namespace box
 {
 
-struct TreeSearchMaximalSpacesOutput: packingsolver::Output<Instance, Solution>
+struct TreeSearchMaximalSpacesOutput: Output
 {
     TreeSearchMaximalSpacesOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct TreeSearchMaximalSpacesParameters: packingsolver::Parameters<Instance, Solution>
+struct TreeSearchMaximalSpacesParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     OptimizationMode optimization_mode = OptimizationMode::Anytime;
 

--- a/src/boxstacks/main.cpp
+++ b/src/boxstacks/main.cpp
@@ -11,7 +11,7 @@ namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
 void read_args(
-        packingsolver::Parameters<Instance, Solution>& parameters,
+        packingsolver::Parameters<Instance, Solution, boxstacks::Output>& parameters,
         const po::variables_map& vm)
 {
     parameters.timer.set_sigint_handler();

--- a/src/boxstacks/optimize.cpp
+++ b/src/boxstacks/optimize.cpp
@@ -32,7 +32,7 @@ packingsolver::boxstacks::Output packingsolver::boxstacks::optimize(
         //sor_parameters.info.set_verbosity_level(2);
         sor_parameters.new_solution_callback = [
             &algorithm_formatter](
-                    const packingsolver::Output<Instance, Solution>& ps_output)
+                    const boxstacks::Output& ps_output)
             {
                 const SequentialOneDimensionalRectangleOutput& sor_output
                     = static_cast<const SequentialOneDimensionalRectangleOutput&>(ps_output);
@@ -120,7 +120,7 @@ packingsolver::boxstacks::Output packingsolver::boxstacks::optimize(
             ts_parameters.guides = parameters.tree_search_guides;
             ts_parameters.maximum_number_of_selected_items = output.sequential_onedimensional_rectangle_number_of_items;
             ts_parameters.new_solution_callback = [&algorithm_formatter](
-                    const packingsolver::Output<Instance, Solution>& ts_output)
+                    const boxstacks::Output& ts_output)
             {
                 algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
             };
@@ -177,20 +177,20 @@ packingsolver::boxstacks::Output packingsolver::boxstacks::optimize(
                 output.number_of_tree_search_better += kp_output.number_of_tree_search_better;
                 return kp_output.solution_pool;
             };
-        SequentialValueCorrectionParameters<Instance, Solution> svc_parameters;
+        SequentialValueCorrectionParameters<Instance, Solution, boxstacks::Output> svc_parameters;
         svc_parameters.verbosity_level = 0;
         svc_parameters.timer = parameters.timer;
         svc_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
         svc_parameters.new_solution_callback = [&algorithm_formatter](
-                const packingsolver::Output<Instance, Solution>& ps_output)
+                const boxstacks::Output& ps_output)
         {
-            const SequentialValueCorrectionOutput<Instance, Solution>& pssvc_output
-                = static_cast<const SequentialValueCorrectionOutput<Instance, Solution>&>(ps_output);
+            const SequentialValueCorrectionOutput<Instance, Solution, boxstacks::Output>& pssvc_output
+                = static_cast<const SequentialValueCorrectionOutput<Instance, Solution, boxstacks::Output>&>(ps_output);
             std::stringstream ss;
             ss << "iteration " << pssvc_output.number_of_iterations;
             algorithm_formatter.update_solution(pssvc_output.solution_pool.best(), ss.str());
         };
-        auto svc_output = sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, kp_solve, svc_parameters);
+        auto svc_output = sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter, boxstacks::Output>(instance, kp_solve, svc_parameters);
 
     }
 

--- a/src/boxstacks/sequential_onedimensional_rectangle.hpp
+++ b/src/boxstacks/sequential_onedimensional_rectangle.hpp
@@ -13,7 +13,7 @@
 
 #pragma once
 
-#include "packingsolver/boxstacks/solution.hpp"
+#include "packingsolver/boxstacks/optimize.hpp"
 
 #include "packingsolver/onedimensional/optimize.hpp"
 
@@ -22,11 +22,11 @@ namespace packingsolver
 namespace boxstacks
 {
 
-struct SequentialOneDimensionalRectangleOutput: packingsolver::Output<Instance, Solution>
+struct SequentialOneDimensionalRectangleOutput: Output
 {
     /** Constructor. */
     SequentialOneDimensionalRectangleOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 
 
     /** Number of iterations. */
@@ -60,7 +60,7 @@ struct SequentialOneDimensionalRectangleOutput: packingsolver::Output<Instance, 
     double rectangle_time = 0.0;
 };
 
-struct SequentialOneDimensionalRectangleParameters: packingsolver::Parameters<Instance, Solution>
+struct SequentialOneDimensionalRectangleParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     bool sequential = true;
 

--- a/src/boxstacks/tree_search.hpp
+++ b/src/boxstacks/tree_search.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "packingsolver/boxstacks/solution.hpp"
+#include "packingsolver/boxstacks/optimize.hpp"
 #include "boxstacks/instance_flipper.hpp"
 
 #include "optimizationtools/utils/utils.hpp"
@@ -673,13 +673,13 @@ namespace packingsolver
 namespace boxstacks
 {
 
-struct TreeSearchOutput: packingsolver::Output<Instance, Solution>
+struct TreeSearchOutput: Output
 {
     TreeSearchOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution>
+struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     std::vector<GuideId> guides;
 

--- a/src/irregular/algorithm_formatter.cpp
+++ b/src/irregular/algorithm_formatter.cpp
@@ -334,7 +334,7 @@ void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
 }
 
 void AlgorithmFormatter::update_bounds(
-        const packingsolver::Output<Instance, Solution>& output)
+        const Output& output)
 {
     switch (instance_.objective()) {
     case Objective::Knapsack:

--- a/src/irregular/large_item_first.hpp
+++ b/src/irregular/large_item_first.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include "packingsolver/irregular/solution.hpp"
+#include "packingsolver/irregular/optimize.hpp"
 
 #include "columngenerationsolver/commons.hpp"
 
@@ -21,14 +21,14 @@ namespace packingsolver
 namespace irregular
 {
 
-struct LargeItemFirstOutput: packingsolver::Output<Instance, Solution>
+struct LargeItemFirstOutput: Output
 {
     /** Constructor. */
     LargeItemFirstOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct LargeItemFirstParameters: packingsolver::Parameters<Instance, Solution>
+struct LargeItemFirstParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     /** Linear programming solver. */
     columngenerationsolver::SolverName linear_programming_solver_name

--- a/src/irregular/local_search.hpp
+++ b/src/irregular/local_search.hpp
@@ -7,21 +7,21 @@
 
 #pragma once
 
-#include "packingsolver/irregular/solution.hpp"
+#include "packingsolver/irregular/optimize.hpp"
 
 namespace packingsolver
 {
 namespace irregular
 {
 
-struct LocalSearchOutput: packingsolver::Output<Instance, Solution>
+struct LocalSearchOutput: Output
 {
     /** Constructor. */
     LocalSearchOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct LocalSearchParameters: packingsolver::Parameters<Instance, Solution>
+struct LocalSearchParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     /** Seed for the random number generator. */
     Seed seed = 0;

--- a/src/irregular/main.cpp
+++ b/src/irregular/main.cpp
@@ -9,7 +9,7 @@ using namespace packingsolver::irregular;
 namespace po = boost::program_options;
 
 void read_args(
-        packingsolver::Parameters<Instance, Solution>& parameters,
+        packingsolver::Parameters<Instance, Solution, irregular::Output>& parameters,
         const po::variables_map& vm)
 {
     parameters.timer.set_sigint_handler();

--- a/src/irregular/milp_raster.hpp
+++ b/src/irregular/milp_raster.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "packingsolver/irregular/solution.hpp"
+#include "packingsolver/irregular/optimize.hpp"
 
 #include "mathoptsolverscmake/mathopt.hpp"
 
@@ -16,14 +16,14 @@ namespace packingsolver
 namespace irregular
 {
 
-struct MilpRasterOutput: packingsolver::Output<Instance, Solution>
+struct MilpRasterOutput: Output
 {
     /** Constructor. */
     MilpRasterOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct MilpRasterParameters: packingsolver::Parameters<Instance, Solution>
+struct MilpRasterParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     /** MILP solver. */
     mathoptsolverscmake::SolverName solver

--- a/src/irregular/optimize.cpp
+++ b/src/irregular/optimize.cpp
@@ -92,7 +92,7 @@ void optimize_trivial_single_item(
     trivial_single_item_parameters.timer = parameters.timer;
     trivial_single_item_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     trivial_single_item_parameters.new_solution_callback = [&algorithm_formatter](
-            const packingsolver::Output<Instance, Solution>& output) {
+            const irregular::Output& output) {
         algorithm_formatter.update_solution(
                 output.solution_pool.best(),
                 "Trivial");
@@ -104,7 +104,7 @@ void optimize_tree_search(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        irregular::Output* local_output)
 {
     TreeSearchParameters ts_parameters;
     ts_parameters.verbosity_level = 0;
@@ -118,7 +118,7 @@ void optimize_tree_search(
     ts_parameters.maximum_approximation_ratio_factor = parameters.maximum_approximation_ratio_factor;
     ts_parameters.json_search_tree_path = parameters.json_search_tree_path;
     ts_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ts_output)
+            const irregular::Output& ts_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
@@ -133,13 +133,13 @@ void optimize_local_search(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        irregular::Output* local_output)
 {
     LocalSearchParameters ls_parameters;
     ls_parameters.verbosity_level = 0;
     ls_parameters.timer = parameters.timer;
     ls_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const irregular::Output& ps_output)
     {
         std::stringstream ss;
         ss << "LS";
@@ -157,7 +157,7 @@ void optimize_sequential_single_knapsack(
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
         Counter queue_size_max,
-        packingsolver::Output<Instance, Solution>* local_output)
+        irregular::Output* local_output)
 {
     double maximum_approximation_ratio = parameters.initial_maximum_approximation_ratio;
     for (Counter queue_size = 1;;) {
@@ -189,17 +189,17 @@ void optimize_sequential_single_knapsack(
                 auto kp_output = optimize(kp_instance, kp_parameters);
                 return kp_output.solution_pool;
             };
-        SequentialValueCorrectionParameters<Instance, Solution> svc_parameters;
+        SequentialValueCorrectionParameters<Instance, Solution, irregular::Output> svc_parameters;
         svc_parameters.verbosity_level = 0;
         svc_parameters.timer = parameters.timer;
         svc_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
         svc_parameters.maximum_number_of_iterations = 1;
         svc_parameters.new_solution_callback = [
             &algorithm_formatter, local_output, &queue_size](
-                    const packingsolver::Output<Instance, Solution>& ps_output)
+                    const irregular::Output& ps_output)
             {
-                const SequentialValueCorrectionOutput<Instance, Solution>& pssvc_output
-                    = static_cast<const SequentialValueCorrectionOutput<Instance, Solution>&>(ps_output);
+                const SequentialValueCorrectionOutput<Instance, Solution, irregular::Output>& pssvc_output
+                    = static_cast<const SequentialValueCorrectionOutput<Instance, Solution, irregular::Output>&>(ps_output);
                 std::stringstream ss;
                 ss << "SSK q " << queue_size;
                 if (local_output != nullptr) {
@@ -208,7 +208,7 @@ void optimize_sequential_single_knapsack(
                     algorithm_formatter.update_solution(pssvc_output.solution_pool.best(), ss.str());
                 }
             };
-        sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, kp_solve, svc_parameters);
+        sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter, irregular::Output>(instance, kp_solve, svc_parameters);
 
         // Check end.
         if (algorithm_formatter.end_boolean())
@@ -232,7 +232,7 @@ void optimize_sequential_value_correction(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        irregular::Output* local_output)
 {
     if (parameters.optimization_mode == OptimizationMode::Anytime) {
         optimize_sequential_single_knapsack(
@@ -261,17 +261,17 @@ void optimize_sequential_value_correction(
             auto kp_output = optimize(kp_instance, kp_parameters);
             return kp_output.solution_pool;
         };
-    SequentialValueCorrectionParameters<Instance, Solution> svc_parameters;
+    SequentialValueCorrectionParameters<Instance, Solution, irregular::Output> svc_parameters;
     svc_parameters.verbosity_level = 0;
     svc_parameters.timer = parameters.timer;
     svc_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     if (parameters.optimization_mode != OptimizationMode::Anytime)
         svc_parameters.maximum_number_of_iterations = parameters.not_anytime_sequential_value_correction_number_of_iterations;
     svc_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const irregular::Output& ps_output)
     {
-        const SequentialValueCorrectionOutput<Instance, Solution>& pssvc_output
-            = static_cast<const SequentialValueCorrectionOutput<Instance, Solution>&>(ps_output);
+        const SequentialValueCorrectionOutput<Instance, Solution, irregular::Output>& pssvc_output
+            = static_cast<const SequentialValueCorrectionOutput<Instance, Solution, irregular::Output>&>(ps_output);
         std::stringstream ss;
         ss << "SVC it " << pssvc_output.number_of_iterations;
         if (local_output != nullptr) {
@@ -280,14 +280,14 @@ void optimize_sequential_value_correction(
             algorithm_formatter.update_solution(pssvc_output.solution_pool.best(), ss.str());
         }
     };
-    sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, kp_solve, svc_parameters);
+    sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter, irregular::Output>(instance, kp_solve, svc_parameters);
 }
 
 void optimize_dichotomic_search(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        irregular::Output* local_output)
 {
     double waste_percentage_upper_bound = std::numeric_limits<double>::infinity();
     double maximum_approximation_ratio = parameters.initial_maximum_approximation_ratio;
@@ -316,17 +316,17 @@ void optimize_dichotomic_search(
                 auto bpp_output = optimize(bpp_instance, bpp_parameters);
                 return bpp_output.solution_pool;
             };
-        DichotomicSearchParameters<Instance, Solution> ds_parameters;
+        DichotomicSearchParameters<Instance, Solution, irregular::Output> ds_parameters;
         ds_parameters.verbosity_level = 0;
         ds_parameters.timer = parameters.timer;
         ds_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
         ds_parameters.initial_waste_percentage_upper_bound = waste_percentage_upper_bound;
         ds_parameters.new_solution_callback = [
             &algorithm_formatter, local_output, &queue_size](
-                    const packingsolver::Output<Instance, Solution>& ps_output)
+                    const irregular::Output& ps_output)
             {
-                const DichotomicSearchOutput<Instance, Solution>& psds_output
-                    = static_cast<const DichotomicSearchOutput<Instance, Solution>&>(ps_output);
+                const DichotomicSearchOutput<Instance, Solution, irregular::Output>& psds_output
+                    = static_cast<const DichotomicSearchOutput<Instance, Solution, irregular::Output>&>(ps_output);
                 std::stringstream ss;
                 ss << "DS q " << queue_size
                     << " w " << psds_output.waste_percentage;
@@ -336,7 +336,7 @@ void optimize_dichotomic_search(
                     algorithm_formatter.update_solution(psds_output.solution_pool.best(), ss.str());
                 }
             };
-        auto ds_output = dichotomic_search<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, bpp_solve, ds_parameters);
+        auto ds_output = dichotomic_search<Instance, InstanceBuilder, Solution, AlgorithmFormatter, irregular::Output>(instance, bpp_solve, ds_parameters);
 
         // Check end.
         if (algorithm_formatter.end_boolean())
@@ -362,9 +362,9 @@ void optimize_column_generation(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        irregular::Output* local_output)
 {
-    ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution> pricing_function
+    ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, irregular::Output> pricing_function
         = [&algorithm_formatter, &parameters](const Instance& kp_instance)
         {
             OptimizeParameters kp_parameters;
@@ -383,14 +383,14 @@ void optimize_column_generation(
             return optimize(kp_instance, kp_parameters);
         };
 
-    ColumnGenerationParameters<Instance, Solution> cg_parameters;
+    ColumnGenerationParameters<Instance, Solution, irregular::Output> cg_parameters;
     cg_parameters.verbosity_level = 0;
     cg_parameters.timer = parameters.timer;
     cg_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     cg_parameters.optimization_mode = parameters.optimization_mode;
     cg_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
     cg_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const irregular::Output& ps_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
@@ -399,21 +399,21 @@ void optimize_column_generation(
         }
         algorithm_formatter.update_bounds(ps_output);
     };
-    column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, pricing_function, cg_parameters);
+    column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter, irregular::Output>(instance, pricing_function, cg_parameters);
 }
 
 void optimize_milp_raster(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        irregular::Output* local_output)
 {
     MilpRasterParameters milp_raster_parameters;
     milp_raster_parameters.verbosity_level = 0;
     milp_raster_parameters.timer = parameters.timer;
     milp_raster_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     milp_raster_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& output) {
+            const irregular::Output& output) {
         if (local_output != nullptr) {
             local_output->solution_pool.add(output.solution_pool.best(), "MILP raster");
         } else {
@@ -641,16 +641,16 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
     // 'local_outputs' owns these; a 'unique_ptr' is used so that it growing
     // does not invalidate the raw pointers captured by the tasks below.
     bool deterministic = (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic);
-    std::vector<std::unique_ptr<packingsolver::Output<Instance, Solution>>> local_outputs;
+    std::vector<std::unique_ptr<irregular::Output>> local_outputs;
     std::vector<std::function<void()>> tasks;
     std::forward_list<std::exception_ptr> exception_ptr_list;
     // Tree search.
     if (use_tree_search) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<irregular::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<irregular::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_tree_search), optimize_tree_search>(
                     exception_ptr,
@@ -665,9 +665,9 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
     if (use_milp_raster) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<irregular::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<irregular::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_milp_raster), optimize_milp_raster>(
                     exception_ptr,
@@ -682,9 +682,9 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
     if (use_local_search) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<irregular::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<irregular::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_local_search), optimize_local_search>(
                     exception_ptr,
@@ -699,9 +699,9 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
     if (use_sequential_single_knapsack) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<irregular::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<irregular::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_sequential_single_knapsack), optimize_sequential_single_knapsack>(
                     exception_ptr,
@@ -717,9 +717,9 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
     if (use_sequential_value_correction) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<irregular::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<irregular::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_sequential_value_correction), optimize_sequential_value_correction>(
                     exception_ptr,
@@ -734,9 +734,9 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
     if (use_dichotomic_search) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<irregular::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<irregular::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_dichotomic_search), optimize_dichotomic_search>(
                     exception_ptr,
@@ -751,9 +751,9 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
     if (use_column_generation) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<irregular::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<irregular::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_column_generation), optimize_column_generation>(
                     exception_ptr,

--- a/src/irregular/sequential_feasibility.hpp
+++ b/src/irregular/sequential_feasibility.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include "packingsolver/irregular/solution.hpp"
+#include "packingsolver/irregular/optimize.hpp"
 
 #include <functional>
 
@@ -23,14 +23,14 @@ namespace irregular
 
 using SequentialFeasibilitySolver = std::function<SolutionPool<Instance, Solution>(const Instance&)>;
 
-struct SequentialFeasibilityOutput: packingsolver::Output<Instance, Solution>
+struct SequentialFeasibilityOutput: Output
 {
     /** Constructor. */
     SequentialFeasibilityOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct SequentialFeasibilityParameters: packingsolver::Parameters<Instance, Solution>
+struct SequentialFeasibilityParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
 };
 

--- a/src/irregular/tree_search.hpp
+++ b/src/irregular/tree_search.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "packingsolver/irregular/solution.hpp"
+#include "packingsolver/irregular/optimize.hpp"
 
 #include "irregular/rotations.hpp"
 #include "shape_simplification.hpp"
@@ -736,13 +736,13 @@ namespace packingsolver
 namespace irregular
 {
 
-struct TreeSearchOutput: packingsolver::Output<Instance, Solution>
+struct TreeSearchOutput: Output
 {
     TreeSearchOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution>
+struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     std::vector<GuideId> guides;
 

--- a/src/irregular/trivial.hpp
+++ b/src/irregular/trivial.hpp
@@ -1,19 +1,19 @@
 #pragma once
 
-#include "packingsolver/irregular/solution.hpp"
+#include "packingsolver/irregular/optimize.hpp"
 
 namespace packingsolver
 {
 namespace irregular
 {
 
-struct TrivialSingleItemOutput: packingsolver::Output<Instance, Solution>
+struct TrivialSingleItemOutput: Output
 {
     TrivialSingleItemOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct TrivialSingleItemParameters: packingsolver::Parameters<Instance, Solution>
+struct TrivialSingleItemParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
 };
 

--- a/src/onedimensional/algorithm_formatter.cpp
+++ b/src/onedimensional/algorithm_formatter.cpp
@@ -287,7 +287,7 @@ void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
 }
 
 void AlgorithmFormatter::update_bounds(
-        const packingsolver::Output<Instance, Solution>& output)
+        const Output& output)
 {
     switch (instance_.objective()) {
     case Objective::Knapsack:

--- a/src/onedimensional/main.cpp
+++ b/src/onedimensional/main.cpp
@@ -11,7 +11,7 @@ namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
 void read_args(
-        packingsolver::Parameters<Instance, Solution>& parameters,
+        packingsolver::Parameters<Instance, Solution, onedimensional::Output>& parameters,
         const po::variables_map& vm)
 {
     parameters.timer.set_sigint_handler();

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -83,7 +83,7 @@ void optimize_tree_search(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        onedimensional::Output* local_output)
 {
     TreeSearchParameters ts_parameters;
     ts_parameters.verbosity_level = 0;
@@ -94,7 +94,7 @@ void optimize_tree_search(
     ts_parameters.not_anytime_tree_search_queue_size = parameters.not_anytime_tree_search_queue_size;
     ts_parameters.json_search_tree_path = parameters.json_search_tree_path;
     ts_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ts_output)
+            const onedimensional::Output& ts_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
@@ -110,7 +110,7 @@ void optimize_sequential_single_knapsack(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        onedimensional::Output* local_output)
 {
     for (Counter queue_size = 1;;) {
 
@@ -133,17 +133,17 @@ void optimize_sequential_single_knapsack(
                 auto kp_output = optimize(kp_instance, kp_parameters);
                 return kp_output.solution_pool;
             };
-        SequentialValueCorrectionParameters<Instance, Solution> svc_parameters;
+        SequentialValueCorrectionParameters<Instance, Solution, onedimensional::Output> svc_parameters;
         svc_parameters.verbosity_level = 0;
         svc_parameters.timer = parameters.timer;
         svc_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
         svc_parameters.maximum_number_of_iterations = 1;
         svc_parameters.new_solution_callback = [
             &algorithm_formatter, local_output, &queue_size](
-                    const packingsolver::Output<Instance, Solution>& ps_output)
+                    const onedimensional::Output& ps_output)
             {
-                const SequentialValueCorrectionOutput<Instance, Solution>& pssvc_output
-                    = static_cast<const SequentialValueCorrectionOutput<Instance, Solution>&>(ps_output);
+                const SequentialValueCorrectionOutput<Instance, Solution, onedimensional::Output>& pssvc_output
+                    = static_cast<const SequentialValueCorrectionOutput<Instance, Solution, onedimensional::Output>&>(ps_output);
                 std::stringstream ss;
                 ss << "SSK q " << queue_size;
                 if (local_output != nullptr) {
@@ -152,7 +152,7 @@ void optimize_sequential_single_knapsack(
                     algorithm_formatter.update_solution(pssvc_output.solution_pool.best(), ss.str());
                 }
             };
-        sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, kp_solve, svc_parameters);
+        sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter, onedimensional::Output>(instance, kp_solve, svc_parameters);
 
         // Check end.
         if (algorithm_formatter.end_boolean())
@@ -173,7 +173,7 @@ void optimize_sequential_value_correction(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        onedimensional::Output* local_output)
 {
     SequentialValueCorrectionFunction<Instance, Solution> kp_solve
         = [&algorithm_formatter, &parameters](const Instance& kp_instance)
@@ -192,17 +192,17 @@ void optimize_sequential_value_correction(
             auto kp_output = optimize(kp_instance, kp_parameters);
             return kp_output.solution_pool;
         };
-    SequentialValueCorrectionParameters<Instance, Solution> svc_parameters;
+    SequentialValueCorrectionParameters<Instance, Solution, onedimensional::Output> svc_parameters;
     svc_parameters.verbosity_level = 0;
     svc_parameters.timer = parameters.timer;
     svc_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     if (parameters.optimization_mode != OptimizationMode::Anytime)
         svc_parameters.maximum_number_of_iterations = parameters.not_anytime_sequential_value_correction_number_of_iterations;
     svc_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const onedimensional::Output& ps_output)
     {
-        const SequentialValueCorrectionOutput<Instance, Solution>& pssvc_output
-            = static_cast<const SequentialValueCorrectionOutput<Instance, Solution>&>(ps_output);
+        const SequentialValueCorrectionOutput<Instance, Solution, onedimensional::Output>& pssvc_output
+            = static_cast<const SequentialValueCorrectionOutput<Instance, Solution, onedimensional::Output>&>(ps_output);
         std::stringstream ss;
         ss << "SVC it " << pssvc_output.number_of_iterations;
         if (local_output != nullptr) {
@@ -211,14 +211,14 @@ void optimize_sequential_value_correction(
             algorithm_formatter.update_solution(pssvc_output.solution_pool.best(), ss.str());
         }
     };
-    sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, kp_solve, svc_parameters);
+    sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter, onedimensional::Output>(instance, kp_solve, svc_parameters);
 }
 
 void optimize_dichotomic_search(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        onedimensional::Output* local_output)
 {
     double waste_percentage_upper_bound = std::numeric_limits<double>::infinity();
     for (Counter queue_size = 1;;) {
@@ -243,17 +243,17 @@ void optimize_dichotomic_search(
                 auto bpp_output = optimize(bpp_instance, bpp_parameters);
                 return bpp_output.solution_pool;
             };
-        DichotomicSearchParameters<Instance, Solution> ds_parameters;
+        DichotomicSearchParameters<Instance, Solution, onedimensional::Output> ds_parameters;
         ds_parameters.verbosity_level = 0;
         ds_parameters.timer = parameters.timer;
         ds_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
         ds_parameters.initial_waste_percentage_upper_bound = waste_percentage_upper_bound;
         ds_parameters.new_solution_callback = [
             &algorithm_formatter, local_output, &queue_size](
-                    const packingsolver::Output<Instance, Solution>& ps_output)
+                    const onedimensional::Output& ps_output)
             {
-                const DichotomicSearchOutput<Instance, Solution>& psds_output
-                    = static_cast<const DichotomicSearchOutput<Instance, Solution>&>(ps_output);
+                const DichotomicSearchOutput<Instance, Solution, onedimensional::Output>& psds_output
+                    = static_cast<const DichotomicSearchOutput<Instance, Solution, onedimensional::Output>&>(ps_output);
                 std::stringstream ss;
                 ss << "DS q " << queue_size
                     << " w " << psds_output.waste_percentage;
@@ -263,7 +263,7 @@ void optimize_dichotomic_search(
                     algorithm_formatter.update_solution(psds_output.solution_pool.best(), ss.str());
                 }
             };
-        auto ds_output = dichotomic_search<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, bpp_solve, ds_parameters);
+        auto ds_output = dichotomic_search<Instance, InstanceBuilder, Solution, AlgorithmFormatter, onedimensional::Output>(instance, bpp_solve, ds_parameters);
 
         // Check end.
         if (algorithm_formatter.end_boolean())
@@ -285,9 +285,9 @@ void optimize_column_generation(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        onedimensional::Output* local_output)
 {
-    ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution> pricing_function
+    ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, onedimensional::Output> pricing_function
         = [&parameters](const Instance& kp_instance)
         {
             OptimizeParameters kp_parameters;
@@ -303,7 +303,7 @@ void optimize_column_generation(
             return optimize(kp_instance, kp_parameters);
         };
 
-    ColumnGenerationParameters<Instance, Solution> cg_parameters;
+    ColumnGenerationParameters<Instance, Solution, onedimensional::Output> cg_parameters;
     cg_parameters.verbosity_level = 0;
     cg_parameters.timer = parameters.timer;
     cg_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
@@ -311,7 +311,7 @@ void optimize_column_generation(
     cg_parameters.internal_diving = 0;
     cg_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
     cg_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const onedimensional::Output& ps_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
@@ -320,7 +320,7 @@ void optimize_column_generation(
         }
         algorithm_formatter.update_bounds(ps_output);
     };
-    column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, pricing_function, cg_parameters);
+    column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter, onedimensional::Output>(instance, pricing_function, cg_parameters);
 }
 
 }
@@ -474,16 +474,16 @@ packingsolver::onedimensional::Output packingsolver::onedimensional::optimize(
     // 'local_outputs' owns these; a 'unique_ptr' is used so that it growing
     // does not invalidate the raw pointers captured by the tasks below.
     bool deterministic = (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic);
-    std::vector<std::unique_ptr<packingsolver::Output<Instance, Solution>>> local_outputs;
+    std::vector<std::unique_ptr<onedimensional::Output>> local_outputs;
     std::vector<std::function<void()>> tasks;
     std::forward_list<std::exception_ptr> exception_ptr_list;
     // Tree search.
     if (use_tree_search) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<onedimensional::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<onedimensional::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_tree_search), optimize_tree_search>(
                     exception_ptr,
@@ -498,9 +498,9 @@ packingsolver::onedimensional::Output packingsolver::onedimensional::optimize(
     if (use_sequential_single_knapsack) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<onedimensional::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<onedimensional::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_sequential_single_knapsack), optimize_sequential_single_knapsack>(
                     exception_ptr,
@@ -515,9 +515,9 @@ packingsolver::onedimensional::Output packingsolver::onedimensional::optimize(
     if (use_sequential_value_correction) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<onedimensional::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<onedimensional::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_sequential_value_correction), optimize_sequential_value_correction>(
                     exception_ptr,
@@ -532,9 +532,9 @@ packingsolver::onedimensional::Output packingsolver::onedimensional::optimize(
     if (use_dichotomic_search) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<onedimensional::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<onedimensional::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_dichotomic_search), optimize_dichotomic_search>(
                     exception_ptr,
@@ -549,9 +549,9 @@ packingsolver::onedimensional::Output packingsolver::onedimensional::optimize(
     if (use_column_generation) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<onedimensional::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<onedimensional::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_column_generation), optimize_column_generation>(
                     exception_ptr,

--- a/src/onedimensional/tree_search.hpp
+++ b/src/onedimensional/tree_search.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "packingsolver/onedimensional/solution.hpp"
+#include "packingsolver/onedimensional/optimize.hpp"
 
 #include "optimizationtools/utils/utils.hpp"
 
@@ -390,13 +390,13 @@ namespace packingsolver
 namespace onedimensional
 {
 
-struct TreeSearchOutput: packingsolver::Output<Instance, Solution>
+struct TreeSearchOutput: Output
 {
     TreeSearchOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution>
+struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     std::vector<GuideId> guides;
 

--- a/src/rectangle/algorithm_formatter.cpp
+++ b/src/rectangle/algorithm_formatter.cpp
@@ -300,7 +300,7 @@ void AlgorithmFormatter::update_bin_packing_bound(
 }
 
 void AlgorithmFormatter::update_bounds(
-        const packingsolver::Output<Instance, Solution>& output)
+        const Output& output)
 {
     switch (instance_.objective()) {
     case Objective::Knapsack:

--- a/src/rectangle/benders_decomposition.hpp
+++ b/src/rectangle/benders_decomposition.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "packingsolver/rectangle/solution.hpp"
+#include "packingsolver/rectangle/optimize.hpp"
 
 #include "mathoptsolverscmake/mathopt.hpp"
 
@@ -9,17 +9,17 @@ namespace packingsolver
 namespace rectangle
 {
 
-struct BendersDecompositionOutput: packingsolver::Output<Instance, Solution>
+struct BendersDecompositionOutput: Output
 {
     /** Constructor. */
     BendersDecompositionOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 
     /** Number of iterations. */
     Counter number_of_iterations = 0;
 };
 
-struct BendersDecompositionParameters: packingsolver::Parameters<Instance, Solution>
+struct BendersDecompositionParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     /** MILP solver. */
     mathoptsolverscmake::SolverName solver = mathoptsolverscmake::SolverName::Highs;

--- a/src/rectangle/dual_feasible_functions.hpp
+++ b/src/rectangle/dual_feasible_functions.hpp
@@ -18,21 +18,21 @@
 
 #pragma once
 
-#include "packingsolver/rectangle/solution.hpp"
+#include "packingsolver/rectangle/optimize.hpp"
 
 namespace packingsolver
 {
 namespace rectangle
 {
 
-struct DualFeasibleFunctionsOutput: packingsolver::Output<Instance, Solution>
+struct DualFeasibleFunctionsOutput: Output
 {
     /** Constructor. */
     DualFeasibleFunctionsOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct DualFeasibleFunctionsParameters: packingsolver::Parameters<Instance, Solution>
+struct DualFeasibleFunctionsParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
 };
 

--- a/src/rectangle/main.cpp
+++ b/src/rectangle/main.cpp
@@ -11,7 +11,7 @@ namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
 void read_args(
-        packingsolver::Parameters<Instance, Solution>& parameters,
+        packingsolver::Parameters<Instance, Solution, rectangle::Output>& parameters,
         const po::variables_map& vm)
 {
     parameters.timer.set_sigint_handler();

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -28,7 +28,7 @@ void optimize_dual_feasible_functions(
     dff_parameters.timer = parameters.timer;
     dff_parameters.new_solution_callback
         = [&algorithm_formatter](
-                const packingsolver::Output<Instance, Solution>& dff_output)
+                const rectangle::Output& dff_output)
         {
             algorithm_formatter.update_bin_packing_bound(
                     dff_output.bin_packing_bound);
@@ -40,7 +40,7 @@ void optimize_tree_search(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangle::Output* local_output)
 {
     TreeSearchParameters ts_parameters;
     ts_parameters.verbosity_level = 0;
@@ -52,7 +52,7 @@ void optimize_tree_search(
     ts_parameters.json_search_tree_path = parameters.json_search_tree_path;
     ts_parameters.fixed_items = parameters.fixed_items;
     ts_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ts_output)
+            const rectangle::Output& ts_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
@@ -68,7 +68,7 @@ void optimize_sequential_single_knapsack(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangle::Output* local_output)
 {
     for (Counter queue_size = 1;;) {
         NodeId queue_size_ms = queue_size;
@@ -94,17 +94,17 @@ void optimize_sequential_single_knapsack(
                 auto kp_output = optimize(kp_instance, kp_parameters);
                 return kp_output.solution_pool;
             };
-        SequentialValueCorrectionParameters<Instance, Solution> svc_parameters;
+        SequentialValueCorrectionParameters<Instance, Solution, rectangle::Output> svc_parameters;
         svc_parameters.verbosity_level = 0;
         svc_parameters.timer = parameters.timer;
         svc_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
         svc_parameters.maximum_number_of_iterations = 1;
         svc_parameters.new_solution_callback = [
             &algorithm_formatter, local_output, &queue_size](
-                    const packingsolver::Output<Instance, Solution>& ps_output)
+                    const rectangle::Output& ps_output)
             {
-                const SequentialValueCorrectionOutput<Instance, Solution>& pssvc_output
-                    = static_cast<const SequentialValueCorrectionOutput<Instance, Solution>&>(ps_output);
+                const SequentialValueCorrectionOutput<Instance, Solution, rectangle::Output>& pssvc_output
+                    = static_cast<const SequentialValueCorrectionOutput<Instance, Solution, rectangle::Output>&>(ps_output);
                 std::stringstream ss;
                 ss << "SSK q " << queue_size;
                 if (local_output != nullptr) {
@@ -113,7 +113,7 @@ void optimize_sequential_single_knapsack(
                     algorithm_formatter.update_solution(pssvc_output.solution_pool.best(), ss.str());
                 }
             };
-        sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, kp_solve, svc_parameters);
+        sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter, rectangle::Output>(instance, kp_solve, svc_parameters);
 
         // Check end.
         if (algorithm_formatter.end_boolean())
@@ -134,7 +134,7 @@ void optimize_sequential_value_correction(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangle::Output* local_output)
 {
     SequentialValueCorrectionFunction<Instance, Solution> kp_solve
         = [&algorithm_formatter, &parameters](const Instance& kp_instance)
@@ -155,17 +155,17 @@ void optimize_sequential_value_correction(
             auto kp_output = optimize(kp_instance, kp_parameters);
             return kp_output.solution_pool;
         };
-    SequentialValueCorrectionParameters<Instance, Solution> svc_parameters;
+    SequentialValueCorrectionParameters<Instance, Solution, rectangle::Output> svc_parameters;
     svc_parameters.verbosity_level = 0;
     svc_parameters.timer = parameters.timer;
     svc_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     if (parameters.optimization_mode != OptimizationMode::Anytime)
         svc_parameters.maximum_number_of_iterations = parameters.not_anytime_sequential_value_correction_number_of_iterations;
     svc_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const rectangle::Output& ps_output)
     {
-        const SequentialValueCorrectionOutput<Instance, Solution>& pssvc_output
-            = static_cast<const SequentialValueCorrectionOutput<Instance, Solution>&>(ps_output);
+        const SequentialValueCorrectionOutput<Instance, Solution, rectangle::Output>& pssvc_output
+            = static_cast<const SequentialValueCorrectionOutput<Instance, Solution, rectangle::Output>&>(ps_output);
         std::stringstream ss;
         ss << "SVC it " << pssvc_output.number_of_iterations;
         if (local_output != nullptr) {
@@ -174,14 +174,14 @@ void optimize_sequential_value_correction(
             algorithm_formatter.update_solution(pssvc_output.solution_pool.best(), ss.str());
         }
     };
-    sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, kp_solve, svc_parameters);
+    sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter, rectangle::Output>(instance, kp_solve, svc_parameters);
 }
 
 void optimize_dichotomic_search(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangle::Output* local_output)
 {
     double waste_percentage_upper_bound = std::numeric_limits<double>::infinity();
     for (Counter queue_size = 1;;) {
@@ -206,17 +206,17 @@ void optimize_dichotomic_search(
                 auto bpp_output = optimize(bpp_instance, bpp_parameters);
                 return bpp_output.solution_pool;
             };
-        DichotomicSearchParameters<Instance, Solution> ds_parameters;
+        DichotomicSearchParameters<Instance, Solution, rectangle::Output> ds_parameters;
         ds_parameters.verbosity_level = 0;
         ds_parameters.timer = parameters.timer;
         ds_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
         ds_parameters.initial_waste_percentage_upper_bound = waste_percentage_upper_bound;
         ds_parameters.new_solution_callback = [
             &algorithm_formatter, local_output, &queue_size](
-                    const packingsolver::Output<Instance, Solution>& ps_output)
+                    const rectangle::Output& ps_output)
             {
-                const DichotomicSearchOutput<Instance, Solution>& psds_output
-                    = static_cast<const DichotomicSearchOutput<Instance, Solution>&>(ps_output);
+                const DichotomicSearchOutput<Instance, Solution, rectangle::Output>& psds_output
+                    = static_cast<const DichotomicSearchOutput<Instance, Solution, rectangle::Output>&>(ps_output);
                 std::stringstream ss;
                 ss << "DS q " << queue_size
                     << " w " << psds_output.waste_percentage;
@@ -226,7 +226,7 @@ void optimize_dichotomic_search(
                     algorithm_formatter.update_solution(psds_output.solution_pool.best(), ss.str());
                 }
             };
-        auto ds_output = dichotomic_search<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, bpp_solve, ds_parameters);
+        auto ds_output = dichotomic_search<Instance, InstanceBuilder, Solution, AlgorithmFormatter, rectangle::Output>(instance, bpp_solve, ds_parameters);
 
         // Check end.
         if (algorithm_formatter.end_boolean())
@@ -248,9 +248,9 @@ void optimize_column_generation(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangle::Output* local_output)
 {
-    ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution> pricing_function
+    ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, rectangle::Output> pricing_function
         = [&parameters](const Instance& kp_instance)
         {
             OptimizeParameters kp_parameters;
@@ -268,14 +268,14 @@ void optimize_column_generation(
             return optimize(kp_instance, kp_parameters);
         };
 
-    ColumnGenerationParameters<Instance, Solution> cg_parameters;
+    ColumnGenerationParameters<Instance, Solution, rectangle::Output> cg_parameters;
     cg_parameters.verbosity_level = 0;
     cg_parameters.timer = parameters.timer;
     cg_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     cg_parameters.optimization_mode = parameters.optimization_mode;
     cg_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
     cg_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const rectangle::Output& ps_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
@@ -284,14 +284,14 @@ void optimize_column_generation(
         }
         algorithm_formatter.update_bounds(ps_output);
     };
-    column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, pricing_function, cg_parameters);
+    column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter, rectangle::Output>(instance, pricing_function, cg_parameters);
 }
 
 void optimize_tree_search_maximal_spaces(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangle::Output* local_output)
 {
     TreeSearchMaximalSpacesParameters ts_ms_parameters;
     ts_ms_parameters.verbosity_level = 0;
@@ -300,7 +300,7 @@ void optimize_tree_search_maximal_spaces(
     ts_ms_parameters.optimization_mode = parameters.optimization_mode;
     ts_ms_parameters.not_anytime_tree_search_queue_size = parameters.not_anytime_tree_search_maximal_spaces_queue_size;
     ts_ms_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ts_output)
+            const rectangle::Output& ts_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ts_output.solution_pool.best(), "TSMS " + ts_output.solution_pool.best_label());
@@ -315,7 +315,7 @@ void optimize_benders_decomposition(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangle::Output* local_output)
 {
     BendersDecompositionParameters bd_parameters;
     bd_parameters.verbosity_level = 0;
@@ -324,7 +324,7 @@ void optimize_benders_decomposition(
     if (parameters.optimization_mode != OptimizationMode::Anytime)
         bd_parameters.maximum_number_of_iterations = parameters.not_anytime_benders_decomposition_number_of_iterations;
     bd_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const rectangle::Output& ps_output)
     {
         const BendersDecompositionOutput& psbd_output
             = static_cast<const BendersDecompositionOutput&>(ps_output);
@@ -345,7 +345,7 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
         const Instance& instance,
         const OptimizeParameters& parameters)
 {
-    Output output(instance);
+    rectangle::Output output(instance);
     AlgorithmFormatter algorithm_formatter(instance, parameters, output);
     algorithm_formatter.start();
     algorithm_formatter.print_header();
@@ -518,16 +518,16 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
     // 'local_outputs' owns these; a 'unique_ptr' is used so that it growing
     // does not invalidate the raw pointers captured by the tasks below.
     bool deterministic = (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic);
-    std::vector<std::unique_ptr<packingsolver::Output<Instance, Solution>>> local_outputs;
+    std::vector<std::unique_ptr<rectangle::Output>> local_outputs;
     std::vector<std::function<void()>> tasks;
     std::forward_list<std::exception_ptr> exception_ptr_list;
     // Tree search.
     if (use_tree_search) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangle::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangle::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_tree_search), optimize_tree_search>(
                     exception_ptr,
@@ -542,9 +542,9 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
     if (use_tree_search_maximal_spaces) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangle::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangle::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_tree_search_maximal_spaces), optimize_tree_search_maximal_spaces>(
                     exception_ptr,
@@ -559,9 +559,9 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
     if (use_benders_decomposition) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangle::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangle::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_benders_decomposition), optimize_benders_decomposition>(
                     exception_ptr,
@@ -576,9 +576,9 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
     if (use_sequential_single_knapsack) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangle::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangle::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_sequential_single_knapsack), optimize_sequential_single_knapsack>(
                     exception_ptr,
@@ -593,9 +593,9 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
     if (use_sequential_value_correction) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangle::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangle::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_sequential_value_correction), optimize_sequential_value_correction>(
                     exception_ptr,
@@ -610,9 +610,9 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
     if (use_dichotomic_search) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangle::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangle::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_dichotomic_search), optimize_dichotomic_search>(
                     exception_ptr,
@@ -627,9 +627,9 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
     if (use_column_generation) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangle::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangle::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_column_generation), optimize_column_generation>(
                     exception_ptr,

--- a/src/rectangle/tree_search.hpp
+++ b/src/rectangle/tree_search.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "packingsolver/rectangle/solution.hpp"
+#include "packingsolver/rectangle/optimize.hpp"
 #include "rectangle/instance_flipper.hpp"
 
 #include "optimizationtools/utils/utils.hpp"
@@ -689,13 +689,13 @@ namespace packingsolver
 namespace rectangle
 {
 
-struct TreeSearchOutput: packingsolver::Output<Instance, Solution>
+struct TreeSearchOutput: Output
 {
     TreeSearchOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution>
+struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     std::vector<GuideId> guides;
 

--- a/src/rectangle/tree_search_maximal_spaces.hpp
+++ b/src/rectangle/tree_search_maximal_spaces.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "rectangle/block.hpp"
+#include "packingsolver/rectangle/optimize.hpp"
 
 #include "optimizationtools/utils/utils.hpp"
 
@@ -480,13 +481,13 @@ namespace packingsolver
 namespace rectangle
 {
 
-struct TreeSearchMaximalSpacesOutput: packingsolver::Output<Instance, Solution>
+struct TreeSearchMaximalSpacesOutput: Output
 {
     TreeSearchMaximalSpacesOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct TreeSearchMaximalSpacesParameters: packingsolver::Parameters<Instance, Solution>
+struct TreeSearchMaximalSpacesParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     OptimizationMode optimization_mode = OptimizationMode::Anytime;
 

--- a/src/rectangleguillotine/algorithm_formatter.cpp
+++ b/src/rectangleguillotine/algorithm_formatter.cpp
@@ -377,7 +377,7 @@ void AlgorithmFormatter::update_open_dimension_y_bound(
 }
 
 void AlgorithmFormatter::update_bounds(
-        const packingsolver::Output<Instance, Solution>& output)
+        const Output& output)
 {
     switch (instance_.objective()) {
     case Objective::Knapsack:

--- a/src/rectangleguillotine/column_generation_strips.hpp
+++ b/src/rectangleguillotine/column_generation_strips.hpp
@@ -51,7 +51,7 @@
 
 #pragma once
 
-#include "packingsolver/rectangleguillotine/solution.hpp"
+#include "packingsolver/rectangleguillotine/optimize.hpp"
 
 #include "columngenerationsolver/commons.hpp"
 
@@ -60,18 +60,18 @@ namespace packingsolver
 namespace rectangleguillotine
 {
 
-struct ColumnGenerationStripsOutput: packingsolver::Output<Instance, Solution>
+struct ColumnGenerationStripsOutput: Output
 {
     /** Constructor. */
     ColumnGenerationStripsOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 
     CutOrientation best_solution_first_stage_orientation;
 
     NodeId best_solution_number_of_nodes;
 };
 
-struct ColumnGenerationStripsParameters: packingsolver::Parameters<Instance, Solution>
+struct ColumnGenerationStripsParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     OptimizationMode optimization_mode = OptimizationMode::Anytime;
 

--- a/src/rectangleguillotine/main.cpp
+++ b/src/rectangleguillotine/main.cpp
@@ -11,7 +11,7 @@ namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
 void read_args(
-        packingsolver::Parameters<Instance, Solution>& parameters,
+        packingsolver::Parameters<Instance, Solution, rectangleguillotine::Output>& parameters,
         const po::variables_map& vm)
 {
     parameters.timer.set_sigint_handler();

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -65,7 +65,7 @@ void optimize_dual_feasible_functions(
     dff_parameters.timer = parameters.timer;
     dff_parameters.new_solution_callback
         = [&algorithm_formatter](
-                const packingsolver::Output<rectangle::Instance, rectangle::Solution>& dff_output)
+                const rectangle::Output& dff_output)
         {
             algorithm_formatter.update_bin_packing_bound(
                     dff_output.bin_packing_bound);
@@ -77,7 +77,7 @@ void optimize_tree_search(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangleguillotine::Output* local_output)
 {
     TreeSearchParameters ts_parameters;
     ts_parameters.verbosity_level = 0;
@@ -88,7 +88,7 @@ void optimize_tree_search(
     ts_parameters.not_anytime_tree_search_queue_size = parameters.not_anytime_tree_search_queue_size;
     ts_parameters.json_search_tree_path = parameters.json_search_tree_path;
     ts_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ts_output)
+            const rectangleguillotine::Output& ts_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
@@ -104,7 +104,7 @@ void optimize_tree_search_maximal_spaces(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangleguillotine::Output* local_output)
 {
     TreeSearchMaximalSpacesParameters ts_ms_parameters;
     ts_ms_parameters.verbosity_level = 0;
@@ -113,7 +113,7 @@ void optimize_tree_search_maximal_spaces(
     ts_ms_parameters.optimization_mode = parameters.optimization_mode;
     ts_ms_parameters.not_anytime_tree_search_queue_size = parameters.not_anytime_tree_search_maximal_spaces_queue_size;
     ts_ms_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ts_output)
+            const rectangleguillotine::Output& ts_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ts_output.solution_pool.best(), "TSMS " + ts_output.solution_pool.best_label());
@@ -128,13 +128,13 @@ void optimize_tree_search_hypergraph_infinite_copies(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangleguillotine::Output* local_output)
 {
     TreeSearchHypergraphInfiniteCopiesParameters tsh_ic_parameters;
     tsh_ic_parameters.verbosity_level = 0;
     tsh_ic_parameters.timer = parameters.timer;
     tsh_ic_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const rectangleguillotine::Output& ps_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ps_output.solution_pool.best(), "TSHIC");
@@ -151,13 +151,13 @@ void optimize_tree_search_hypergraph(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangleguillotine::Output* local_output)
 {
     TreeSearchHypergraphParameters tsh_parameters;
     tsh_parameters.verbosity_level = 0;
     tsh_parameters.timer = parameters.timer;
     tsh_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const rectangleguillotine::Output& ps_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ps_output.solution_pool.best(), "TSH " + ps_output.solution_pool.best_label());
@@ -174,7 +174,7 @@ void optimize_column_generation_strips(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangleguillotine::Output* local_output)
 {
     ColumnGenerationStripsParameters cg_parameters;
     cg_parameters.verbosity_level = 0;
@@ -184,7 +184,7 @@ void optimize_column_generation_strips(
     cg_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     cg_parameters.optimization_mode = parameters.optimization_mode;
     cg_parameters.new_solution_callback = [&instance, &algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const rectangleguillotine::Output& ps_output)
     {
         const ColumnGenerationStripsOutput& pscg_output
             = static_cast<const ColumnGenerationStripsOutput&>(ps_output);
@@ -212,7 +212,7 @@ void optimize_sequential_strips_onedimensional(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangleguillotine::Output* local_output)
 {
     SequentialStripsOnedimensionalParameters sso_parameters;
     sso_parameters.verbosity_level = 0;
@@ -222,7 +222,7 @@ void optimize_sequential_strips_onedimensional(
     sso_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     sso_parameters.optimization_mode = parameters.optimization_mode;
     sso_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const rectangleguillotine::Output& ps_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(
@@ -241,7 +241,7 @@ void optimize_sequential_single_knapsack(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangleguillotine::Output* local_output)
 {
     for (Counter queue_size = 1;;) {
         NodeId queue_size_ms = queue_size;
@@ -267,17 +267,17 @@ void optimize_sequential_single_knapsack(
                 auto kp_output = optimize(kp_instance, kp_parameters);
                 return kp_output.solution_pool;
             };
-        SequentialValueCorrectionParameters<Instance, Solution> svc_parameters;
+        SequentialValueCorrectionParameters<Instance, Solution, rectangleguillotine::Output> svc_parameters;
         svc_parameters.verbosity_level = 0;
         svc_parameters.timer = parameters.timer;
         svc_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
         svc_parameters.maximum_number_of_iterations = 1;
         svc_parameters.new_solution_callback = [
             &algorithm_formatter, local_output, &queue_size](
-                    const packingsolver::Output<Instance, Solution>& ps_output)
+                    const rectangleguillotine::Output& ps_output)
             {
-                const SequentialValueCorrectionOutput<Instance, Solution>& pssvc_output
-                    = static_cast<const SequentialValueCorrectionOutput<Instance, Solution>&>(ps_output);
+                const SequentialValueCorrectionOutput<Instance, Solution, rectangleguillotine::Output>& pssvc_output
+                    = static_cast<const SequentialValueCorrectionOutput<Instance, Solution, rectangleguillotine::Output>&>(ps_output);
                 std::stringstream ss;
                 ss << "SSK q " << queue_size;
                 if (local_output != nullptr) {
@@ -286,7 +286,7 @@ void optimize_sequential_single_knapsack(
                     algorithm_formatter.update_solution(pssvc_output.solution_pool.best(), ss.str());
                 }
             };
-        sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, kp_solve, svc_parameters);
+        sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter, rectangleguillotine::Output>(instance, kp_solve, svc_parameters);
 
         // Check end.
         if (algorithm_formatter.end_boolean())
@@ -307,7 +307,7 @@ void optimize_sequential_value_correction(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangleguillotine::Output* local_output)
 {
     SequentialValueCorrectionFunction<Instance, Solution> kp_solve
         = [&algorithm_formatter, &parameters](const Instance& kp_instance)
@@ -328,17 +328,17 @@ void optimize_sequential_value_correction(
             auto kp_output = optimize(kp_instance, kp_parameters);
             return kp_output.solution_pool;
         };
-    SequentialValueCorrectionParameters<Instance, Solution> svc_parameters;
+    SequentialValueCorrectionParameters<Instance, Solution, rectangleguillotine::Output> svc_parameters;
     svc_parameters.verbosity_level = 0;
     svc_parameters.timer = parameters.timer;
     svc_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     if (parameters.optimization_mode != OptimizationMode::Anytime)
         svc_parameters.maximum_number_of_iterations = parameters.not_anytime_sequential_value_correction_number_of_iterations;
     svc_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const rectangleguillotine::Output& ps_output)
     {
-        const SequentialValueCorrectionOutput<Instance, Solution>& pssvc_output
-            = static_cast<const SequentialValueCorrectionOutput<Instance, Solution>&>(ps_output);
+        const SequentialValueCorrectionOutput<Instance, Solution, rectangleguillotine::Output>& pssvc_output
+            = static_cast<const SequentialValueCorrectionOutput<Instance, Solution, rectangleguillotine::Output>&>(ps_output);
         std::stringstream ss;
         ss << "SVC it " << pssvc_output.number_of_iterations;
         if (local_output != nullptr) {
@@ -347,14 +347,14 @@ void optimize_sequential_value_correction(
             algorithm_formatter.update_solution(pssvc_output.solution_pool.best(), ss.str());
         }
     };
-    sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, kp_solve, svc_parameters);
+    sequential_value_correction<Instance, InstanceBuilder, Solution, AlgorithmFormatter, rectangleguillotine::Output>(instance, kp_solve, svc_parameters);
 }
 
 void optimize_dichotomic_search(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangleguillotine::Output* local_output)
 {
     double waste_percentage_upper_bound = std::numeric_limits<double>::infinity();
     for (Counter queue_size = 1;;) {
@@ -379,17 +379,17 @@ void optimize_dichotomic_search(
                 auto bpp_output = optimize(bpp_instance, bpp_parameters);
                 return bpp_output.solution_pool;
             };
-        DichotomicSearchParameters<Instance, Solution> ds_parameters;
+        DichotomicSearchParameters<Instance, Solution, rectangleguillotine::Output> ds_parameters;
         ds_parameters.verbosity_level = 0;
         ds_parameters.timer = parameters.timer;
         ds_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
         ds_parameters.initial_waste_percentage_upper_bound = waste_percentage_upper_bound;
         ds_parameters.new_solution_callback = [
             &algorithm_formatter, local_output, &queue_size](
-                    const packingsolver::Output<Instance, Solution>& ps_output)
+                    const rectangleguillotine::Output& ps_output)
             {
-                const DichotomicSearchOutput<Instance, Solution>& psds_output
-                    = static_cast<const DichotomicSearchOutput<Instance, Solution>&>(ps_output);
+                const DichotomicSearchOutput<Instance, Solution, rectangleguillotine::Output>& psds_output
+                    = static_cast<const DichotomicSearchOutput<Instance, Solution, rectangleguillotine::Output>&>(ps_output);
                 std::stringstream ss;
                 ss << "DS q " << queue_size
                     << " w " << psds_output.waste_percentage;
@@ -399,7 +399,7 @@ void optimize_dichotomic_search(
                     algorithm_formatter.update_solution(psds_output.solution_pool.best(), ss.str());
                 }
             };
-        auto ds_output = dichotomic_search<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, bpp_solve, ds_parameters);
+        auto ds_output = dichotomic_search<Instance, InstanceBuilder, Solution, AlgorithmFormatter, rectangleguillotine::Output>(instance, bpp_solve, ds_parameters);
 
         // Check end.
         if (algorithm_formatter.end_boolean())
@@ -421,9 +421,9 @@ void optimize_column_generation(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        packingsolver::Output<Instance, Solution>* local_output)
+        rectangleguillotine::Output* local_output)
 {
-    ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution> pricing_function
+    ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, rectangleguillotine::Output> pricing_function
         = [&algorithm_formatter, &parameters](const Instance& kp_instance)
         {
             OptimizeParameters kp_parameters;
@@ -442,14 +442,14 @@ void optimize_column_generation(
             return optimize(kp_instance, kp_parameters);
         };
 
-    ColumnGenerationParameters<Instance, Solution> cg_parameters;
+    ColumnGenerationParameters<Instance, Solution, rectangleguillotine::Output> cg_parameters;
     cg_parameters.verbosity_level = 0;
     cg_parameters.timer = parameters.timer;
     cg_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     cg_parameters.optimization_mode = parameters.optimization_mode;
     cg_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
     cg_parameters.new_solution_callback = [&algorithm_formatter, local_output](
-            const packingsolver::Output<Instance, Solution>& ps_output)
+            const rectangleguillotine::Output& ps_output)
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
@@ -458,7 +458,7 @@ void optimize_column_generation(
         }
         algorithm_formatter.update_bounds(ps_output);
     };
-    column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter>(instance, pricing_function, cg_parameters);
+    column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter, rectangleguillotine::Output>(instance, pricing_function, cg_parameters);
 }
 
 }
@@ -679,16 +679,16 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
     // 'local_outputs' owns these; a 'unique_ptr' is used so that it growing
     // does not invalidate the raw pointers captured by the tasks below.
     bool deterministic = (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic);
-    std::vector<std::unique_ptr<packingsolver::Output<Instance, Solution>>> local_outputs;
+    std::vector<std::unique_ptr<rectangleguillotine::Output>> local_outputs;
     std::vector<std::function<void()>> tasks;
     std::forward_list<std::exception_ptr> exception_ptr_list;
     // Tree search.
     if (use_tree_search) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangleguillotine::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangleguillotine::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_tree_search), optimize_tree_search>(
                     exception_ptr,
@@ -703,9 +703,9 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
     if (use_tree_search_maximal_spaces) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangleguillotine::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangleguillotine::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_tree_search_maximal_spaces), optimize_tree_search_maximal_spaces>(
                     exception_ptr,
@@ -720,9 +720,9 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
     if (use_tree_search_hypergraph_infinite_copies) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangleguillotine::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangleguillotine::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_tree_search_hypergraph_infinite_copies), optimize_tree_search_hypergraph_infinite_copies>(
                     exception_ptr,
@@ -737,9 +737,9 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
     if (use_tree_search_hypergraph) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangleguillotine::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangleguillotine::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_tree_search_hypergraph), optimize_tree_search_hypergraph>(
                     exception_ptr,
@@ -754,9 +754,9 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
     if (use_column_generation_strips) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangleguillotine::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangleguillotine::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_column_generation_strips), optimize_column_generation_strips>(
                     exception_ptr,
@@ -771,9 +771,9 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
     if (use_sequential_strips_onedimensional) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangleguillotine::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangleguillotine::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_sequential_strips_onedimensional), optimize_sequential_strips_onedimensional>(
                     exception_ptr,
@@ -788,9 +788,9 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
     if (use_sequential_single_knapsack) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangleguillotine::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangleguillotine::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_sequential_single_knapsack), optimize_sequential_single_knapsack>(
                     exception_ptr,
@@ -805,9 +805,9 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
     if (use_sequential_value_correction) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangleguillotine::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangleguillotine::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_sequential_value_correction), optimize_sequential_value_correction>(
                     exception_ptr,
@@ -822,9 +822,9 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
     if (use_dichotomic_search) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangleguillotine::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangleguillotine::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_dichotomic_search), optimize_dichotomic_search>(
                     exception_ptr,
@@ -839,9 +839,9 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
     if (use_column_generation) {
         exception_ptr_list.push_front(std::exception_ptr());
         std::exception_ptr& exception_ptr = exception_ptr_list.front();
-        std::unique_ptr<packingsolver::Output<Instance, Solution>> local_output;
+        std::unique_ptr<rectangleguillotine::Output> local_output;
         if (deterministic)
-            local_output = std::make_unique<packingsolver::Output<Instance, Solution>>(instance);
+            local_output = std::make_unique<rectangleguillotine::Output>(instance);
         tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
             wrapper<decltype(&optimize_column_generation), optimize_column_generation>(
                     exception_ptr,

--- a/src/rectangleguillotine/sequential_feasibility.hpp
+++ b/src/rectangleguillotine/sequential_feasibility.hpp
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "packingsolver/rectangleguillotine/solution.hpp"
+#include "packingsolver/rectangleguillotine/optimize.hpp"
 
 #include <functional>
 
@@ -21,14 +21,14 @@ namespace rectangleguillotine
 
 using SequentialFeasibilitySolver = std::function<SolutionPool<Instance, Solution>(const Instance&)>;
 
-struct SequentialFeasibilityOutput: packingsolver::Output<Instance, Solution>
+struct SequentialFeasibilityOutput: Output
 {
     /** Constructor. */
     SequentialFeasibilityOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct SequentialFeasibilityParameters: packingsolver::Parameters<Instance, Solution>
+struct SequentialFeasibilityParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
 };
 

--- a/src/rectangleguillotine/sequential_strips_onedimensional.hpp
+++ b/src/rectangleguillotine/sequential_strips_onedimensional.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "packingsolver/rectangleguillotine/solution.hpp"
+#include "packingsolver/rectangleguillotine/optimize.hpp"
 
 #include "columngenerationsolver/commons.hpp"
 
@@ -25,14 +25,14 @@ namespace packingsolver
 namespace rectangleguillotine
 {
 
-struct SequentialStripsOnedimensionalOutput: packingsolver::Output<Instance, Solution>
+struct SequentialStripsOnedimensionalOutput: Output
 {
     /** Constructor. */
     SequentialStripsOnedimensionalOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct SequentialStripsOnedimensionalParameters: packingsolver::Parameters<Instance, Solution>
+struct SequentialStripsOnedimensionalParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     OptimizationMode optimization_mode = OptimizationMode::Anytime;
 

--- a/src/rectangleguillotine/tree_search.hpp
+++ b/src/rectangleguillotine/tree_search.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "packingsolver/rectangleguillotine/solution.hpp"
+#include "packingsolver/rectangleguillotine/optimize.hpp"
 #include "rectangleguillotine/instance_flipper.hpp"
 
 #include "optimizationtools/utils/utils.hpp"
@@ -829,13 +829,13 @@ namespace packingsolver
 namespace rectangleguillotine
 {
 
-struct TreeSearchOutput: packingsolver::Output<Instance, Solution>
+struct TreeSearchOutput: Output
 {
     TreeSearchOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution>
+struct TreeSearchParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     std::vector<GuideId> guides;
 

--- a/src/rectangleguillotine/tree_search_hypergraph.hpp
+++ b/src/rectangleguillotine/tree_search_hypergraph.hpp
@@ -1,19 +1,19 @@
 #pragma once
 
-#include "packingsolver/rectangleguillotine/solution.hpp"
+#include "packingsolver/rectangleguillotine/optimize.hpp"
 
 namespace packingsolver
 {
 namespace rectangleguillotine
 {
 
-struct TreeSearchHypergraphOutput: packingsolver::Output<Instance, Solution>
+struct TreeSearchHypergraphOutput: Output
 {
     TreeSearchHypergraphOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct TreeSearchHypergraphParameters: packingsolver::Parameters<Instance, Solution>
+struct TreeSearchHypergraphParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
 };
 

--- a/src/rectangleguillotine/tree_search_hypergraph_infinite_copies.hpp
+++ b/src/rectangleguillotine/tree_search_hypergraph_infinite_copies.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
-#include "packingsolver/rectangleguillotine/solution.hpp"
+#include "packingsolver/rectangleguillotine/optimize.hpp"
 
 namespace packingsolver
 {
 namespace rectangleguillotine
 {
 
-struct TreeSearchHypergraphInfiniteCopiesOutput: packingsolver::Output<Instance, Solution>
+struct TreeSearchHypergraphInfiniteCopiesOutput: Output
 {
     TreeSearchHypergraphInfiniteCopiesOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 
     /**
      * DP values indexed by width + (eff_width + 1) * height, where
@@ -23,7 +23,7 @@ struct TreeSearchHypergraphInfiniteCopiesOutput: packingsolver::Output<Instance,
     std::vector<Profit> dp_values;
 };
 
-struct TreeSearchHypergraphInfiniteCopiesParameters: packingsolver::Parameters<Instance, Solution>
+struct TreeSearchHypergraphInfiniteCopiesParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
 };
 

--- a/src/rectangleguillotine/tree_search_maximal_spaces.hpp
+++ b/src/rectangleguillotine/tree_search_maximal_spaces.hpp
@@ -2,7 +2,7 @@
 
 #include "rectangleguillotine/block.hpp"
 
-#include "packingsolver/rectangleguillotine/solution.hpp"
+#include "packingsolver/rectangleguillotine/optimize.hpp"
 
 #include "optimizationtools/utils/utils.hpp"
 
@@ -324,13 +324,13 @@ namespace packingsolver
 namespace rectangleguillotine
 {
 
-struct TreeSearchMaximalSpacesOutput: packingsolver::Output<Instance, Solution>
+struct TreeSearchMaximalSpacesOutput: Output
 {
     TreeSearchMaximalSpacesOutput(const Instance& instance):
-        packingsolver::Output<Instance, Solution>(instance) { }
+        Output(instance) { }
 };
 
-struct TreeSearchMaximalSpacesParameters: packingsolver::Parameters<Instance, Solution>
+struct TreeSearchMaximalSpacesParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     OptimizationMode optimization_mode = OptimizationMode::Anytime;
 


### PR DESCRIPTION
knapsack_bound/bin_packing_bound/variable_sized_bin_packing_bound/ open_dimension_x_bound/open_dimension_y_bound used to live on the generic packingsolver::Output base, even for problem types that never use them (e.g. onedimensional carrying open-dimension bounds it has no concept of). Each problem type's own Output now only declares the bounds it actually supports, and its to_json()/format() surface them (previously computed but never exposed in --output JSON or the console summary).

Parameters/NewSolutionCallback gain an Output template parameter (defaulting to the generic base) so per-type Parameters structs (and the shared column_generation/dichotomic_search/sequential_value_correction algorithms) can carry the richer callback type through to each AlgorithmFormatter.