### PR TITLE
irregular: fix crash in shape approximation when item_item_minimum_spacing meets holed items

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -34,11 +34,16 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(optimizationtools)
 
 # Fetch fontanf/shape.
+# PATCH: approximate_by_line_segments seeded its union with the arc-bearing shape,
+# leaking CircularArcs through compute_union -> is_polygon() throw on inflated holed
+# shapes (the native item_item_minimum_spacing crash). Patch is idempotent: apply,
+# or verify already-applied via --reverse --check.
 set(SHAPE_BUILD_TEST OFF)
 FetchContent_Declare(
     shape
     GIT_REPOSITORY https://github.com/fontanf/shape.git
     GIT_TAG 1809a9c7a1f8734fc8c7330ffe00cc3270ba7d44
+    PATCH_COMMAND git apply --ignore-whitespace "${CMAKE_CURRENT_SOURCE_DIR}/shape-approximation-297.patch" || git apply --reverse --check --ignore-whitespace "${CMAKE_CURRENT_SOURCE_DIR}/shape-approximation-297.patch"
     #SOURCE_DIR "${PROJECT_SOURCE_DIR}/../shape/"
     EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(shape)

--- a/extern/shape-approximation-297.patch
+++ b/extern/shape-approximation-297.patch
@@ -1,0 +1,74 @@
+diff --git a/src/approximation.cpp b/src/approximation.cpp
+index 99a797d..6bb6f4f 100644
+--- a/src/approximation.cpp
++++ b/src/approximation.cpp
+@@ -359,7 +359,9 @@ ShapeWithHoles shape::approximate_shape_by_line_segments(
+         return shape_new;
+     }
+ 
+-    std::vector<ShapeWithHoles> union_input = {{shape}};
++    // Seed with the FLATTENED shape — seeding with `shape` leaks CircularArc
++    // elements through compute_union into the result (packingsolver #297).
++    std::vector<ShapeWithHoles> union_input = {shape_new};
+ 
+     for (const ShapeElement& element: shape.elements) {
+         switch (element.type) {
+@@ -384,7 +386,11 @@ ShapeWithHoles shape::approximate_shape_by_line_segments(
+ 
+     //Writer().add_shapes_with_holes(union_input).write_json("union_input.json");
+     std::vector<ShapeWithHoles> union_output = compute_union(union_input);
+-    return union_output.front();
++    const ShapeWithHoles* best = &union_output.front();
++    for (const ShapeWithHoles& component: union_output)
++        if (component.shape.compute_area() > best->shape.compute_area())
++            best = &component;
++    return *best;
+ }
+ 
+ Shape shape::approximate_path_by_line_segments(
+@@ -501,7 +507,10 @@ ShapeWithHoles shape::approximate_by_line_segments(
+         return shape_new;
+     }
+ 
+-    std::vector<ShapeWithHoles> union_input = {shape};
++    // Union the FLATTENED shape with the arc extras. Seeding with `shape` leaks
++    // CircularArc elements through compute_union into the result, whose holes then
++    // fail is_polygon() — crashes on inflated holed shapes (packingsolver #297).
++    std::vector<ShapeWithHoles> union_input = {shape_new};
+ 
+     for (const ShapeElement& element: shape.shape.elements) {
+         switch (element.type) {
+@@ -519,7 +528,6 @@ ShapeWithHoles shape::approximate_by_line_segments(
+     }
+ 
+     for (const Shape& hole: shape.holes) {
+-        Shape hole_new;
+         for (const ShapeElement& element: hole.elements) {
+             switch (element.type) {
+             case ShapeElementType::LineSegment: {
+@@ -534,7 +542,6 @@ ShapeWithHoles shape::approximate_by_line_segments(
+             }
+             }
+         }
+-        shape_new.holes.push_back(hole_new);
+     }
+ 
+     std::vector<ShapeWithHoles> union_output = compute_union(union_input);
+@@ -545,10 +552,15 @@ ShapeWithHoles shape::approximate_by_line_segments(
+         .add_shapes_with_holes(union_output, "Union output")
+         .write_json("union_input.json");
+ #endif
+-    if (!union_output.front().is_polygon()) {
++    // Extras always touch the shape, but be defensive: keep the largest component.
++    const ShapeWithHoles* best = &union_output.front();
++    for (const ShapeWithHoles& component: union_output)
++        if (component.shape.compute_area() > best->shape.compute_area())
++            best = &component;
++    if (!best->is_polygon()) {
+         throw std::logic_error(FUNC_SIGNATURE);
+     }
+-    return union_output.front();
++    return *best;
+ }
+ 
+ void shape::approximate_shape_by_line_segments_export_inputs(


### PR DESCRIPTION
## Symptom

The `irregular` solver aborts with:

```
Error: struct shape::ShapeWithHoles __cdecl shape::approximate_by_line_segments(const struct shape::ShapeWithHoles &,double)
```

Typical trigger: `--item-item-minimum-spacing` > 0 on instances containing item shapes with interior holes. It can also fire without spacing when a very thin item skews instance scaling. Minimal reliable repro from a real laser-cutting job: one 18-hole polygon item + one needle-thin 3-vertex triangle (bbox ≈ 3.9×6.7), VSBP objective — crashes on load, before any placement.

## Root cause (in the pinned fontanf/shape dependency)

In `approximate_by_line_segments` — both the `ShapeWithHoles` and `Shape` overloads — when the arc-flattened approximation self-intersects, the shape is rebuilt through `compute_union`. The union input is seeded with the **original arc-bearing shape** instead of the flattened one:

```cpp
std::vector<ShapeWithHoles> union_input = {shape};   // CircularArcs leak into the union
```

`compute_union` passes those `CircularArc` elements through into its output, whose rings then fail `is_polygon()` → `throw std::logic_error(FUNC_SIGNATURE)`. Spacing inflation rounds hole corners into arcs, which is why holed shapes + minimum spacing hit this path. The hole loop in the `ShapeWithHoles` overload additionally pushes half-built empty `hole_new` rings into `shape_new`, which corrupts the seed once it is used correctly.

## Change

Since `shape` is consumed via FetchContent at a pinned commit, this PR carries the fix as `extern/shape-approximation-297.patch` applied through `PATCH_COMMAND` (idempotent — re-applies or verifies already-applied on reconfigure):

1. Seed the union with the flattened `shape_new` (the arc-extras still cover the chord-vs-arc gap regions), so the union input is all line segments by construction.
2. Remove the stray empty-hole pushes.
3. Return the largest-area union component instead of `union_output.front()`.

If you'd prefer the fix directly in fontanf/shape plus a pin bump here, happy to open that PR instead — this form just makes the fix usable from this repo immediately.

## Validation

- The saved failing instances (18-hole part + sliver, VSBP, spacing 5) load and solve after the fix; items place correctly.
- Minimum spacing verified in solutions: minimum pairwise item distance exactly equals the requested spacing, including around holed items.
- Regression benchmark over 7 production nesting cases (switching a downstream pipeline from a Shapely pre-inflation workaround to native `item_item_minimum_spacing`): −3.4% total sheet area, −39% wall time, identical placement counts.