### PR TITLE
Fix crash on empty-item instances by centralizing optimality checks

### DIFF
--- a/include/packingsolver/box/algorithm_formatter.hpp
+++ b/include/packingsolver/box/algorithm_formatter.hpp
@@ -24,19 +24,8 @@ public:
         output_(output),
         os_(parameters.create_os())
     {
-        // Check optimality.
-        if (instance_.objective() == Objective::BinPacking) {
-            if (output_.solution_pool.best().full()
-                    && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
-                end_ = true;
-            }
-        } else if (instance_.objective() == Objective::Feasibility) {
-            if ((output_.solution_pool.best().full()
-                        && output_.solution_pool.best().feasible())
-                    || output_.is_proven_infeasible) {
-                end_ = true;
-            }
-        }
+        if (output_.is_proven_optimal())
+            end_ = true;
     }
 
     /** Print the header. */

--- a/include/packingsolver/box/optimize.hpp
+++ b/include/packingsolver/box/optimize.hpp
@@ -35,6 +35,36 @@ struct Output: packingsolver::Output<Instance, Solution>
     /** True if the instance has been proven infeasible (Feasibility objective only). */
     bool is_proven_infeasible = false;
 
+    /** Return 'true' iff the current bound proves the best solution optimal. */
+    bool is_proven_optimal() const
+    {
+        switch (solution_pool.best().instance().objective()) {
+        case Objective::Knapsack:
+            return equal(knapsack_bound, solution_pool.best().profit());
+        case Objective::BinPacking:
+            return solution_pool.best().full()
+                && bin_packing_bound == solution_pool.best().number_of_bins();
+        case Objective::VariableSizedBinPacking:
+            return solution_pool.best().full()
+                && equal(variable_sized_bin_packing_bound, solution_pool.best().cost());
+        case Objective::OpenDimensionX:
+            return solution_pool.best().full()
+                && open_dimension_x_bound == solution_pool.best().x_max();
+        case Objective::OpenDimensionY:
+            return solution_pool.best().full()
+                && open_dimension_y_bound == solution_pool.best().y_max();
+        case Objective::OpenDimensionZ:
+            return solution_pool.best().full()
+                && open_dimension_z_bound == solution_pool.best().z_max();
+        case Objective::Feasibility:
+            return (solution_pool.best().full()
+                    && solution_pool.best().feasible())
+                || is_proven_infeasible;
+        default:
+            return false;
+        }
+    }
+
     virtual nlohmann::json to_json() const override
     {
         nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();

--- a/include/packingsolver/boxstacks/algorithm_formatter.hpp
+++ b/include/packingsolver/boxstacks/algorithm_formatter.hpp
@@ -24,19 +24,8 @@ public:
         output_(output),
         os_(parameters.create_os())
     {
-        // Check optimality.
-        if (instance_.objective() == Objective::BinPacking) {
-            if (output_.solution_pool.best().full()
-                    && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
-                end_ = true;
-            }
-        } else if (instance_.objective() == Objective::Feasibility) {
-            if ((output_.solution_pool.best().full()
-                        && output_.solution_pool.best().feasible())
-                    || output_.is_proven_infeasible) {
-                end_ = true;
-            }
-        }
+        if (output_.is_proven_optimal())
+            end_ = true;
     }
 
     /** Print the header. */

--- a/include/packingsolver/boxstacks/optimize.hpp
+++ b/include/packingsolver/boxstacks/optimize.hpp
@@ -26,6 +26,27 @@ struct Output: packingsolver::Output<Instance, Solution>
     /** True if the instance has been proven infeasible (Feasibility objective only). */
     bool is_proven_infeasible = false;
 
+    /** Return 'true' iff the current bound proves the best solution optimal. */
+    bool is_proven_optimal() const
+    {
+        switch (solution_pool.best().instance().objective()) {
+        case Objective::Knapsack:
+            return equal(knapsack_bound, solution_pool.best().profit());
+        case Objective::BinPacking:
+            return solution_pool.best().full()
+                && bin_packing_bound == solution_pool.best().number_of_bins();
+        case Objective::VariableSizedBinPacking:
+            return solution_pool.best().full()
+                && equal(variable_sized_bin_packing_bound, solution_pool.best().cost());
+        case Objective::Feasibility:
+            return (solution_pool.best().full()
+                    && solution_pool.best().feasible())
+                || is_proven_infeasible;
+        default:
+            return false;
+        }
+    }
+
     virtual nlohmann::json to_json() const override
     {
         nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();

--- a/include/packingsolver/irregular/algorithm_formatter.hpp
+++ b/include/packingsolver/irregular/algorithm_formatter.hpp
@@ -24,23 +24,8 @@ public:
         output_(output),
         os_(parameters.create_os())
     {
-        // Check optimality.
-        if (instance_.objective() == Objective::Knapsack) {
-            if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
-                end_ = true;
-            }
-        } else if (instance_.objective() == Objective::BinPacking) {
-            if (output_.solution_pool.best().full()
-                    && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
-                end_ = true;
-            }
-        } else if (instance_.objective() == Objective::Feasibility) {
-            if ((output_.solution_pool.best().full()
-                        && output_.solution_pool.best().feasible())
-                    || output_.is_proven_infeasible) {
-                end_ = true;
-            }
-        }
+        if (output_.is_proven_optimal())
+            end_ = true;
     }
 
     /** Print the header. */

--- a/include/packingsolver/irregular/optimize.hpp
+++ b/include/packingsolver/irregular/optimize.hpp
@@ -32,6 +32,33 @@ struct Output: packingsolver::Output<Instance, Solution>
     /** True if the instance has been proven infeasible (Feasibility objective only). */
     bool is_proven_infeasible = false;
 
+    /** Return 'true' iff the current bound proves the best solution optimal. */
+    bool is_proven_optimal() const
+    {
+        switch (solution_pool.best().instance().objective()) {
+        case Objective::Knapsack:
+            return equal(knapsack_bound, solution_pool.best().profit());
+        case Objective::BinPacking:
+            return solution_pool.best().full()
+                && bin_packing_bound == solution_pool.best().number_of_bins();
+        case Objective::VariableSizedBinPacking:
+            return solution_pool.best().full()
+                && equal(variable_sized_bin_packing_bound, solution_pool.best().cost());
+        case Objective::OpenDimensionX:
+            return solution_pool.best().full()
+                && equal(open_dimension_x_bound, solution_pool.best().x_max());
+        case Objective::OpenDimensionY:
+            return solution_pool.best().full()
+                && equal(open_dimension_y_bound, solution_pool.best().y_max());
+        case Objective::Feasibility:
+            return (solution_pool.best().full()
+                    && solution_pool.best().feasible())
+                || is_proven_infeasible;
+        default:
+            return false;
+        }
+    }
+
     virtual nlohmann::json to_json() const override
     {
         nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();

--- a/include/packingsolver/onedimensional/algorithm_formatter.hpp
+++ b/include/packingsolver/onedimensional/algorithm_formatter.hpp
@@ -24,28 +24,8 @@ public:
         output_(output),
         os_(parameters.create_os())
     {
-        // Check optimality.
-        if (instance_.objective() == Objective::Knapsack) {
-            if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
-                end_ = true;
-            }
-       } else if (instance_.objective() == Objective::BinPacking) {
-            if (output_.solution_pool.best().full()
-                    && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
-                end_ = true;
-            }
-       } else if (instance_.objective() == Objective::VariableSizedBinPacking) {
-            if (output_.solution_pool.best().full()
-                    && equal(output_.variable_sized_bin_packing_bound, output_.solution_pool.best().cost())) {
-                end_ = true;
-            }
-       } else if (instance_.objective() == Objective::Feasibility) {
-            if ((output_.solution_pool.best().full()
-                        && output_.solution_pool.best().feasible())
-                    || output_.is_proven_infeasible) {
-                end_ = true;
-            }
-        }
+        if (output_.is_proven_optimal())
+            end_ = true;
     }
 
     /** Print the header. */

--- a/include/packingsolver/onedimensional/optimize.hpp
+++ b/include/packingsolver/onedimensional/optimize.hpp
@@ -26,6 +26,27 @@ struct Output: packingsolver::Output<Instance, Solution>
     /** True if the instance has been proven infeasible (Feasibility objective only). */
     bool is_proven_infeasible = false;
 
+    /** Return 'true' iff the current bound proves the best solution optimal. */
+    bool is_proven_optimal() const
+    {
+        switch (solution_pool.best().instance().objective()) {
+        case Objective::Knapsack:
+            return equal(knapsack_bound, solution_pool.best().profit());
+        case Objective::BinPacking:
+            return solution_pool.best().full()
+                && bin_packing_bound == solution_pool.best().number_of_bins();
+        case Objective::VariableSizedBinPacking:
+            return solution_pool.best().full()
+                && equal(variable_sized_bin_packing_bound, solution_pool.best().cost());
+        case Objective::Feasibility:
+            return (solution_pool.best().full()
+                    && solution_pool.best().feasible())
+                || is_proven_infeasible;
+        default:
+            return false;
+        }
+    }
+
     virtual nlohmann::json to_json() const override
     {
         nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();

--- a/include/packingsolver/rectangle/algorithm_formatter.hpp
+++ b/include/packingsolver/rectangle/algorithm_formatter.hpp
@@ -22,7 +22,11 @@ public:
         instance_(instance),
         parameters_(parameters),
         output_(output),
-        os_(parameters.create_os()) { }
+        os_(parameters.create_os())
+    {
+        if (output_.is_proven_optimal())
+            end_ = true;
+    }
 
     /** Print the header. */
     void start();

--- a/include/packingsolver/rectangle/optimize.hpp
+++ b/include/packingsolver/rectangle/optimize.hpp
@@ -32,6 +32,33 @@ struct Output: packingsolver::Output<Instance, Solution>
     /** True if the instance has been proven infeasible (Feasibility objective only). */
     bool is_proven_infeasible = false;
 
+    /** Return 'true' iff the current bound proves the best solution optimal. */
+    bool is_proven_optimal() const
+    {
+        switch (solution_pool.best().instance().objective()) {
+        case Objective::Knapsack:
+            return equal(knapsack_bound, solution_pool.best().profit());
+        case Objective::BinPacking:
+            return solution_pool.best().full()
+                && bin_packing_bound == solution_pool.best().number_of_bins();
+        case Objective::VariableSizedBinPacking:
+            return solution_pool.best().full()
+                && equal(variable_sized_bin_packing_bound, solution_pool.best().cost());
+        case Objective::OpenDimensionX:
+            return solution_pool.best().full()
+                && open_dimension_x_bound == solution_pool.best().x_max();
+        case Objective::OpenDimensionY:
+            return solution_pool.best().full()
+                && open_dimension_y_bound == solution_pool.best().y_max();
+        case Objective::Feasibility:
+            return (solution_pool.best().full()
+                    && solution_pool.best().feasible())
+                || is_proven_infeasible;
+        default:
+            return false;
+        }
+    }
+
     virtual nlohmann::json to_json() const override
     {
         nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();

--- a/include/packingsolver/rectangleguillotine/algorithm_formatter.hpp
+++ b/include/packingsolver/rectangleguillotine/algorithm_formatter.hpp
@@ -24,19 +24,8 @@ public:
         output_(output),
         os_(parameters.create_os())
     {
-        // Check optimality.
-        if (instance_.objective() == Objective::BinPacking) {
-            if (output_.solution_pool.best().full()
-                    && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
-                end_ = true;
-            }
-        } else if (instance_.objective() == Objective::Feasibility) {
-            if ((output_.solution_pool.best().full()
-                        && output_.solution_pool.best().feasible())
-                    || output_.is_proven_infeasible) {
-                end_ = true;
-            }
-        }
+        if (output_.is_proven_optimal())
+            end_ = true;
     }
 
     /** Print the header. */

--- a/include/packingsolver/rectangleguillotine/optimize.hpp
+++ b/include/packingsolver/rectangleguillotine/optimize.hpp
@@ -32,6 +32,33 @@ struct Output: packingsolver::Output<Instance, Solution>
     /** True if the instance has been proven infeasible (Feasibility objective only). */
     bool is_proven_infeasible = false;
 
+    /** Return 'true' iff the current bound proves the best solution optimal. */
+    bool is_proven_optimal() const
+    {
+        switch (solution_pool.best().instance().objective()) {
+        case Objective::Knapsack:
+            return equal(knapsack_bound, solution_pool.best().profit());
+        case Objective::BinPacking:
+            return solution_pool.best().full()
+                && bin_packing_bound == solution_pool.best().number_of_bins();
+        case Objective::VariableSizedBinPacking:
+            return solution_pool.best().full()
+                && equal(variable_sized_bin_packing_bound, solution_pool.best().cost());
+        case Objective::OpenDimensionX:
+            return solution_pool.best().full()
+                && open_dimension_x_bound == solution_pool.best().width();
+        case Objective::OpenDimensionY:
+            return solution_pool.best().full()
+                && open_dimension_y_bound == solution_pool.best().height();
+        case Objective::Feasibility:
+            return (solution_pool.best().full()
+                    && solution_pool.best().feasible())
+                || is_proven_infeasible;
+        default:
+            return false;
+        }
+    }
+
     virtual nlohmann::json to_json() const override
     {
         nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();

--- a/src/box/algorithm_formatter.cpp
+++ b/src/box/algorithm_formatter.cpp
@@ -260,19 +260,8 @@ void AlgorithmFormatter::update_solution(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (instance_.objective() == Objective::BinPacking) {
-            if (output_.solution_pool.best().full()
-                    && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
-                end_ = true;
-            }
-        } else if (instance_.objective() == Objective::Feasibility) {
-            if (output_.solution_pool.best().full()
-                    && output_.solution_pool.best().feasible()) {
-                end_ = true;
-            }
-        }
-
+        if (output_.is_proven_optimal())
+            end_ = true;
     }
     mutex_.unlock();
 }
@@ -300,10 +289,8 @@ void AlgorithmFormatter::update_knapsack_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -318,11 +305,8 @@ void AlgorithmFormatter::update_bin_packing_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -337,11 +321,8 @@ void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && equal(output_.variable_sized_bin_packing_bound, output_.solution_pool.best().cost())) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -356,11 +337,8 @@ void AlgorithmFormatter::update_open_dimension_x_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && output_.open_dimension_x_bound == output_.solution_pool.best().x_max()) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -375,11 +353,8 @@ void AlgorithmFormatter::update_open_dimension_y_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && output_.open_dimension_y_bound == output_.solution_pool.best().y_max()) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -394,11 +369,8 @@ void AlgorithmFormatter::update_open_dimension_z_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && output_.open_dimension_z_bound == output_.solution_pool.best().z_max()) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }

