### PR TITLE
Fix parallel algorithms racing on the shared end boolean via bound updates in NotAnytimeDeterministic mode

### DIFF
--- a/include/packingsolver/box/optimize.hpp
+++ b/include/packingsolver/box/optimize.hpp
@@ -65,6 +65,51 @@ struct Output: packingsolver::Output<Instance, Solution>
         }
     }
 
+    /**
+     * Tighten this output's bounds with 'output's. Unlike
+     * 'AlgorithmFormatter::update_bounds', this has no side effect (no
+     * printing, no external callback): it is meant to accumulate bounds into
+     * a task-local 'Output' (e.g. when running algorithms in parallel in
+     * 'NotAnytimeDeterministic' mode), so that a parallel algorithm's bound
+     * updates cannot flip a sibling's stop signal at a non-deterministic
+     * point.
+     */
+    void update_bounds(const Output& output)
+    {
+        switch (solution_pool.best().instance().objective()) {
+        case Objective::Knapsack:
+            if (output.knapsack_bound < knapsack_bound)
+                knapsack_bound = output.knapsack_bound;
+            break;
+        case Objective::BinPacking:
+            if (output.bin_packing_bound > bin_packing_bound)
+                bin_packing_bound = output.bin_packing_bound;
+            break;
+        case Objective::VariableSizedBinPacking:
+            if (output.variable_sized_bin_packing_bound > variable_sized_bin_packing_bound)
+                variable_sized_bin_packing_bound = output.variable_sized_bin_packing_bound;
+            break;
+        case Objective::OpenDimensionX:
+            if (output.open_dimension_x_bound > open_dimension_x_bound)
+                open_dimension_x_bound = output.open_dimension_x_bound;
+            break;
+        case Objective::OpenDimensionY:
+            if (output.open_dimension_y_bound > open_dimension_y_bound)
+                open_dimension_y_bound = output.open_dimension_y_bound;
+            break;
+        case Objective::OpenDimensionZ:
+            if (output.open_dimension_z_bound > open_dimension_z_bound)
+                open_dimension_z_bound = output.open_dimension_z_bound;
+            break;
+        case Objective::Feasibility:
+            if (output.is_proven_infeasible)
+                is_proven_infeasible = true;
+            break;
+        default:
+            break;
+        }
+    }
+
     virtual nlohmann::json to_json() const override
     {
         nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();

--- a/include/packingsolver/irregular/optimize.hpp
+++ b/include/packingsolver/irregular/optimize.hpp
@@ -59,6 +59,47 @@ struct Output: packingsolver::Output<Instance, Solution>
         }
     }
 
+    /**
+     * Tighten this output's bounds with 'output's. Unlike
+     * 'AlgorithmFormatter::update_bounds', this has no side effect (no
+     * printing, no external callback): it is meant to accumulate bounds into
+     * a task-local 'Output' (e.g. when running algorithms in parallel in
+     * 'NotAnytimeDeterministic' mode), so that a parallel algorithm's bound
+     * updates cannot flip a sibling's stop signal at a non-deterministic
+     * point.
+     */
+    void update_bounds(const Output& output)
+    {
+        switch (solution_pool.best().instance().objective()) {
+        case Objective::Knapsack:
+            if (output.knapsack_bound < knapsack_bound)
+                knapsack_bound = output.knapsack_bound;
+            break;
+        case Objective::BinPacking:
+            if (output.bin_packing_bound > bin_packing_bound)
+                bin_packing_bound = output.bin_packing_bound;
+            break;
+        case Objective::VariableSizedBinPacking:
+            if (output.variable_sized_bin_packing_bound > variable_sized_bin_packing_bound)
+                variable_sized_bin_packing_bound = output.variable_sized_bin_packing_bound;
+            break;
+        case Objective::OpenDimensionX:
+            if (output.open_dimension_x_bound > open_dimension_x_bound)
+                open_dimension_x_bound = output.open_dimension_x_bound;
+            break;
+        case Objective::OpenDimensionY:
+            if (output.open_dimension_y_bound > open_dimension_y_bound)
+                open_dimension_y_bound = output.open_dimension_y_bound;
+            break;
+        case Objective::Feasibility:
+            if (output.is_proven_infeasible)
+                is_proven_infeasible = true;
+            break;
+        default:
+            break;
+        }
+    }
+
     virtual nlohmann::json to_json() const override
     {
         nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();

--- a/include/packingsolver/onedimensional/optimize.hpp
+++ b/include/packingsolver/onedimensional/optimize.hpp
@@ -47,6 +47,39 @@ struct Output: packingsolver::Output<Instance, Solution>
         }
     }
 
