### PR TITLE
Add Feasibility case to multi-bin algorithm selection

### DIFF
--- a/src/box/optimize.cpp
+++ b/src/box/optimize.cpp
@@ -433,6 +433,35 @@ packingsolver::box::Output packingsolver::box::optimize(
                 use_tree_search = true;
             }
         }
+    } else if (instance.objective() == Objective::Feasibility) {
+        // Disable algorithms which are not available for this objective.
+        use_tree_search_maximal_spaces = false;
+        use_dichotomic_search = false;
+        // Automatic selection.
+        if (!use_tree_search
+                && !use_sequential_single_knapsack
+                && !use_sequential_value_correction
+                && !use_column_generation) {
+            if (mean_item_type_copies(instance)
+                    > parameters.many_item_type_copies_factor
+                    * mean_number_of_items_in_bins) {
+                if (mean_number_of_items_in_bins
+                        > parameters.many_items_in_bins_threshold) {
+                    use_sequential_single_knapsack = true;
+                } else {
+                    use_sequential_value_correction = true;
+                    use_column_generation = true;
+                }
+            } else {
+                if (mean_number_of_items_in_bins
+                        > parameters.many_items_in_bins_threshold_2) {
+                    use_sequential_single_knapsack = true;
+                } else {
+                    use_tree_search = true;
+                    use_column_generation = true;
+                }
+            }
+        }
     } else if (instance.objective() == Objective::Knapsack) {
         // Disable algorithms which are not available for this objective.
         use_tree_search_maximal_spaces = false;

--- a/src/irregular/optimize.cpp
+++ b/src/irregular/optimize.cpp
@@ -521,7 +521,7 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
                 && !use_milp_raster) {
             use_tree_search = true;
         }
-    } else if (instance.objective() == Objective::Knapsack) {
+    } else if (instance.objective() == Objective::Feasibility) {
         // Disable algorithms which are not available for this objective.
         use_local_search = false;
         use_dichotomic_search = false;
@@ -546,35 +546,30 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
                 use_column_generation = true;
             }
         }
-    } else if (instance.objective() == Objective::Feasibility) {
+    } else if (instance.objective() == Objective::Knapsack) {
         // Disable algorithms which are not available for this objective.
+        use_local_search = false;
         use_dichotomic_search = false;
         // Automatic selection.
         if (!use_tree_search
                 && !use_milp_raster
-                && !use_local_search
+                && !use_sequential_single_knapsack
+                && !use_sequential_value_correction
                 && !use_column_generation) {
-            use_tree_search = true;
-            //if (mean_item_type_copies(instance)
-            //        > parameters.many_item_type_copies_factor
-            //        * mean_number_of_items_in_bins) {
-            //    if (mean_number_of_items_in_bins
-            //            > parameters.many_items_in_bins_threshold) {
-            //        use_sequential_single_knapsack = true;
-            //    } else {
-            //        use_sequential_value_correction = true;
-            //        use_column_generation = true;
-            //    }
-            //} else {
-            //    use_tree_search = true;
-            //    if (mean_number_of_items_in_bins
-            //            > parameters.many_items_in_bins_threshold) {
-            //        use_sequential_single_knapsack = true;
-            //    } else {
-            //        use_sequential_value_correction = true;
-            //        use_column_generation = true;
-            //    }
-            //}
+            if (mean_item_type_copies(instance)
+                    > parameters.many_item_type_copies_factor
+                    * mean_number_of_items_in_bins) {
+                if (mean_number_of_items_in_bins
+                        > parameters.many_items_in_bins_threshold) {
+                    use_sequential_single_knapsack = true;
+                } else {
+                    use_sequential_value_correction = true;
+                    use_column_generation = true;
+                }
+            } else {
+                use_tree_search = true;
+                use_column_generation = true;
+            }
         }
     } else if (instance.objective() == Objective::BinPacking
             || instance.objective() == Objective::BinPackingWithLeftovers) {

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -392,6 +392,29 @@ packingsolver::onedimensional::Output packingsolver::onedimensional::optimize(
         use_sequential_value_correction = false;
         use_dichotomic_search = false;
         use_column_generation = false;
+    } else if (instance.objective() == Objective::Feasibility) {
+        // Disable algorithms which are not available for this objective.
+        use_dichotomic_search = false;
+        // Automatic selection.
+        if (!use_tree_search
+                && !use_sequential_single_knapsack
+                && !use_sequential_value_correction
+                && !use_column_generation) {
+            if (mean_item_type_copies(instance)
+                    > parameters.many_item_type_copies_factor
+                    * mean_number_of_items_in_bins) {
+                if (mean_number_of_items_in_bins
+                        > parameters.many_items_in_bins_threshold) {
+                    use_sequential_single_knapsack = true;
+                } else {
+                    use_sequential_value_correction = true;
+                    use_column_generation = true;
+                }
+            } else {
+                use_tree_search = true;
+                use_column_generation = true;
+            }
+        }
     } else if (instance.objective() == Objective::Knapsack) {
         // Disable algorithms which are not available for this objective.
         use_dichotomic_search = false;

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -459,6 +459,31 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
                 use_tree_search = true;
             }
         }