--- a/src/box/optimize.cpp
+++ b/src/box/optimize.cpp
@@ -405,6 +405,30 @@ packingsolver::box::Output packingsolver::box::optimize(
     algorithm_formatter.start();
     algorithm_formatter.print_header();
 
+    optimize_trivial_bound(instance, algorithm_formatter);
+
+    if (instance.objective() == Objective::BinPacking) {
+        // The 3-axis threshold sweep is cubic in the number of item types
+        // (against quadratic for the 2D 'rectangle' case), so this is
+        // gated more conservatively.
+        if (instance.number_of_bin_types() == 1
+                && instance.number_of_items() <= 50) {
+            optimize_dual_feasible_functions(
+                    instance,
+                    parameters,
+                    algorithm_formatter);
+        }
+    }
+
+    if (algorithm_formatter.end_boolean()) {
+        algorithm_formatter.end();
+        return output;
+    }
+    if (parameters.timer.needs_to_end()) {
+        algorithm_formatter.end();
+        return output;
+    }
+
     // Select algorithms to run.
     ItemPos mean_number_of_items_in_bins
         = largest_bin_space(instance) / mean_item_space(instance);
@@ -576,30 +600,6 @@ packingsolver::box::Output packingsolver::box::optimize(
                 }
             }
         }
-    }
-
-    optimize_trivial_bound(instance, algorithm_formatter);
-
-    if (instance.objective() == Objective::BinPacking) {
-        // The 3-axis threshold sweep is cubic in the number of item types
-        // (against quadratic for the 2D 'rectangle' case), so this is
-        // gated more conservatively.
-        if (instance.number_of_bin_types() == 1
-                && instance.number_of_items() <= 50) {
-            optimize_dual_feasible_functions(
-                    instance,
-                    parameters,
-                    algorithm_formatter);
-        }
-    }
-
-    if (algorithm_formatter.end_boolean()) {
-        algorithm_formatter.end();
-        return output;
-    }
-    if (parameters.timer.needs_to_end()) {
-        algorithm_formatter.end();
-        return output;
     }
 
     // Run selected algorithms.