+    /**
+     * Tighten this output's bounds with 'output's. Unlike
+     * 'AlgorithmFormatter::update_bounds', this has no side effect (no
+     * printing, no external callback): it is meant to accumulate bounds into
+     * a task-local 'Output' (e.g. when running algorithms in parallel in
+     * 'NotAnytimeDeterministic' mode), so that a parallel algorithm's bound
+     * updates cannot flip a sibling's stop signal at a non-deterministic
+     * point.
+     */
+    void update_bounds(const Output& output)
+    {
+        switch (solution_pool.best().instance().objective()) {
+        case Objective::Knapsack:
+            if (output.knapsack_bound < knapsack_bound)
+                knapsack_bound = output.knapsack_bound;
+            break;
+        case Objective::BinPacking:
+            if (output.bin_packing_bound > bin_packing_bound)
+                bin_packing_bound = output.bin_packing_bound;
+            break;
+        case Objective::VariableSizedBinPacking:
+            if (output.variable_sized_bin_packing_bound > variable_sized_bin_packing_bound)
+                variable_sized_bin_packing_bound = output.variable_sized_bin_packing_bound;
+            break;
+        case Objective::Feasibility:
+            if (output.is_proven_infeasible)
+                is_proven_infeasible = true;
+            break;
+        default:
+            break;
+        }
+    }
+
     virtual nlohmann::json to_json() const override
     {
         nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();

--- a/include/packingsolver/rectangle/optimize.hpp
+++ b/include/packingsolver/rectangle/optimize.hpp
@@ -59,6 +59,47 @@ struct Output: packingsolver::Output<Instance, Solution>
         }
     }
 
+    /**
+     * Tighten this output's bounds with 'output's. Unlike
+     * 'AlgorithmFormatter::update_bounds', this has no side effect (no
+     * printing, no external callback): it is meant to accumulate bounds into
+     * a task-local 'Output' (e.g. when running algorithms in parallel in
+     * 'NotAnytimeDeterministic' mode), so that a parallel algorithm's bound
+     * updates cannot flip a sibling's stop signal at a non-deterministic
+     * point.
+     */
+    void update_bounds(const Output& output)
+    {
+        switch (solution_pool.best().instance().objective()) {
+        case Objective::Knapsack:
+            if (output.knapsack_bound < knapsack_bound)
+                knapsack_bound = output.knapsack_bound;
+            break;
+        case Objective::BinPacking:
+            if (output.bin_packing_bound > bin_packing_bound)
+                bin_packing_bound = output.bin_packing_bound;
+            break;
+        case Objective::VariableSizedBinPacking:
+            if (output.variable_sized_bin_packing_bound > variable_sized_bin_packing_bound)
+                variable_sized_bin_packing_bound = output.variable_sized_bin_packing_bound;
+            break;
+        case Objective::OpenDimensionX:
+            if (output.open_dimension_x_bound > open_dimension_x_bound)
+                open_dimension_x_bound = output.open_dimension_x_bound;
+            break;
+        case Objective::OpenDimensionY:
+            if (output.open_dimension_y_bound > open_dimension_y_bound)
+                open_dimension_y_bound = output.open_dimension_y_bound;
+            break;
+        case Objective::Feasibility:
+            if (output.is_proven_infeasible)
+                is_proven_infeasible = true;
+            break;
+        default:
+            break;
+        }
+    }
+
     virtual nlohmann::json to_json() const override
     {
         nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();

--- a/include/packingsolver/rectangleguillotine/optimize.hpp
+++ b/include/packingsolver/rectangleguillotine/optimize.hpp
@@ -59,6 +59,47 @@ struct Output: packingsolver::Output<Instance, Solution>
         }
     }
 
+    /**
+     * Tighten this output's bounds with 'output's. Unlike
+     * 'AlgorithmFormatter::update_bounds', this has no side effect (no
+     * printing, no external callback): it is meant to accumulate bounds into
+     * a task-local 'Output' (e.g. when running algorithms in parallel in
+     * 'NotAnytimeDeterministic' mode), so that a parallel algorithm's bound
+     * updates cannot flip a sibling's stop signal at a non-deterministic
+     * point.
+     */
+    void update_bounds(const Output& output)
+    {
+        switch (solution_pool.best().instance().objective()) {
+        case Objective::Knapsack:
+            if (output.knapsack_bound < knapsack_bound)
+                knapsack_bound = output.knapsack_bound;
+            break;
+        case Objective::BinPacking:
+            if (output.bin_packing_bound > bin_packing_bound)
+                bin_packing_bound = output.bin_packing_bound;
+            break;
+        case Objective::VariableSizedBinPacking:
+            if (output.variable_sized_bin_packing_bound > variable_sized_bin_packing_bound)
+                variable_sized_bin_packing_bound = output.variable_sized_bin_packing_bound;
+            break;
+        case Objective::OpenDimensionX:
+            if (output.open_dimension_x_bound > open_dimension_x_bound)
+                open_dimension_x_bound = output.open_dimension_x_bound;
+            break;
+        case Objective::OpenDimensionY:
+            if (output.open_dimension_y_bound > open_dimension_y_bound)
+                open_dimension_y_bound = output.open_dimension_y_bound;
+            break;
+        case Objective::Feasibility:
+            if (output.is_proven_infeasible)
+                is_proven_infeasible = true;
+            break;
+        default:
+            break;
+        }
+    }
+
     virtual nlohmann::json to_json() const override
     {
         nlohmann::json json = packingsolver::Output<Instance, Solution>::to_json();

--- a/src/box/optimize.cpp
+++ b/src/box/optimize.cpp
@@ -189,10 +189,11 @@ void optimize_tree_search(
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
+            local_output->update_bounds(ts_output);
         } else {
             algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
+            algorithm_formatter.update_bounds(ts_output);
         }
-        algorithm_formatter.update_bounds(ts_output);
     };
     tree_search(instance, ts_parameters);
 }
