### PR TITLE
Use true/false consistently for use_* boolean parameter assignments

### DIFF
--- a/src/box/optimize.cpp
+++ b/src/box/optimize.cpp
@@ -306,7 +306,7 @@ void optimize_dichotomic_search(
                     = (parameters.optimization_mode == OptimizationMode::NotAnytimeSequential)?
                     OptimizationMode::NotAnytimeSequential:
                     OptimizationMode::NotAnytimeDeterministic;
-                bpp_parameters.use_tree_search = 1;
+                bpp_parameters.use_tree_search = true;
                 bpp_parameters.not_anytime_tree_search_queue_size = queue_size;
                 bpp_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
                 auto bpp_output = optimize(bpp_instance, bpp_parameters);

--- a/src/boxstacks/sequential_onedimensional_rectangle.cpp
+++ b/src/boxstacks/sequential_onedimensional_rectangle.cpp
@@ -737,7 +737,7 @@ const SequentialOneDimensionalRectangleOutput boxstacks::sequential_onedimension
                 = (parameters.sequential)?
                 OptimizationMode::NotAnytimeSequential:
                 OptimizationMode::NotAnytime;
-            onedim_parameters.use_column_generation = 1;
+            onedim_parameters.use_column_generation = true;
             auto onedim_begin = std::chrono::steady_clock::now();
             auto onedim_output = onedimensional::optimize(
                     onedim_instance,

--- a/src/irregular/optimize.cpp
+++ b/src/irregular/optimize.cpp
@@ -366,7 +366,7 @@ void optimize_dichotomic_search(
                     OptimizationMode::NotAnytimeSequential:
                     OptimizationMode::NotAnytimeDeterministic;
                 bpp_parameters.not_anytime_maximum_approximation_ratio = maximum_approximation_ratio;
-                bpp_parameters.use_tree_search = 1;
+                bpp_parameters.use_tree_search = true;
                 bpp_parameters.not_anytime_tree_search_queue_size = queue_size;
                 bpp_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
                 auto bpp_output = optimize(bpp_instance, bpp_parameters);

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -281,7 +281,7 @@ void optimize_dichotomic_search(
                     = (parameters.optimization_mode == OptimizationMode::NotAnytimeSequential)?
                     OptimizationMode::NotAnytimeSequential:
                     OptimizationMode::NotAnytimeDeterministic;
-                bpp_parameters.use_tree_search = 1;
+                bpp_parameters.use_tree_search = true;
                 bpp_parameters.not_anytime_tree_search_queue_size = queue_size;
                 bpp_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
                 auto bpp_output = optimize(bpp_instance, bpp_parameters);

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -278,7 +278,7 @@ void optimize_dichotomic_search(
                     = (parameters.optimization_mode == OptimizationMode::NotAnytimeSequential)?
                     OptimizationMode::NotAnytimeSequential:
                     OptimizationMode::NotAnytimeDeterministic;
-                bpp_parameters.use_tree_search = 1;
+                bpp_parameters.use_tree_search = true;
                 bpp_parameters.not_anytime_tree_search_queue_size = queue_size;
                 bpp_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
                 auto bpp_output = optimize(bpp_instance, bpp_parameters);

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -451,7 +451,7 @@ void optimize_dichotomic_search(
                     = (parameters.optimization_mode == OptimizationMode::NotAnytimeSequential)?
                     OptimizationMode::NotAnytimeSequential:
                     OptimizationMode::NotAnytimeDeterministic;
-                bpp_parameters.use_tree_search = 1;
+                bpp_parameters.use_tree_search = true;
                 bpp_parameters.not_anytime_tree_search_queue_size = queue_size;
                 bpp_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
                 auto bpp_output = optimize(bpp_instance, bpp_parameters);


### PR DESCRIPTION
Several sub-parameter assignments used 1 instead of true, while every other assignment to these bool fields used true/false.