--- a/src/boxstacks/algorithm_formatter.cpp
+++ b/src/boxstacks/algorithm_formatter.cpp
@@ -242,19 +242,8 @@ void AlgorithmFormatter::update_solution(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (instance_.objective() == Objective::BinPacking) {
-            if (output_.solution_pool.best().full()
-                    && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
-                end_ = true;
-            }
-        } else if (instance_.objective() == Objective::Feasibility) {
-            if (output_.solution_pool.best().full()
-                    && output_.solution_pool.best().feasible()) {
-                end_ = true;
-            }
-        }
-
+        if (output_.is_proven_optimal())
+            end_ = true;
     }
     mutex_.unlock();
 }
@@ -282,10 +271,8 @@ void AlgorithmFormatter::update_knapsack_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -300,11 +287,8 @@ void AlgorithmFormatter::update_bin_packing_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -319,11 +303,8 @@ void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && equal(output_.variable_sized_bin_packing_bound, output_.solution_pool.best().cost())) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }

--- a/src/irregular/algorithm_formatter.cpp
+++ b/src/irregular/algorithm_formatter.cpp
@@ -257,23 +257,8 @@ void AlgorithmFormatter::update_solution(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (instance_.objective() == Objective::Knapsack) {
-            if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
-                end_ = true;
-            }
-        } else if (instance_.objective() == Objective::BinPacking) {
-            if (output_.solution_pool.best().full()
-                    && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
-                end_ = true;
-            }
-        } else if (instance_.objective() == Objective::Feasibility) {
-            if (output_.solution_pool.best().full()
-                    && output_.solution_pool.best().feasible()) {
-                end_ = true;
-            }
-        }
-
+        if (output_.is_proven_optimal())
+            end_ = true;
     }
     mutex_.unlock();
 }