@@ -437,10 +438,11 @@ void optimize_column_generation(
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
+            local_output->update_bounds(ps_output);
         } else {
             algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
+            algorithm_formatter.update_bounds(ps_output);
         }
-        algorithm_formatter.update_bounds(ps_output);
     };
     column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter, box::Output>(instance, pricing_function, cg_parameters);
 }
@@ -774,14 +776,15 @@ packingsolver::box::Output packingsolver::box::optimize(
         if (exception_ptr)
             std::rethrow_exception(exception_ptr);
 
-    // Replay the solutions found by each algorithm in a fixed, deterministic
-    // order (registration order), instead of the (non-deterministic) order in
-    // which the algorithms actually finished.
+    // Replay the solutions and bounds found by each algorithm in a fixed,
+    // deterministic order (registration order), instead of the
+    // (non-deterministic) order in which the algorithms actually finished.
     if (deterministic) {
         for (const auto& local_output: local_outputs) {
             algorithm_formatter.update_solution(
                     local_output->solution_pool.best(),
                     local_output->solution_pool.best_label());
+            algorithm_formatter.update_bounds(*local_output);
         }
     }
 

--- a/src/irregular/optimize.cpp
+++ b/src/irregular/optimize.cpp
@@ -507,10 +507,11 @@ void optimize_column_generation(
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
+            local_output->update_bounds(ps_output);
         } else {
             algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
+            algorithm_formatter.update_bounds(ps_output);
         }
-        algorithm_formatter.update_bounds(ps_output);
     };
     column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter, irregular::Output>(instance, pricing_function, cg_parameters);
 }
@@ -529,10 +530,12 @@ void optimize_milp_raster(
             const irregular::Output& output) {
         if (local_output != nullptr) {
             local_output->solution_pool.add(output.solution_pool.best(), "MILP raster");
+            local_output->update_bounds(output);
         } else {
             algorithm_formatter.update_solution(
                     output.solution_pool.best(),
                     "MILP raster");
+            algorithm_formatter.update_bounds(output);
         }
     };
     milp_raster(instance, milp_raster_parameters);
@@ -876,14 +879,15 @@ packingsolver::irregular::Output packingsolver::irregular::optimize(
         if (exception_ptr)
             std::rethrow_exception(exception_ptr);
 
-    // Replay the solutions found by each algorithm in a fixed, deterministic
-    // order (registration order), instead of the (non-deterministic) order in
-    // which the algorithms actually finished.
+    // Replay the solutions and bounds found by each algorithm in a fixed,
+    // deterministic order (registration order), instead of the
+    // (non-deterministic) order in which the algorithms actually finished.
     if (deterministic) {
         for (const auto& local_output: local_outputs) {
             algorithm_formatter.update_solution(
                     local_output->solution_pool.best(),
                     local_output->solution_pool.best_label());
+            algorithm_formatter.update_bounds(*local_output);
         }
     }
 

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -202,10 +202,11 @@ void optimize_tree_search(
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
+            local_output->update_bounds(ts_output);
         } else {
             algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
+            algorithm_formatter.update_bounds(ts_output);
         }
-        algorithm_formatter.update_bounds(ts_output);
     };
     tree_search(instance, ts_parameters);
 }
@@ -419,10 +420,11 @@ void optimize_column_generation(
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
+            local_output->update_bounds(ps_output);
         } else {
             algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
+            algorithm_formatter.update_bounds(ps_output);
         }
-        algorithm_formatter.update_bounds(ps_output);
     };
     column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter, onedimensional::Output>(instance, pricing_function, cg_parameters);
 }