+    } else if (instance.objective() == Objective::Feasibility) {
+        // Disable algorithms which are not available for this objective.
+        use_tree_search_maximal_spaces = false;
+        use_dichotomic_search = false;
+        use_benders_decomposition = false;
+        // Automatic selection.
+        if (!use_tree_search
+                && !use_sequential_single_knapsack
+                && !use_sequential_value_correction
+                && !use_column_generation) {
+            if (mean_item_type_copies(instance)
+                    > parameters.many_item_type_copies_factor
+                    * mean_number_of_items_in_bins) {
+                if (mean_number_of_items_in_bins
+                        > parameters.many_items_in_bins_threshold) {
+                    use_sequential_single_knapsack = true;
+                } else {
+                    use_sequential_value_correction = true;
+                    use_column_generation = true;
+                }
+            } else {
+                use_tree_search = true;
+                use_column_generation = true;
+            }
+        }
     } else if (instance.objective() == Objective::Knapsack) {
         // Disable algorithms which are not available for this objective.
         use_tree_search_maximal_spaces = false;

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -605,6 +605,31 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
                 use_tree_search = true;
             }
         }
+    } else if (instance.objective() == Objective::Feasibility) {
+        // Disable algorithms which are not available for this objective.
+        use_dichotomic_search = false;
+        use_column_generation_strips = false;
+        use_sequential_strips_onedimensional = false;
+        // Automatic selection.
+        if (!use_tree_search
+                && !use_sequential_single_knapsack
+                && !use_sequential_value_correction
+                && !use_column_generation) {
+            if (mean_item_type_copies(instance)
+                    > parameters.many_item_type_copies_factor
+                    * mean_number_of_items_in_bins) {
+                if (mean_number_of_items_in_bins
+                        > parameters.many_items_in_bins_threshold) {
+                    use_sequential_single_knapsack = true;
+                } else {
+                    use_sequential_value_correction = true;
+                    use_column_generation = true;
+                }
+            } else {
+                use_tree_search = true;
+                use_column_generation = true;
+            }
+        }
     } else if (instance.objective() == Objective::Knapsack) {
         // Disable algorithms which are not available for this objective.
         use_dichotomic_search = false;


### PR DESCRIPTION
The multi-bin algorithm-selection else-if chain in each domain's optimize() had no branch for Objective::Feasibility, so all use_* algorithm flags stayed false and no algorithm ran, silently returning an empty (but not marked infeasible) solution. Add a dedicated Feasibility branch, mirroring the Knapsack branch's selection logic, right after the number_of_bins() <= 1 block in rectangleguillotine, rectangle, box, and onedimensional; irregular already had a stub Feasibility branch, now filled in with the same logic instead of the prior unconditional use_tree_search = true fallback.