@@ -301,10 +286,8 @@ void AlgorithmFormatter::update_knapsack_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -319,11 +302,8 @@ void AlgorithmFormatter::update_bin_packing_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -338,11 +318,8 @@ void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && equal(output_.variable_sized_bin_packing_bound, output_.solution_pool.best().cost())) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -357,11 +334,8 @@ void AlgorithmFormatter::update_open_dimension_x_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && equal(output_.open_dimension_x_bound, output_.solution_pool.best().x_max())) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -376,11 +350,8 @@ void AlgorithmFormatter::update_open_dimension_y_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && equal(output_.open_dimension_y_bound, output_.solution_pool.best().y_max())) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }

--- a/src/irregular/optimize.cpp
+++ b/src/irregular/optimize.cpp
@@ -492,6 +492,37 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
     algorithm_formatter.start();
     algorithm_formatter.print_header();
 
+    optimize_trivial_bound(instance, algorithm_formatter);
+
+    if (instance.objective() == Objective::BinPacking
+            || instance.objective() == Objective::Knapsack
+            || instance.objective() == Objective::VariableSizedBinPacking) {
+        optimize_onedimensional_bound(
+                instance,
+                parameters,
+                algorithm_formatter);
+    }
+
+    if (instance.number_of_items() == 1
+            && instance.number_of_bins() == 1
+            && (instance.objective() == Objective::Knapsack
+                || instance.objective() == Objective::BinPacking
+                || instance.objective() == Objective::Feasibility)) {
+        optimize_trivial_single_item(
+                instance,
+                parameters,
+                algorithm_formatter);
+    }
+
+    if (algorithm_formatter.end_boolean()) {
+        algorithm_formatter.end();
+        return output;
+    }
+    if (parameters.timer.needs_to_end()) {
+        algorithm_formatter.end();
+        return output;
+    }
+
     // Select algorithms to run.
     ItemPos mean_number_of_items_in_bins
         = largest_bin_space(instance) / mean_item_space(instance);