@@ -696,14 +698,15 @@ packingsolver::onedimensional::Output packingsolver::onedimensional::optimize(
         if (exception_ptr)
             std::rethrow_exception(exception_ptr);
 
-    // Replay the solutions found by each algorithm in a fixed, deterministic
-    // order (registration order), instead of the (non-deterministic) order in
-    // which the algorithms actually finished.
+    // Replay the solutions and bounds found by each algorithm in a fixed,
+    // deterministic order (registration order), instead of the
+    // (non-deterministic) order in which the algorithms actually finished.
     if (deterministic) {
         for (const auto& local_output: local_outputs) {
             algorithm_formatter.update_solution(
                     local_output->solution_pool.best(),
                     local_output->solution_pool.best_label());
+            algorithm_formatter.update_bounds(*local_output);
         }
     }
 

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -187,10 +187,11 @@ void optimize_tree_search(
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
+            local_output->update_bounds(ts_output);
         } else {
             algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
+            algorithm_formatter.update_bounds(ts_output);
         }
-        algorithm_formatter.update_bounds(ts_output);
     };
     tree_search(instance, ts_parameters);
 }
@@ -410,10 +411,11 @@ void optimize_column_generation(
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
+            local_output->update_bounds(ps_output);
         } else {
             algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
+            algorithm_formatter.update_bounds(ps_output);
         }
-        algorithm_formatter.update_bounds(ps_output);
     };
     column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter, rectangle::Output>(instance, pricing_function, cg_parameters);
 }
@@ -803,14 +805,15 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
         if (exception_ptr)
             std::rethrow_exception(exception_ptr);
 
-    // Replay the solutions found by each algorithm in a fixed, deterministic
-    // order (registration order), instead of the (non-deterministic) order in
-    // which the algorithms actually finished.
+    // Replay the solutions and bounds found by each algorithm in a fixed,
+    // deterministic order (registration order), instead of the
+    // (non-deterministic) order in which the algorithms actually finished.
     if (deterministic) {
         for (const auto& local_output: local_outputs) {
             algorithm_formatter.update_solution(
                     local_output->solution_pool.best(),
                     local_output->solution_pool.best_label());
+            algorithm_formatter.update_bounds(*local_output);
         }
     }
 

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -217,10 +217,11 @@ void optimize_tree_search(
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
+            local_output->update_bounds(ts_output);
         } else {
             algorithm_formatter.update_solution(ts_output.solution_pool.best(), "TS " + ts_output.solution_pool.best_label());
+            algorithm_formatter.update_bounds(ts_output);
         }
-        algorithm_formatter.update_bounds(ts_output);
     };
     tree_search(instance, ts_parameters);
 }
@@ -578,10 +579,11 @@ void optimize_column_generation(
     {
         if (local_output != nullptr) {
             local_output->solution_pool.add(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
+            local_output->update_bounds(ps_output);
         } else {
             algorithm_formatter.update_solution(ps_output.solution_pool.best(), "CG " + ps_output.solution_pool.best_label());
+            algorithm_formatter.update_bounds(ps_output);
         }
-        algorithm_formatter.update_bounds(ps_output);
     };
     column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter, rectangleguillotine::Output>(instance, pricing_function, cg_parameters);
 }
@@ -1010,14 +1012,15 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
         if (exception_ptr)
             std::rethrow_exception(exception_ptr);
 
-    // Replay the solutions found by each algorithm in a fixed, deterministic
-    // order (registration order), instead of the (non-deterministic) order in
-    // which the algorithms actually finished.
+    // Replay the solutions and bounds found by each algorithm in a fixed,
+    // deterministic order (registration order), instead of the
+    // (non-deterministic) order in which the algorithms actually finished.
     if (deterministic) {
         for (const auto& local_output: local_outputs) {
             algorithm_formatter.update_solution(
                     local_output->solution_pool.best(),
                     local_output->solution_pool.best_label());
+            algorithm_formatter.update_bounds(*local_output);
         }
     }
 


### PR DESCRIPTION
Bound updates (unlike solution updates) were always forwarded straight to the shared AlgorithmFormatter, even when an algorithm was running as one of several parallel tasks with a task-local Output for deterministic replay. Since one algorithm's bound proving optimal flips the shared end boolean that every sibling's timer also watches, this let a sibling get cut off at a non-deterministic, thread-scheduling-dependent point, defeating the purpose of NotAnytimeDeterministic mode.

Bounds are now merged into the task-local Output (via a new, side-effect- free Output::update_bounds) alongside solutions, and only replayed into the shared AlgorithmFormatter afterward, in the same fixed registration order already used for solutions. The shared end boolean itself is left wired up unchanged, so legitimate global stops (time limit, memory limit, external cancel) still apply non-deterministically, as expected.

Applied identically to rectangle, irregular, onedimensional, rectangleguillotine, and box (boxstacks delegates to these and needed no changes).