### PR TITLE
Bump the shape dependency and adapt to its MultiShapeWithHoles and RasterizedGrid API changes

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -38,7 +38,7 @@ set(SHAPE_BUILD_TEST OFF)
 FetchContent_Declare(
     shape
     GIT_REPOSITORY https://github.com/fontanf/shape.git
-    GIT_TAG abea9254537b8a5ad9fa3d410523379b54d3c962
+    GIT_TAG 20cf454450c2bb1a0086ee93d29e0ff3cbd0a5ef
     #SOURCE_DIR "${PROJECT_SOURCE_DIR}/../shape/"
     EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(shape)

--- a/src/irregular/local_search.cpp
+++ b/src/irregular/local_search.cpp
@@ -110,8 +110,10 @@ BinPos assign_item_to_bin(
     for (const Defect& border: best_bin_type.borders)
         occupied_shapes.push_back(border.shape_scaled);
 
-    const std::vector<shape::ShapeWithHoles> free_regions =
-            shape::compute_difference({bin_shape}, occupied_shapes);
+    const shape::MultiShapeWithHoles free_regions_multi = shape::compute_difference(
+            shape::MultiShapeWithHoles{{bin_shape}},
+            shape::MultiShapeWithHoles{occupied_shapes});
+    const std::vector<shape::ShapeWithHoles>& free_regions = free_regions_multi.shapes_with_holes;
     //shape::Writer().add_shape_with_holes(bin_shape, "Bin")
     //    .add_shapes_with_holes(occupied_shapes, "Occupied")
     //    .add_shapes_with_holes(free_regions, "Difference")

--- a/src/irregular/milp_raster.cpp
+++ b/src/irregular/milp_raster.cpp
@@ -114,14 +114,21 @@ Solution solve_milp_raster_for_cell_size(
                 border_pos < (Counter)bin_type.borders.size();
                 ++border_pos) {
             const ShapeWithHoles& border_shape = bin_type.borders[border_pos].shape_scaled;
-            std::vector<shape::IntersectedCell> border_cells = shape::rasterization(border_shape, cell_size, cell_size);
+            shape::RasterizedGrid border_grid = shape::rasterization(border_shape, cell_size, cell_size);
             //writer.add_shape_with_holes(border_shape, "Border " + std::to_string(border_pos));
-            //writer.add_shape_with_holes(cells_to_shapes(border_cells, cell_size, cell_size).front(), "Border " + std::to_string(border_pos));
-            for (const shape::IntersectedCell& ic: border_cells) {
-                shape::ColumnId c = ic.cell.column - data.col_shift;
-                shape::RowId r = ic.cell.row - data.row_shift;
-                if (c >= 0 && c < data.num_cols && r >= 0 && r < data.num_rows)
-                    data.available[c][r] = false;
+            for (shape::ColumnId column = border_grid.column_offset;
+                    column < border_grid.column_offset + border_grid.number_of_columns;
+                    ++column) {
+                for (shape::RowId row = border_grid.row_offset;
+                        row < border_grid.row_offset + border_grid.number_of_rows;
+                        ++row) {
+                    if (!shape::strictly_greater(border_grid.at(column, row).coverage, 0.0))
+                        continue;
+                    shape::ColumnId c = column - data.col_shift;
+                    shape::RowId r = row - data.row_shift;
+                    if (c >= 0 && c < data.num_cols && r >= 0 && r < data.num_rows)
+                        data.available[c][r] = false;
+                }
             }
         }
 
@@ -129,14 +136,21 @@ Solution solve_milp_raster_for_cell_size(
                 defect_pos < (Counter)bin_type.defects.size();
                 ++defect_pos) {
             const ShapeWithHoles& defect_shape = bin_type.defects[defect_pos].shape_scaled;
-            std::vector<shape::IntersectedCell> defect_cells = shape::rasterization(defect_shape, cell_size, cell_size);
+            shape::RasterizedGrid defect_grid = shape::rasterization(defect_shape, cell_size, cell_size);
             //writer.add_shape_with_holes(defect_shape, "Defect " + std::to_string(defect_pos));
-            //writer.add_shape_with_holes(cells_to_shapes(defect_cells, cell_size, cell_size).front(), "Defect " + std::to_string(defect_pos));
-            for (const shape::IntersectedCell& ic: defect_cells) {
-                shape::ColumnId c = ic.cell.column - data.col_shift;
-                shape::RowId r = ic.cell.row - data.row_shift;
-                if (c >= 0 && c < data.num_cols && r >= 0 && r < data.num_rows)
-                    data.available[c][r] = false;
+            for (shape::ColumnId column = defect_grid.column_offset;
+                    column < defect_grid.column_offset + defect_grid.number_of_columns;
+                    ++column) {
+                for (shape::RowId row = defect_grid.row_offset;
+                        row < defect_grid.row_offset + defect_grid.number_of_rows;
+                        ++row) {
+                    if (!shape::strictly_greater(defect_grid.at(column, row).coverage, 0.0))
+                        continue;
+                    shape::ColumnId c = column - data.col_shift;
+                    shape::RowId r = row - data.row_shift;
+                    if (c >= 0 && c < data.num_cols && r >= 0 && r < data.num_rows)
+                        data.available[c][r] = false;
+                }
             }
         }
 
@@ -151,12 +165,20 @@ Solution solve_milp_raster_for_cell_size(
                 transformed.shift(
                         fixed_item.bl_corner.x * scale,
                         fixed_item.bl_corner.y * scale);
-                std::vector<shape::IntersectedCell> raster_cells = shape::rasterization(transformed, cell_size, cell_size);
-                for (const shape::IntersectedCell& ic: raster_cells) {
-                    shape::ColumnId c = ic.cell.column - data.col_shift;
-                    shape::RowId r = ic.cell.row - data.row_shift;
-                    if (c >= 0 && c < data.num_cols && r >= 0 && r < data.num_rows)
-                        data.fixed_items[c][r] = true;
+                shape::RasterizedGrid raster_grid = shape::rasterization(transformed, cell_size, cell_size);
+                for (shape::ColumnId column = raster_grid.column_offset;
+                        column < raster_grid.column_offset + raster_grid.number_of_columns;
+                        ++column) {
+                    for (shape::RowId row = raster_grid.row_offset;
+                            row < raster_grid.row_offset + raster_grid.number_of_rows;
+                            ++row) {
+                        if (!shape::strictly_greater(raster_grid.at(column, row).coverage, 0.0))
+                            continue;
+                        shape::ColumnId c = column - data.col_shift;
+                        shape::RowId r = row - data.row_shift;
+                        if (c >= 0 && c < data.num_cols && r >= 0 && r < data.num_rows)
+                            data.fixed_items[c][r] = true;
+                    }
                 }
             }
         }
@@ -190,9 +212,17 @@ Solution solve_milp_raster_for_cell_size(
                         ++item_shape_pos) {
                     ShapeWithHoles transformed = instance.item_shape_scaled(item_type_id, item_shape_pos, rotation.angle, rotation.mirror);
                     transformed.shift(-combined_aabb.x_min, -combined_aabb.y_min);
-                    std::vector<shape::IntersectedCell> raster_cells = shape::rasterization(transformed, cell_size, cell_size);
-                    for (const shape::IntersectedCell& ic: raster_cells)
-                        placement_cells.push_back(std::make_pair(ic.cell.column, ic.cell.row));
+                    shape::RasterizedGrid raster_grid = shape::rasterization(transformed, cell_size, cell_size);
+                    for (shape::ColumnId column = raster_grid.column_offset;
+                            column < raster_grid.column_offset + raster_grid.number_of_columns;
+                            ++column) {
+                        for (shape::RowId row = raster_grid.row_offset;
+                                row < raster_grid.row_offset + raster_grid.number_of_rows;
+                                ++row) {
+                            if (shape::strictly_greater(raster_grid.at(column, row).coverage, 0.0))
+                                placement_cells.push_back(std::make_pair(column, row));
+                        }
+                    }
                 }
 
                 if (placement_cells.empty())

--- a/src/irregular/periodic_packing.cpp
+++ b/src/irregular/periodic_packing.cpp
@@ -66,10 +66,10 @@ ShapeWithHoles get_item_combined_shape(
     }
     if ((ItemShapePos)shapes.size() == 1)
         return shapes[0];
-    std::vector<ShapeWithHoles> union_result = shape::compute_union(shapes);
-    if (union_result.empty())
+    MultiShapeWithHoles union_result = shape::compute_union(shapes);
+    if (union_result.shapes_with_holes.empty())
         return shapes[0];
-    return union_result[0];
+    return union_result.shapes_with_holes[0];
 }
 
 /**
@@ -415,30 +415,30 @@ std::vector<PeriodicPacking> find_periodic_packing_lattice(
     std::vector<ShapeWithHoles> combined_nfp;
     for (int i = 0; i < n; ++i) {
         for (int j = 0; j < n; ++j) {
-            std::vector<ShapeWithHoles> nfp_ij = shape::no_fit_polygon(shapes[i], shapes[j]);
-            if (nfp_ij.empty())
+            MultiShapeWithHoles nfp_ij = shape::no_fit_polygon(shapes[i], shapes[j]);
+            if (nfp_ij.shapes_with_holes.empty())
                 continue;
-            for (const ShapeWithHoles& swh: shape::compute_union(nfp_ij))
+            for (const ShapeWithHoles& swh: shape::compute_union(nfp_ij.shapes_with_holes).shapes_with_holes)
                 combined_nfp.push_back(swh);
         }
     }
     if (combined_nfp.empty())
         return {};
-    std::vector<ShapeWithHoles> combined_nfp_union = shape::compute_union(combined_nfp);
+    MultiShapeWithHoles combined_nfp_union = shape::compute_union(combined_nfp);
 
     std::vector<PeriodicPacking> result;
 
     // Horizontal strategy: v1 = (w, 0).
     {
-        Point vector_1 = find_leftmost_y0_point(combined_nfp_union);
+        Point vector_1 = find_leftmost_y0_point(combined_nfp_union.shapes_with_holes);
         if (shape::strictly_greater(vector_1.x, 0.0)
                 && vector_1.x != std::numeric_limits<double>::infinity()) {
-            std::vector<ShapeWithHoles> ext_nfp = combined_nfp_union;
-            std::vector<ShapeWithHoles> shifted = combined_nfp_union;
+            std::vector<ShapeWithHoles> ext_nfp = combined_nfp_union.shapes_with_holes;
+            std::vector<ShapeWithHoles> shifted = combined_nfp_union.shapes_with_holes;
             for (ShapeWithHoles& swh: shifted)
                 swh.shift(vector_1.x, vector_1.y);
             ext_nfp.insert(ext_nfp.end(), shifted.begin(), shifted.end());
-            std::vector<ShapeWithHoles> ext_nfp_union = shape::compute_union(ext_nfp);
+            std::vector<ShapeWithHoles> ext_nfp_union = shape::compute_union(ext_nfp).shapes_with_holes;
             Point vector_2 = find_bottommost_constrained_point(ext_nfp_union, vector_1.x);
             if (shape::strictly_greater(vector_2.y, 0.0)
                     && check_periodic_packing(shapes, zero_positions, vector_1, vector_2, 3)) {
@@ -449,15 +449,15 @@ std::vector<PeriodicPacking> find_periodic_packing_lattice(
 
     // Vertical strategy: v1 = (0, h).
     {
-        Point vector_1 = find_bottommost_x0_point(combined_nfp_union);
+        Point vector_1 = find_bottommost_x0_point(combined_nfp_union.shapes_with_holes);
         if (shape::strictly_greater(vector_1.y, 0.0)
                 && vector_1.y != std::numeric_limits<double>::infinity()) {
-            std::vector<ShapeWithHoles> ext_nfp = combined_nfp_union;
-            std::vector<ShapeWithHoles> shifted = combined_nfp_union;
+            std::vector<ShapeWithHoles> ext_nfp = combined_nfp_union.shapes_with_holes;
+            std::vector<ShapeWithHoles> shifted = combined_nfp_union.shapes_with_holes;
             for (ShapeWithHoles& swh: shifted)
                 swh.shift(vector_1.x, vector_1.y);
             ext_nfp.insert(ext_nfp.end(), shifted.begin(), shifted.end());
-            std::vector<ShapeWithHoles> ext_nfp_union = shape::compute_union(ext_nfp);
+            std::vector<ShapeWithHoles> ext_nfp_union = shape::compute_union(ext_nfp).shapes_with_holes;
             Point vector_2 = find_leftmost_constrained_point(ext_nfp_union, vector_1.y);
             if (shape::strictly_greater(vector_2.x, 0.0)
                     && check_periodic_packing(shapes, zero_positions, vector_1, vector_2, 3)) {
@@ -523,10 +523,10 @@ std::vector<PeriodicPacking> packingsolver::irregular::compute_periodic_packings
 
     // NFP(shape_0, shape_r) shifted by position_0 gives translations t_r such
     // that (shape_r + t_r) just touches shifted_shape_0.
-    std::vector<ShapeWithHoles> nfp_0r = shape::no_fit_polygon(shape_0, shape_r);
-    if (nfp_0r.empty())
+    MultiShapeWithHoles nfp_0r = shape::no_fit_polygon(shape_0, shape_r);
+    if (nfp_0r.shapes_with_holes.empty())
         return {};
-    std::vector<ShapeWithHoles> nfp_0r_union = shape::compute_union(nfp_0r);
+    std::vector<ShapeWithHoles> nfp_0r_union = shape::compute_union(nfp_0r.shapes_with_holes).shapes_with_holes;
     for (ShapeWithHoles& swh: nfp_0r_union) swh.shift(position_0.x, position_0.y);
 
     // Collect all boundary vertices as candidate placements for shape_r.

--- a/src/irregular/sequential_feasibility.cpp
+++ b/src/irregular/sequential_feasibility.cpp
@@ -124,11 +124,11 @@ SequentialFeasibilityOutput packingsolver::irregular::sequential_feasibility(
                 AxisAlignedBoundingBox restricting_aabb = bin_type.aabb_scaled;
                 restricting_aabb.x_max = restricting_aabb.x_min + x;
                 const Shape restricting_rect = shape::build_rectangle(restricting_aabb);
-                const std::vector<shape::ShapeWithHoles> intersection = shape::compute_intersection(
+                const shape::MultiShapeWithHoles intersection = shape::compute_intersection(
                         {{bin_type.shape_orig},
                         {restricting_rect}});
                 BinTypeId sub_bin_type_id = sub_instance_builder.add_bin_type(
-                        intersection[0].shape);
+                        intersection.shapes_with_holes[0].shape);
                 sub_instance_builder.set_bin_type_cost(sub_bin_type_id, bin_type.cost);
                 sub_instance_builder.set_bin_type_copies(sub_bin_type_id, copies);
                 sub_instance_builder.set_item_bin_minimum_spacing(
@@ -144,10 +144,10 @@ SequentialFeasibilityOutput packingsolver::irregular::sequential_feasibility(
             restricting_aabb.x_max = restricting_aabb.x_min + x;
             restricting_aabb.y_max = restricting_aabb.y_min + y;
             const Shape restricting_rect = shape::build_rectangle(restricting_aabb);
-            const std::vector<shape::ShapeWithHoles> intersection = shape::compute_intersection(
+            const shape::MultiShapeWithHoles intersection = shape::compute_intersection(
                     {{original_bin_type.shape_orig},
                     {restricting_rect}});
-            sub_instance_builder.add_bin_type(intersection[0].shape);
+            sub_instance_builder.add_bin_type(intersection.shapes_with_holes[0].shape);
             sub_instance_builder.set_item_bin_minimum_spacing(
                     0,
                     instance.bin_type(0).item_bin_minimum_spacing);

--- a/src/irregular/solution.cpp
+++ b/src/irregular/solution.cpp
@@ -440,9 +440,9 @@ void Solution::write(
                 restricting_aabb.y_max = bin.y_max;
             }
             const Shape restricting_rect = shape::build_rectangle(restricting_aabb);
-            const std::vector<shape::ShapeWithHoles> intersection = shape::compute_intersection(
+            const shape::MultiShapeWithHoles intersection = shape::compute_intersection(
                     {{bin_type.shape_orig}, {restricting_rect}});
-            bin_shape = intersection[0].shape;
+            bin_shape = intersection.shapes_with_holes[0].shape;
         }
         for (Counter element_pos = 0;
                 element_pos < (Counter)bin_shape.elements.size();


### PR DESCRIPTION
compute_union/compute_intersection/compute_difference/no_fit_polygon now return a MultiShapeWithHoles instead of a raw vector of ShapeWithHoles, and rasterization() now returns a dense RasterizedGrid instead of a sparse vector of IntersectedCell.