@@ -649,37 +680,6 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
                 }
             }
         }
-    }
-
-    optimize_trivial_bound(instance, algorithm_formatter);
-
-    if (instance.objective() == Objective::BinPacking
-            || instance.objective() == Objective::Knapsack
-            || instance.objective() == Objective::VariableSizedBinPacking) {
-        optimize_onedimensional_bound(
-                instance,
-                parameters,
-                algorithm_formatter);
-    }
-
-    if (instance.number_of_items() == 1
-            && instance.number_of_bins() == 1
-            && (instance.objective() == Objective::Knapsack
-                || instance.objective() == Objective::BinPacking
-                || instance.objective() == Objective::Feasibility)) {
-        optimize_trivial_single_item(
-                instance,
-                parameters,
-                algorithm_formatter);
-    }
-
-    if (algorithm_formatter.end_boolean()) {
-        algorithm_formatter.end();
-        return output;
-    }
-    if (parameters.timer.needs_to_end()) {
-        algorithm_formatter.end();
-        return output;
     }
 
     // Run selected algorithms.

--- a/src/onedimensional/algorithm_formatter.cpp
+++ b/src/onedimensional/algorithm_formatter.cpp
@@ -206,27 +206,8 @@ void AlgorithmFormatter::update_solution(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (instance_.objective() == Objective::Knapsack) {
-            if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
-                end_ = true;
-            }
-       } else if (instance_.objective() == Objective::BinPacking) {
-            if (output_.solution_pool.best().full()
-                    && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
-                end_ = true;
-            }
-       } else if (instance_.objective() == Objective::VariableSizedBinPacking) {
-            if (output_.solution_pool.best().full()
-                    && equal(output_.variable_sized_bin_packing_bound, output_.solution_pool.best().cost())) {
-                end_ = true;
-            }
-        } else if (instance_.objective() == Objective::Feasibility) {
-            if (output_.solution_pool.best().full()
-                    && output_.solution_pool.best().feasible()) {
-                end_ = true;
-            }
-        }
+        if (output_.is_proven_optimal())
+            end_ = true;
     }
     mutex_.unlock();
 }
@@ -254,10 +235,8 @@ void AlgorithmFormatter::update_knapsack_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -272,11 +251,8 @@ void AlgorithmFormatter::update_bin_packing_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -291,11 +267,8 @@ void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && equal(output_.variable_sized_bin_packing_bound, output_.solution_pool.best().cost())) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -378,6 +378,25 @@ packingsolver::onedimensional::Output packingsolver::onedimensional::optimize(
     algorithm_formatter.start();
     algorithm_formatter.print_header();
 
+    optimize_trivial_bound(instance, algorithm_formatter);
+
+    if (instance.number_of_bins() == 1
+            && instance.objective() == Objective::Knapsack) {
+        optimize_dynamic_programming(
+                instance,
+                parameters,
+                algorithm_formatter);
+    }
+
+    if (algorithm_formatter.end_boolean()) {
+        algorithm_formatter.end();
+        return output;
+    }
+    if (parameters.timer.needs_to_end()) {
+        algorithm_formatter.end();
+        return output;
+    }
+
     // Select algorithms to run.
     ItemPos mean_number_of_items_in_bins
         = largest_bin_space(instance) / mean_item_space(instance);
@@ -513,25 +532,6 @@ packingsolver::onedimensional::Output packingsolver::onedimensional::optimize(
                 }
             }
         }
-    }
-
-    optimize_trivial_bound(instance, algorithm_formatter);
-
-    if (instance.number_of_bins() == 1
-            && instance.objective() == Objective::Knapsack) {
-        optimize_dynamic_programming(
-                instance,
-                parameters,
-                algorithm_formatter);
-    }
-
-    if (algorithm_formatter.end_boolean()) {
-        algorithm_formatter.end();
-        return output;
-    }
-    if (parameters.timer.needs_to_end()) {
-        algorithm_formatter.end();
-        return output;
     }
 
     // Run selected algorithms.

--- a/src/rectangle/algorithm_formatter.cpp
+++ b/src/rectangle/algorithm_formatter.cpp
@@ -242,23 +242,8 @@ void AlgorithmFormatter::update_solution(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (instance_.objective() == Objective::Knapsack) {
-            if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
-                end_ = true;
-            }
-        } else if (instance_.objective() == Objective::BinPacking) {
-            if (output_.solution_pool.best().full()
-                    && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
-                end_ = true;
-            }
-        } else if (instance_.objective() == Objective::Feasibility) {
-            if (output_.solution_pool.best().full()
-                    && output_.solution_pool.best().feasible()) {
-                end_ = true;
-            }
-        }
-
+        if (output_.is_proven_optimal())
+            end_ = true;
     }
     mutex_.unlock();
 }
@@ -286,10 +271,8 @@ void AlgorithmFormatter::update_knapsack_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -304,11 +287,8 @@ void AlgorithmFormatter::update_bin_packing_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -323,11 +303,8 @@ void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && equal(output_.variable_sized_bin_packing_bound, output_.solution_pool.best().cost())) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -342,11 +319,8 @@ void AlgorithmFormatter::update_open_dimension_x_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && output_.open_dimension_x_bound == output_.solution_pool.best().x_max()) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -361,11 +335,8 @@ void AlgorithmFormatter::update_open_dimension_y_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && output_.open_dimension_y_bound == output_.solution_pool.best().y_max()) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -428,6 +428,27 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
     algorithm_formatter.start();
     algorithm_formatter.print_header();
 
+    optimize_trivial_bound(instance, algorithm_formatter);
+
+    if (instance.objective() == Objective::BinPacking) {
+        if (instance.number_of_bin_types() == 1
+                && instance.number_of_items() <= 100) {
+            optimize_dual_feasible_functions(
+                    instance,
+                    parameters,
+                    algorithm_formatter);
+        }
+    }
+
+    if (algorithm_formatter.end_boolean()) {
+        algorithm_formatter.end();
+        return output;
+    }
+    if (parameters.timer.needs_to_end()) {
+        algorithm_formatter.end();
+        return output;
+    }
+
     // Select algorithms to run.
     ItemPos mean_number_of_items_in_bins
         = largest_bin_space(instance) / mean_item_space(instance);
@@ -588,27 +609,6 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
                 }
             }
         }
-    }
-
-    optimize_trivial_bound(instance, algorithm_formatter);
-
-    if (instance.objective() == Objective::BinPacking) {
-        if (instance.number_of_bin_types() == 1
-                && instance.number_of_items() <= 100) {
-            optimize_dual_feasible_functions(
-                    instance,
-                    parameters,
-                    algorithm_formatter);
-        }
-    }
-
-    if (algorithm_formatter.end_boolean()) {
-        algorithm_formatter.end();
-        return output;
-    }
-    if (parameters.timer.needs_to_end()) {
-        algorithm_formatter.end();
-        return output;
     }
 
     // Run selected algorithms.

--- a/src/rectangleguillotine/algorithm_formatter.cpp
+++ b/src/rectangleguillotine/algorithm_formatter.cpp
@@ -266,19 +266,8 @@ void AlgorithmFormatter::update_solution(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (instance_.objective() == Objective::BinPacking) {
-            if (output_.solution_pool.best().full()
-                    && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
-                end_ = true;
-            }
-        } else if (instance_.objective() == Objective::Feasibility) {
-            if (output_.solution_pool.best().full()
-                    && output_.solution_pool.best().feasible()) {
-                end_ = true;
-            }
-        }
-
+        if (output_.is_proven_optimal())
+            end_ = true;
     }
     mutex_.unlock();
 }
@@ -306,10 +295,8 @@ void AlgorithmFormatter::update_knapsack_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (equal(output_.knapsack_bound, output_.solution_pool.best().profit())) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -324,11 +311,8 @@ void AlgorithmFormatter::update_bin_packing_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && output_.bin_packing_bound == output_.solution_pool.best().number_of_bins()) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -343,11 +327,8 @@ void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && equal(output_.variable_sized_bin_packing_bound, output_.solution_pool.best().cost())) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -362,11 +343,8 @@ void AlgorithmFormatter::update_open_dimension_x_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && output_.open_dimension_x_bound == output_.solution_pool.best().width()) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }
@@ -381,11 +359,8 @@ void AlgorithmFormatter::update_open_dimension_y_bound(
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
 
-        // Check optimality.
-        if (output_.solution_pool.best().full()
-                && output_.open_dimension_y_bound == output_.solution_pool.best().height()) {
+        if (output_.is_proven_optimal())
             end_ = true;
-        }
     }
     mutex_.unlock();
 }

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -550,6 +550,27 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
     algorithm_formatter.start();
     algorithm_formatter.print_header();
 
+    optimize_trivial_bound(instance, algorithm_formatter);
+
+    if (instance.objective() == Objective::BinPacking) {
+        if (instance.number_of_bin_types() == 1
+                && instance.number_of_items() <= 100) {
+            optimize_dual_feasible_functions(
+                    instance,
+                    parameters,
+                    algorithm_formatter);
+        }
+    }
+
+    if (algorithm_formatter.end_boolean()) {
+        algorithm_formatter.end();
+        return output;
+    }
+    if (parameters.timer.needs_to_end()) {
+        algorithm_formatter.end();
+        return output;
+    }
+
     // Select algorithms to run.
     ItemPos mean_number_of_items_in_bins
         = largest_bin_space(instance) / mean_item_space(instance);
@@ -752,27 +773,6 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
         use_sequential_value_correction = false;
         use_dichotomic_search = false;
         use_column_generation = false;
-    }
-
-    optimize_trivial_bound(instance, algorithm_formatter);
-
-    if (instance.objective() == Objective::BinPacking) {
-        if (instance.number_of_bin_types() == 1
-                && instance.number_of_items() <= 100) {
-            optimize_dual_feasible_functions(
-                    instance,
-                    parameters,
-                    algorithm_formatter);
-        }
-    }
-
-    if (algorithm_formatter.end_boolean()) {
-        algorithm_formatter.end();
-        return output;
-    }
-    if (parameters.timer.needs_to_end()) {
-        algorithm_formatter.end();
-        return output;
     }
 
     // Run selected algorithms.


### PR DESCRIPTION
Reorder optimize_trivial_bound() (and the objective-specific bound helpers) before the algorithm-selection heuristics in each domain's optimize(), so they run before mean_item_space()/mean_number_of_items_in_bins is computed. With zero item types that computation divides by zero, producing a NaN that gets cast to an integer (UB) ahead of any early-return check.

Add Output::is_proven_optimal() to each domain, covering every objective that has a bound (Knapsack, BinPacking,
VariableSizedBinPacking, OpenDimensionX/Y/Z, Feasibility), and call it from the AlgorithmFormatter constructor, update_solution(), and every update_*_bound() method instead of each maintaining its own partial, independently-drifting copy of the same objective-by-objective check. This is what actually fixes the reported crash: VariableSizedBinPacking had no such check anywhere, so an empty instance fell through into column generation, where dummy_column_objective_coefficient (derived from largest_item_copies(), zero for an empty instance) is rejected as non-null by columngenerationsolver.