### PR TITLE
Make tree search and sequential value correction consider bin types by increasing space for the Knapsack objective

### DIFF
--- a/src/algorithms/sequential_value_correction.hpp
+++ b/src/algorithms/sequential_value_correction.hpp
@@ -38,7 +38,9 @@
 
 #include "packingsolver/algorithms/common.hpp"
 
+#include <algorithm>
 #include <functional>
+#include <numeric>
 #include <sstream>
 
 namespace packingsolver
@@ -109,6 +111,32 @@ SequentialValueCorrectionOutput<Instance, Solution, Output> sequential_value_cor
     }
     auto lbs = largest_bin_space(instance);
 
+    // Bin type of the bin at each position, in the order in which bins are
+    // considered by the algorithm.
+    //
+    // For the Knapsack objective, bins are considered by increasing space,
+    // regardless of the order in which they appear in the instance.
+    // Otherwise, bins are considered in the order in which they appear in
+    // the instance.
+    std::vector<BinTypeId> bin_type_id_order(instance.number_of_bin_types());
+    std::iota(bin_type_id_order.begin(), bin_type_id_order.end(), 0);
+    if (instance.objective() == Objective::Knapsack) {
+        std::stable_sort(
+                bin_type_id_order.begin(),
+                bin_type_id_order.end(),
+                [&instance](BinTypeId bin_type_id_1, BinTypeId bin_type_id_2)
+                {
+                    return instance.bin_type(bin_type_id_1).space()
+                        < instance.bin_type(bin_type_id_2).space();
+                });
+    }
+    std::vector<BinTypeId> bin_type_ids_by_position;
+    for (BinTypeId bin_type_id: bin_type_id_order) {
+        const auto& bin_type = instance.bin_type(bin_type_id);
+        for (BinPos copy = 0; copy < bin_type.copies; ++copy)
+            bin_type_ids_by_position.push_back(bin_type_id);
+    }
+
     for (output.number_of_iterations = 0;; output.number_of_iterations++) {
         // track fixed copies from bins added to the partial solution in this iteration
         std::vector<ItemPos> partial_fixed_copies(instance.number_of_item_types(), 0);
@@ -175,7 +203,7 @@ SequentialValueCorrectionOutput<Instance, Solution, Output> sequential_value_cor
                     }
                 }
             } else {
-                bin_type_ids.push_back(instance.bin_type_id(solution.number_of_bins()));
+                bin_type_ids.push_back(bin_type_ids_by_position[solution.number_of_bins()]);
             }
 
             std::vector<ItemPos> bin_fixed_copies(instance.number_of_item_types(), 0);

--- a/src/box/tree_search.cpp
+++ b/src/box/tree_search.cpp
@@ -5,6 +5,8 @@
 #include "algorithms/thread_pool.hpp"
 #include "treesearchsolver/iterative_beam_search_2.hpp"
 
+#include <algorithm>
+#include <numeric>
 #include <string>
 
 using namespace packingsolver;
@@ -34,6 +36,36 @@ BranchingScheme::BranchingScheme(
     predecessors_(instance_orig.number_of_item_types())
 {
     const Instance& instance = this->instance();
+
+    // Compute bin_type_ids_ and previous_bins_volume_.
+    //
+    // For the Knapsack objective, bins are considered by increasing space,
+    // regardless of the order in which they appear in the instance.
+    // Otherwise, bins are considered in the order in which they appear in
+    // the instance.
+    {
+        std::vector<BinTypeId> bin_type_id_order(instance.number_of_bin_types());
+        std::iota(bin_type_id_order.begin(), bin_type_id_order.end(), 0);
+        if (instance.objective() == Objective::Knapsack) {
+            std::stable_sort(
+                    bin_type_id_order.begin(),
+                    bin_type_id_order.end(),
+                    [&instance](BinTypeId bin_type_id_1, BinTypeId bin_type_id_2)
+                    {
+                        return instance.bin_type(bin_type_id_1).space()
+                            < instance.bin_type(bin_type_id_2).space();
+                    });
+        }
+        Volume previous_bin_volume = 0;
+        for (BinTypeId bin_type_id: bin_type_id_order) {
+            const BinType& bin_type = instance.bin_type(bin_type_id);
+            for (BinPos copy = 0; copy < bin_type.copies; ++copy) {
+                bin_type_ids_.push_back(bin_type_id);
+                previous_bins_volume_.push_back(previous_bin_volume);
+                previous_bin_volume += bin_type.volume();
+            }
+        }
+    }
 
     // Compute predecessors.
     //instance.format(std::cout, 3);
@@ -201,7 +233,7 @@ BranchingScheme::Node BranchingScheme::child_tmp(
 
     BinPos i = node.number_of_bins - 1;
     Direction o = node.last_bin_direction;
-    BinTypeId bin_type_id = instance.bin_type_id(i);
+    BinTypeId bin_type_id = bin_type_ids_[i];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     const ItemType& item_type = instance.item_type(insertion.item_type_id);
 
@@ -301,8 +333,8 @@ BranchingScheme::Node BranchingScheme::child_tmp(
     node.xs_max = (insertion.new_bin == 0)?
         std::max(parent.xs_max, insertion.x):
         insertion.x;
-    node.current_volume = instance.previous_bin_volume(i);
-    node.guide_volume = instance.previous_bin_volume(i) + node.xs_max * yi * zi;
+    node.current_volume = previous_bins_volume_[i];
+    node.guide_volume = previous_bins_volume_[i] + node.xs_max * yi * zi;
     for (const UncoveredItem& uncovered_item: node.uncovered_items) {
         node.current_volume += uncovered_item.x_dominance
             * (uncovered_item.ye - uncovered_item.ys)
@@ -358,7 +390,7 @@ const std::vector<BranchingScheme::Insertion>& BranchingScheme::insertions(
     // Insert in the current bin.
     if (parent->number_of_bins > 0) {
         const Instance& instance = this->instance(parent->last_bin_direction);
-        BinTypeId bin_type_id = instance.bin_type_id(parent->number_of_bins - 1);
+        BinTypeId bin_type_id = bin_type_ids_[parent->number_of_bins - 1];
         const BinType& bin_type = instance.bin_type(bin_type_id);
 
         // For all y uncovered item.
@@ -408,7 +440,7 @@ const std::vector<BranchingScheme::Insertion>& BranchingScheme::insertions(
         } else if (parameters_.direction == Direction::Z) {
             new_bin = 3;
         } else {
-            BinTypeId bin_type_id = instance().bin_type_id(new_bin_pos);
+            BinTypeId bin_type_id = bin_type_ids_[new_bin_pos];
             const BinType& bin_type = instance().bin_type(bin_type_id);
             if (bin_type.box.x >= std::max(bin_type.box.y, bin_type.box.z)) {
                 new_bin = 1;
@@ -421,7 +453,7 @@ const std::vector<BranchingScheme::Insertion>& BranchingScheme::insertions(
         //std::cout << "new bin " << (int)new_bin << std::endl;
 
         const Instance& instance = this->instance(new_bin);
-        BinTypeId bin_type_id = instance.bin_type_id(new_bin_pos);
+        BinTypeId bin_type_id = bin_type_ids_[new_bin_pos];
         const BinType& bin_type = instance.bin_type(bin_type_id);
 
         // Items.
@@ -477,8 +509,8 @@ void BranchingScheme::insertion_item(
         this->instance(new_bin);
     const ItemType& item_type = instance.item_type(item_type_id);
     BinTypeId bin_type_id = (new_bin == 0)?
-        instance.bin_type_id(parent->number_of_bins - 1):
-        instance.bin_type_id(new_bin_pos);
+        bin_type_ids_[parent->number_of_bins - 1]:
+        bin_type_ids_[new_bin_pos];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     Box box = item_type.box.rotate(rotation);
     Length xi = bin_type.box.x;
@@ -658,7 +690,7 @@ bool BranchingScheme::bound(
             bin_pos++;
             if (bin_pos >= instance().number_of_bins())
                 return true;
-            BinTypeId bin_type_id = instance().bin_type_id(bin_pos);
+            BinTypeId bin_type_id = bin_type_ids_[bin_pos];
             const BinType& bin_type = instance().bin_type(bin_type_id);
             a -= bin_type.volume();
         }
@@ -719,7 +751,7 @@ Solution BranchingScheme::to_solution(
         // added to the solution, as empty bins.
         while (number_of_bins < current_node->number_of_bins) {
             bin_pos = solution_builder.add_bin(
-                    instance.bin_type_id(number_of_bins),
+                    bin_type_ids_[number_of_bins],
                     1);
             number_of_bins++;
         }
@@ -836,7 +868,7 @@ nlohmann::json BranchingScheme::json_export(
     nlohmann::json plot;
     Counter i = 0;
     // Plot bin.
-    BinTypeId bin_type_id = instance().bin_type_id(node->number_of_bins - 1);
+    BinTypeId bin_type_id = bin_type_ids_[node->number_of_bins - 1];
     plot[i] = {
         {"Id",json_bins_init_ids_[bin_type_id]},
         {"X", 0},

--- a/src/box/tree_search.hpp
+++ b/src/box/tree_search.hpp
@@ -333,6 +333,19 @@ private:
     /** Parameters. */
     Parameters parameters_;
 
+    /**
+     * Bin type of the bin at each position, in the order in which bins are
+     * considered by the branching scheme.
+     *
+     * For the Knapsack objective, bins are considered by increasing space,
+     * regardless of the order in which they appear in the instance.
+     * Otherwise, this matches 'instance_.bin_type_id(bin_pos)'.
+     */
+    std::vector<BinTypeId> bin_type_ids_;
+
+    /** Total volume of the bins preceding each position, in the same order as 'bin_type_ids_'. */
+    std::vector<Volume> previous_bins_volume_;
+
     std::vector<std::vector<ItemTypeId>> predecessors_;
 
     ItemPos number_of_selected_items_ = 0;

--- a/src/boxstacks/tree_search.cpp
+++ b/src/boxstacks/tree_search.cpp
@@ -10,8 +10,10 @@
 
 #include <thread>
 
+#include <algorithm>
 #include <string>
 #include <cmath>
+#include <numeric>
 #include <unordered_set>
 
 using namespace packingsolver;
@@ -235,6 +237,36 @@ BranchingScheme::BranchingScheme(
 {
     Direction o = parameters_.direction;
     const Instance& instance = this->instance(o);
+
+    // Compute bin_type_ids_ and previous_bins_volume_.
+    //
+    // For the Knapsack objective, bins are considered by increasing space,
+    // regardless of the order in which they appear in the instance.
+    // Otherwise, bins are considered in the order in which they appear in
+    // the instance.
+    {
+        std::vector<BinTypeId> bin_type_id_order(instance.number_of_bin_types());
+        std::iota(bin_type_id_order.begin(), bin_type_id_order.end(), 0);
+        if (instance.objective() == Objective::Knapsack) {
+            std::stable_sort(
+                    bin_type_id_order.begin(),
+                    bin_type_id_order.end(),
+                    [&instance](BinTypeId bin_type_id_1, BinTypeId bin_type_id_2)
+                    {
+                        return instance.bin_type(bin_type_id_1).space()
+                            < instance.bin_type(bin_type_id_2).space();
+                    });
+        }
+        Volume previous_bin_volume = 0;
+        for (BinTypeId bin_type_id: bin_type_id_order) {
+            const BinType& bin_type_tmp = instance.bin_type(bin_type_id);
+            for (BinPos copy = 0; copy < bin_type_tmp.copies; ++copy) {
+                bin_type_ids_.push_back(bin_type_id);
+                previous_bins_volume_.push_back(previous_bin_volume);
+                previous_bin_volume += bin_type_tmp.volume();
+            }
+        }
+    }
 
     // Compute dominated items.
     std::vector<StackSet> item_type_stacks = generate_all_stacks(instance);
@@ -531,7 +563,7 @@ BranchingScheme::Node BranchingScheme::child_tmp(
 
     BinPos i = node.number_of_bins - 1;
     Direction o = node.last_bin_direction;
-    BinTypeId bin_type_id = instance.bin_type_id(i);
+    BinTypeId bin_type_id = bin_type_ids_[i];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     const ItemType& item_type = instance.item_type(insertion.item_type_id);
 
@@ -698,8 +730,8 @@ BranchingScheme::Node BranchingScheme::child_tmp(
     node.xs_max = (insertion.new_bin == 0)?
         std::max(parent.xs_max, insertion.x):
         insertion.x;
-    node.current_volume = instance.previous_bin_volume(i);
-    node.guide_volume = instance.previous_bin_volume(i) + node.xs_max * yi * zi;
+    node.current_volume = previous_bins_volume_[i];
+    node.guide_volume = previous_bins_volume_[i] + node.xs_max * yi * zi;
     for (const UncoveredItem& uncovered_item: node.uncovered_items) {
         node.current_volume += uncovered_item.xs
             * (uncovered_item.ye - uncovered_item.ys)
@@ -765,7 +797,7 @@ const std::vector<BranchingScheme::Insertion>& BranchingScheme::insertions(
     // Insert in the current bin.
     if (parent->number_of_bins > 0) {
         const Instance& instance = this->instance(parent->last_bin_direction);
-        BinTypeId bin_type_id = instance.bin_type_id(parent->number_of_bins - 1);
+        BinTypeId bin_type_id = bin_type_ids_[parent->number_of_bins - 1];
         const BinType& bin_type = instance.bin_type(bin_type_id);
 
         // Insert above a previous item.
@@ -885,7 +917,7 @@ const std::vector<BranchingScheme::Insertion>& BranchingScheme::insertions(
         } else if (parameters_.direction == Direction::Y) {
             new_bin = 2;
         } else {
-            BinTypeId bin_type_id = instance().bin_type_id(new_bin_pos);
+            BinTypeId bin_type_id = bin_type_ids_[new_bin_pos];
             const BinType& bin_type = instance().bin_type(bin_type_id);
             if (bin_type.box.x >= bin_type.box.y) {
                 new_bin = 1;
@@ -894,7 +926,7 @@ const std::vector<BranchingScheme::Insertion>& BranchingScheme::insertions(
             }
         }
         const Instance& instance = this->instance(new_bin);
-        BinTypeId bin_type_id = instance.bin_type_id(new_bin_pos);
+        BinTypeId bin_type_id = bin_type_ids_[new_bin_pos];
         const BinType& bin_type = instance.bin_type(bin_type_id);
 
         // Items.
@@ -961,7 +993,7 @@ void BranchingScheme::insertion_item_above(
     Direction o = parent->last_bin_direction;
     const Instance& instance = this->instance(o);
     const ItemType& item_type = instance.item_type(item_type_id);
-    BinTypeId bin_type_id = instance.bin_type_id(parent->number_of_bins - 1);
+    BinTypeId bin_type_id = bin_type_ids_[parent->number_of_bins - 1];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     Length xj = item_type.x(rotation);
     Length yj = item_type.y(rotation);
@@ -1058,8 +1090,8 @@ void BranchingScheme::insertion_item(
     const Instance& instance = this->instance(o);
     const ItemType& item_type = instance.item_type(item_type_id);
     BinTypeId bin_type_id = (new_bin == 0)?
-        instance.bin_type_id(parent->number_of_bins - 1):
-        instance.bin_type_id(new_bin_pos);
+        bin_type_ids_[parent->number_of_bins - 1]:
+        bin_type_ids_[new_bin_pos];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     Length xj = item_type.x(rotation);
     Length yj = item_type.y(rotation);
@@ -1220,7 +1252,7 @@ void BranchingScheme::insertion_item_left(
     Direction o = parent->last_bin_direction;
     const Instance& instance = this->instance(o);
     const ItemType& item_type = instance.item_type(item_type_id);
-    BinTypeId bin_type_id = instance.bin_type_id(parent->number_of_bins - 1);
+    BinTypeId bin_type_id = bin_type_ids_[parent->number_of_bins - 1];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     Length xj = item_type.x(rotation);
     Length yj = item_type.y(rotation);
@@ -1451,7 +1483,7 @@ bool BranchingScheme::bound(
             bin_pos++;
             if (bin_pos >= instance().number_of_bins())
                 return true;
-            BinTypeId bin_type_id = instance().bin_type_id(bin_pos);
+            BinTypeId bin_type_id = bin_type_ids_[bin_pos];
             const BinType& bin_type = instance().bin_type(bin_type_id);
             a -= bin_type.volume();
         }
@@ -1512,7 +1544,7 @@ Solution BranchingScheme::to_solution(
         // added to the solution, as empty bins.
         while (number_of_bins < current_node->number_of_bins) {
             bin_pos = solution_builder.add_bin(
-                    instance.bin_type_id(number_of_bins),
+                    bin_type_ids_[number_of_bins],
                     1);
             number_of_bins++;
         }

--- a/src/boxstacks/tree_search.hpp
+++ b/src/boxstacks/tree_search.hpp
@@ -422,6 +422,19 @@ private:
     /** Parameters. */
     Parameters parameters_;
 
+    /**
+     * Bin type of the bin at each position, in the order in which bins are
+     * considered by the branching scheme.
+     *
+     * For the Knapsack objective, bins are considered by increasing space,
+     * regardless of the order in which they appear in the instance.
+     * Otherwise, this matches 'instance_.bin_type_id(bin_pos)'.
+     */
+    std::vector<BinTypeId> bin_type_ids_;
+
+    /** Total volume of the bins preceding each position, in the same order as 'bin_type_ids_'. */
+    std::vector<Volume> previous_bins_volume_;
+
     std::vector<std::vector<ItemTypeId>> predecessors_;
 
     ItemPos number_of_selected_items_ = 0;

--- a/src/irregular/tree_search.cpp
+++ b/src/irregular/tree_search.cpp
@@ -15,7 +15,9 @@
 #include "shape/supports.hpp"
 #include "shape/shapes_intersections.hpp"
 
+#include <algorithm>
 #include <iostream>
+#include <numeric>
 
 using namespace packingsolver;
 using namespace packingsolver::irregular;
@@ -122,6 +124,36 @@ BranchingScheme::BranchingScheme(
             parameters.maximum_approximation_ratio)),
     parameters_(parameters)
 {
+    // Compute bin_type_ids_ and previous_bins_area_.
+    //
+    // For the Knapsack objective, bins are considered by increasing space,
+    // regardless of the order in which they appear in the instance.
+    // Otherwise, bins are considered in the order in which they appear in
+    // the instance.
+    {
+        std::vector<BinTypeId> bin_type_id_order(instance.number_of_bin_types());
+        std::iota(bin_type_id_order.begin(), bin_type_id_order.end(), 0);
+        if (instance.objective() == Objective::Knapsack) {
+            std::stable_sort(
+                    bin_type_id_order.begin(),
+                    bin_type_id_order.end(),
+                    [&instance](BinTypeId bin_type_id_1, BinTypeId bin_type_id_2)
+                    {
+                        return instance.bin_type(bin_type_id_1).space()
+                            < instance.bin_type(bin_type_id_2).space();
+                    });
+        }
+        AreaDbl previous_bin_area = 0;
+        for (BinTypeId bin_type_id: bin_type_id_order) {
+            const BinType& bin_type = instance.bin_type(bin_type_id);
+            for (BinPos copy = 0; copy < bin_type.copies; ++copy) {
+                bin_type_ids_.push_back(bin_type_id);
+                previous_bins_area_.push_back(previous_bin_area);
+                previous_bin_area += bin_type.area_orig;
+            }
+        }
+    }
+
     item_types_allowed_rotations_ = compute_item_type_rotations(instance);
 
     //std::cout << "BranchingScheme" << std::endl;
@@ -1051,7 +1083,7 @@ BranchingScheme::Node BranchingScheme::child_tmp(
 
     BinPos bin_pos = node.number_of_bins - 1;
     Direction o = node.last_bin_direction;
-    BinTypeId bin_type_id = instance().bin_type_id(bin_pos);
+    BinTypeId bin_type_id = bin_type_ids_[bin_pos];
     const BinType& bin_type = instance().bin_type(bin_type_id);
     const DirectionData& direction_data = directions_data_[(int)node.last_bin_direction];
     const BranchingSchemeBinType& bb_bin_type = direction_data.bin_types[bin_type_id];
@@ -1238,7 +1270,7 @@ BranchingScheme::Node BranchingScheme::child_tmp(
     node.xs_max = (insertion.new_bin_direction == Direction::Any)?  // Same bin
         std::max(parent.xs_max, insertion.x + trapezoid_set.x_min):
         insertion.x + trapezoid_set.x_min;
-    node.guide_area = instance().previous_bin_area(bin_pos)
+    node.guide_area = previous_bins_area_[bin_pos]
         + (node.xs_max - bb_bin_type.x_min)
         * (bb_bin_type.y_max - bb_bin_type.y_min);
     for (auto it = node.all_trapezoids_skyline.rbegin(); it != node.all_trapezoids_skyline.rend(); ++it) {
@@ -1316,7 +1348,7 @@ void BranchingScheme::update_extra_trapezoids(Node& node) const
         const Node& parent = *node.parent;
         const DirectionData& direction_data = directions_data_[(int)node.last_bin_direction];
         BinPos bin_pos = node.number_of_bins - 1;
-        BinTypeId bin_type_id = instance().bin_type_id(bin_pos);
+        BinTypeId bin_type_id = bin_type_ids_[bin_pos];
         const BranchingSchemeBinType& bb_bin_type = direction_data.bin_types[bin_type_id];
 
         // Don't add extra rectangles which are behind the skyline.
@@ -1397,7 +1429,7 @@ std::vector<std::shared_ptr<BranchingScheme::Node>> BranchingScheme::children(
         //BinPos bin_pos = cs.back()->number_of_bins - 1;
         //Direction o = cs.back()->last_bin_direction;
         //const DirectionData& direction_data = directions_data_[(int)o];
-        //BinTypeId bin_type_id = instance().bin_type_id(bin_pos);
+        //BinTypeId bin_type_id = bin_type_ids_[bin_pos];
         //const BranchingSchemeBinType& bb_bin_type = direction_data.bin_types[bin_type_id];
         //std::cout << cs.back()->id
         //    << " insertion " << parent->children_insertions[i]
@@ -1417,7 +1449,7 @@ void BranchingScheme::insertions(
 {
     uncovered_trapezoids_cur_.clear();
     if (parent->number_of_bins > 0) {
-        BinTypeId bin_type_id = instance().bin_type_id(parent->number_of_bins - 1);
+        BinTypeId bin_type_id = bin_type_ids_[parent->number_of_bins - 1];
         const DirectionData& direction_data = directions_data_[(int)parent->last_bin_direction];
         const BranchingSchemeBinType& bb_bin_type = direction_data.bin_types[bin_type_id];
         for (ItemPos uncovered_trapezoid_pos_cur = 0;
@@ -1457,7 +1489,7 @@ void BranchingScheme::insertions(
     // Insert in the current bin.
     if (parent->number_of_bins > 0) {
 
-        BinTypeId bin_type_id = instance().bin_type_id(parent->number_of_bins - 1);
+        BinTypeId bin_type_id = bin_type_ids_[parent->number_of_bins - 1];
         const BinType& bin_type = instance().bin_type(bin_type_id);
         const DirectionData& direction_data = directions_data_[(int)parent->last_bin_direction];
         const BranchingSchemeBinType& bb_bin_type = direction_data.bin_types[bin_type_id];
@@ -1522,7 +1554,7 @@ void BranchingScheme::insertions(
             && new_bin_pos < instance().number_of_bins();
             ++new_bin_pos) {
         //std::cout << "insert in a new bin " << new_bin_pos << std::endl;
-        BinTypeId bin_type_id = instance().bin_type_id(new_bin_pos);
+        BinTypeId bin_type_id = bin_type_ids_[new_bin_pos];
         const BinType& bin_type = instance().bin_type(bin_type_id);
 
         Direction new_bin_direction = parameters_.direction;
@@ -1709,7 +1741,7 @@ void BranchingScheme::update_insertion(
 {
     //std::cout << "update_insertion " << insertion_orig << std::endl;
 
-    BinTypeId bin_type_id = instance().bin_type_id(parent->number_of_bins - 1);
+    BinTypeId bin_type_id = bin_type_ids_[parent->number_of_bins - 1];
     const BinType& bin_type = instance().bin_type(bin_type_id);
     Direction direction = parent->last_bin_direction;
 
@@ -1847,8 +1879,8 @@ void BranchingScheme::insertion_trapezoid_set(
     //    << std::endl;
 
     BinTypeId bin_type_id = (new_bin_direction == Direction::Any)?
-        instance().bin_type_id(parent->number_of_bins - 1):
-        instance().bin_type_id(new_bin_pos);
+        bin_type_ids_[parent->number_of_bins - 1]:
+        bin_type_ids_[new_bin_pos];
     const BinType& bin_type = instance().bin_type(bin_type_id);
     Direction direction = (new_bin_direction == Direction::Any)?
         parent->last_bin_direction:
@@ -2210,12 +2242,12 @@ Solution BranchingScheme::to_solution(
         // added to the solution, as empty bins.
         while (number_of_bins < current_node->number_of_bins) {
             bin_pos = solution_builder.add_bin(
-                    instance().bin_type_id(number_of_bins),
+                    bin_type_ids_[number_of_bins],
                     1);
             number_of_bins++;
         }
 
-        BinTypeId bin_type_id_cur = instance().bin_type_id(current_node->number_of_bins - 1);
+        BinTypeId bin_type_id_cur = bin_type_ids_[current_node->number_of_bins - 1];
         const DirectionData& direction_data = directions_data_[(int)current_node->last_bin_direction];
         const TrapezoidSet& trapezoid_set = direction_data.bin_types[bin_type_id_cur].trapezoid_sets[current_node->trapezoid_set_id];
         Point bl_corner = convert_point_back({current_node->x, current_node->y}, current_node->last_bin_direction);
@@ -2240,11 +2272,11 @@ Solution BranchingScheme::to_solution(
             bin_pos <= instance().last_bin_with_fixed_items();
             ++bin_pos) {
         if (bin_pos >= number_of_bins) {
-            BinTypeId bin_type_id = instance().bin_type_id(bin_pos);
+            BinTypeId bin_type_id = bin_type_ids_[bin_pos];
             solution_builder.add_bin(bin_type_id, 1);
             number_of_bins++;
         }
-        BinTypeId bin_type_id = instance().bin_type_id(bin_pos);
+        BinTypeId bin_type_id = bin_type_ids_[bin_pos];
         const BinType& bin_type = instance().bin_type(bin_type_id);
         for (const FixedItem& fixed_item: bin_type.fixed_items) {
             solution_builder.add_item(
@@ -2390,7 +2422,7 @@ nlohmann::json BranchingScheme::json_export(
         return json;
     }
 
-    BinTypeId bin_type_id = instance().bin_type_id(node->number_of_bins - 1);
+    BinTypeId bin_type_id = bin_type_ids_[node->number_of_bins - 1];
     const DirectionData& direction_data = directions_data_[(int)node->last_bin_direction];
     const TrapezoidSet& trapezoid_set = direction_data.bin_types[bin_type_id].trapezoid_sets[node->trapezoid_set_id];
     Point bl_orig = convert_point_back({node->x, node->y}, node->last_bin_direction);
@@ -2429,7 +2461,7 @@ nlohmann::json BranchingScheme::json_export(
     for (std::shared_ptr<const Node> node_tmp = node;
             node_tmp->number_of_bins == node->number_of_bins;
             node_tmp = node_tmp->parent) {
-        BinTypeId bin_type_id_tmp = instance().bin_type_id(node_tmp->number_of_bins - 1);
+        BinTypeId bin_type_id_tmp = bin_type_ids_[node_tmp->number_of_bins - 1];
         const DirectionData& direction_data_tmp = directions_data_[(int)node_tmp->last_bin_direction];
         const TrapezoidSet& trapezoid_set = direction_data_tmp.bin_types[bin_type_id_tmp].trapezoid_sets[node_tmp->trapezoid_set_id];
         Point bl_corner = convert_point_back({node_tmp->x, node_tmp->y}, node_tmp->last_bin_direction);
@@ -2464,7 +2496,7 @@ void BranchingScheme::write_svg(
         return;
 
     BinPos bin_pos = node->number_of_bins - 1;
-    BinTypeId bin_type_id = instance().bin_type_id(bin_pos);
+    BinTypeId bin_type_id = bin_type_ids_[bin_pos];
     const BinType& bin_type = instance().bin_type(bin_type_id);
     const DirectionData& direction_data = directions_data_[(int)node->last_bin_direction];
     const BranchingSchemeBinType& bb_bin_type = direction_data.bin_types[bin_type_id];

--- a/src/irregular/tree_search.hpp
+++ b/src/irregular/tree_search.hpp
@@ -514,6 +514,19 @@ private:
     /** Parameters. */
     Parameters parameters_;
 
+    /**
+     * Bin type of the bin at each position, in the order in which bins are
+     * considered by the branching scheme.
+     *
+     * For the Knapsack objective, bins are considered by increasing space,
+     * regardless of the order in which they appear in the instance.
+     * Otherwise, this matches 'instance_.bin_type_id(bin_pos)'.
+     */
+    std::vector<BinTypeId> bin_type_ids_;
+
+    /** Total area of the bins preceding each position, in the same order as 'bin_type_ids_'. */
+    std::vector<AreaDbl> previous_bins_area_;
+
     SimplifiedInstance simplified_instance_;
 
     std::vector<AreaDbl> item_types_convex_hull_area_;

--- a/src/onedimensional/tree_search.cpp
+++ b/src/onedimensional/tree_search.cpp
@@ -5,6 +5,8 @@
 #include "algorithms/thread_pool.hpp"
 #include "treesearchsolver/iterative_beam_search_2.hpp"
 
+#include <algorithm>
+#include <numeric>
 #include <thread>
 
 using namespace packingsolver;
@@ -20,6 +22,33 @@ BranchingScheme::BranchingScheme(
     instance_(instance),
     parameters_(parameters)
 {
+    // Compute bin_type_ids_ and previous_bins_length_.
+    //
+    // For the Knapsack objective, bins are considered by increasing space,
+    // regardless of the order in which they appear in the instance.
+    // Otherwise, bins are considered in the order in which they appear in
+    // the instance.
+    std::vector<BinTypeId> bin_type_id_order(instance.number_of_bin_types());
+    std::iota(bin_type_id_order.begin(), bin_type_id_order.end(), 0);
+    if (instance.objective() == Objective::Knapsack) {
+        std::stable_sort(
+                bin_type_id_order.begin(),
+                bin_type_id_order.end(),
+                [&instance](BinTypeId bin_type_id_1, BinTypeId bin_type_id_2)
+                {
+                    return instance.bin_type(bin_type_id_1).space()
+                        < instance.bin_type(bin_type_id_2).space();
+                });
+    }
+    Length previous_bin_length = 0;
+    for (BinTypeId bin_type_id: bin_type_id_order) {
+        const BinType& bin_type = instance.bin_type(bin_type_id);
+        for (BinPos copy = 0; copy < bin_type.copies; ++copy) {
+            bin_type_ids_.push_back(bin_type_id);
+            previous_bins_length_.push_back(previous_bin_length);
+            previous_bin_length += bin_type.length;
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -73,7 +102,7 @@ BranchingScheme::Node BranchingScheme::child_tmp(
     node.profit = parent.profit + item_type.profit;
 
     // Compute current_length, guide_length and width using uncovered_items.
-    node.current_length = instance_.previous_bin_length(i) + node.last_bin_length;
+    node.current_length = previous_bins_length_[i] + node.last_bin_length;
     node.waste = node.current_length - node.item_length;
 
     node.id = node_id_++;
@@ -99,7 +128,7 @@ const std::vector<BranchingScheme::Insertion>& BranchingScheme::insertions(
 
     // Insert an item in the same bin.
     if (parent->number_of_bins > 0) {
-        BinTypeId bin_type_id = instance().bin_type_id(parent->number_of_bins - 1);
+        BinTypeId bin_type_id = bin_type_ids_[parent->number_of_bins - 1];
         const BinType& bin_type = instance().bin_type(bin_type_id);
         for (ItemTypeId item_type_id: bin_type.item_type_ids) {
             const ItemType& item_type = instance_.item_type(item_type_id);
@@ -115,7 +144,7 @@ const std::vector<BranchingScheme::Insertion>& BranchingScheme::insertions(
     for (BinPos new_bin_pos = parent->number_of_bins;
             insertions_.empty() && new_bin_pos < instance().number_of_bins();
             ++new_bin_pos) {
-        BinTypeId bin_type_id = instance().bin_type_id(new_bin_pos);
+        BinTypeId bin_type_id = bin_type_ids_[new_bin_pos];
         const BinType& bin_type = instance().bin_type(bin_type_id);
         for (ItemTypeId item_type_id: bin_type.item_type_ids) {
             const ItemType& item_type = instance_.item_type(item_type_id);
@@ -133,7 +162,7 @@ void BranchingScheme::insertion_item_same_bin(
         ItemTypeId item_type_id) const
 {
     const ItemType& item_type = instance_.item_type(item_type_id);
-    BinTypeId bin_type_id = instance().bin_type_id(parent->number_of_bins - 1);
+    BinTypeId bin_type_id = bin_type_ids_[parent->number_of_bins - 1];
     const BinType& bin_type = instance().bin_type(bin_type_id);
 
     // Check bin length.
@@ -165,7 +194,7 @@ void BranchingScheme::insertion_item_new_bin(
 {
     //std::cout << "insertion_item " << item_type_id << std::endl;
     const ItemType& item_type = instance_.item_type(item_type_id);
-    BinTypeId bin_type_id = instance().bin_type_id(new_bin_pos);
+    BinTypeId bin_type_id = bin_type_ids_[new_bin_pos];
     const BinType& bin_type = instance().bin_type(bin_type_id);
     // Check bin length.
     if (item_type.length > bin_type.length)
@@ -262,7 +291,7 @@ bool BranchingScheme::bound(
             bin_pos++;
             if (bin_pos >= instance_.number_of_bins())
                 return true;
-            BinTypeId bin_type_id = instance().bin_type_id(bin_pos);
+            BinTypeId bin_type_id = bin_type_ids_[bin_pos];
             a -= instance().bin_type(bin_type_id).length;
         }
         return (bin_pos + 1 >= node_2->number_of_bins);
@@ -310,7 +339,7 @@ Solution BranchingScheme::to_solution(
         // Bins that were skipped because no item fit in them are still
         // added to the solution, as empty bins.
         while (number_of_bins < current_node->number_of_bins) {
-            bin_pos = solution_builder.add_bin(instance().bin_type_id(number_of_bins), 1);
+            bin_pos = solution_builder.add_bin(bin_type_ids_[number_of_bins], 1);
             number_of_bins++;
         }
         solution_builder.add_item(bin_pos, current_node->item_type_id);

--- a/src/onedimensional/tree_search.hpp
+++ b/src/onedimensional/tree_search.hpp
@@ -243,6 +243,19 @@ private:
     /** Parameters. */
     Parameters parameters_;
 
+    /**
+     * Bin type of the bin at each position, in the order in which bins are
+     * considered by the branching scheme.
+     *
+     * For the Knapsack objective, bins are considered by increasing space,
+     * regardless of the order in which they appear in the instance.
+     * Otherwise, this matches 'instance_.bin_type_id(bin_pos)'.
+     */
+    std::vector<BinTypeId> bin_type_ids_;
+
+    /** Total length of the bins preceding each position, in the same order as 'bin_type_ids_'. */
+    std::vector<Length> previous_bins_length_;
+
     mutable Counter node_id_ = 0;
 
     mutable std::vector<Insertion> insertions_;

--- a/src/rectangle/tree_search.cpp
+++ b/src/rectangle/tree_search.cpp
@@ -6,7 +6,9 @@
 
 #include "rectangle/solution_builder.hpp"
 
+#include <algorithm>
 #include <iostream>
+#include <numeric>
 #include <string>
 
 #include "shape/shape.hpp"
@@ -46,6 +48,36 @@ BranchingScheme::BranchingScheme(
     predecessors_1_(instance.number_of_item_types()),
     predecessors_2_(instance.number_of_item_types())
 {
+    // Compute bin_type_ids_ and previous_bins_area_.
+    //
+    // For the Knapsack objective, bins are considered by increasing space,
+    // regardless of the order in which they appear in the instance.
+    // Otherwise, bins are considered in the order in which they appear in
+    // the instance.
+    {
+        std::vector<BinTypeId> bin_type_id_order(instance.number_of_bin_types());
+        std::iota(bin_type_id_order.begin(), bin_type_id_order.end(), 0);
+        if (instance.objective() == Objective::Knapsack) {
+            std::stable_sort(
+                    bin_type_id_order.begin(),
+                    bin_type_id_order.end(),
+                    [&instance](BinTypeId bin_type_id_1, BinTypeId bin_type_id_2)
+                    {
+                        return instance.bin_type(bin_type_id_1).space()
+                            < instance.bin_type(bin_type_id_2).space();
+                    });
+        }
+        Area previous_bin_area = 0;
+        for (BinTypeId bin_type_id: bin_type_id_order) {
+            const BinType& bin_type = instance.bin_type(bin_type_id);
+            for (BinPos copy = 0; copy < bin_type.copies; ++copy) {
+                bin_type_ids_.push_back(bin_type_id);
+                previous_bins_area_.push_back(previous_bin_area);
+                previous_bin_area += bin_type.area();
+            }
+        }
+    }
+
     // Compute predecessors.
     //instance.format(std::cout, 3);
     for (ItemTypeId item_type_id = 0;
@@ -180,7 +212,7 @@ BranchingScheme::Node BranchingScheme::child_tmp(
 
     BinPos bin_pos = node.number_of_bins - 1;
     Direction o = node.last_bin_direction;
-    BinTypeId bin_type_id = instance.bin_type_id(bin_pos);
+    BinTypeId bin_type_id = bin_type_ids_[bin_pos];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     const ItemType& item_type = instance.item_type(insertion.item_type_id);
 
@@ -353,8 +385,8 @@ BranchingScheme::Node BranchingScheme::child_tmp(
         std::max(parent.xs_max, insertion.x):
         insertion.x;
     node.ye_max = (insertion.new_bin == 0)? parent.ye_max: 0;
-    node.current_area = instance.previous_bin_area(bin_pos);
-    node.guide_area = instance.previous_bin_area(bin_pos) + node.xs_max * yi;
+    node.current_area = previous_bins_area_[bin_pos];
+    node.guide_area = previous_bins_area_[bin_pos] + node.xs_max * yi;
     Length x = 0;
     for (auto it = node.uncovered_items.rbegin(); it != node.uncovered_items.rend(); ++it) {
         const auto& uncovered_item = *it;
@@ -371,13 +403,13 @@ BranchingScheme::Node BranchingScheme::child_tmp(
     }
 
     if (node.number_of_items == instance.number_of_items()) {
-        node.current_area = instance.previous_bin_area(bin_pos) + node.xe_max * yi;
+        node.current_area = previous_bins_area_[bin_pos] + node.xe_max * yi;
     }
 
     node.waste = node.current_area - node.item_area;
 
     {
-        Area waste = instance.previous_bin_area(bin_pos) + node.xe_max * yi - instance.item_area();
+        Area waste = previous_bins_area_[bin_pos] + node.xe_max * yi - instance.item_area();
         if (node.waste < waste)
             node.waste = waste;
     }
@@ -415,7 +447,7 @@ BranchingScheme::Node BranchingScheme::child_tmp(
             if (!ok) {
                 if (!item_type.oriented && xj > yj)
                     xj = yj;
-                Area waste = instance.previous_bin_area(bin_pos + 1)
+                Area waste = previous_bins_area_[bin_pos + 1]
                     + xj * yi - instance.item_area();
                 if (node.waste < waste)
                     node.waste = waste;
@@ -535,7 +567,7 @@ const std::vector<BranchingScheme::Insertion>& BranchingScheme::insertions(
     // Insert in the current bin.
     if (parent->number_of_bins > 0) {
         const Instance& instance = this->instance(parent->last_bin_direction);
-        BinTypeId bin_type_id = instance.bin_type_id(parent->number_of_bins - 1);
+        BinTypeId bin_type_id = bin_type_ids_[parent->number_of_bins - 1];
         const BinType& bin_type = instance.bin_type(bin_type_id);
 
         // Items.
@@ -685,7 +717,7 @@ const std::vector<BranchingScheme::Insertion>& BranchingScheme::insertions(
         } else if (parameters_.direction == Direction::Y) {
             new_bin = 2;
         } else {
-            BinTypeId bin_type_id = instance().bin_type_id(new_bin_pos);
+            BinTypeId bin_type_id = bin_type_ids_[new_bin_pos];
             const BinType& bin_type = instance().bin_type(bin_type_id);
             if ((double)instance().total_item_height() / bin_type.rect.y
                     >= (double)instance().total_item_width() / bin_type.rect.x) {
@@ -695,7 +727,7 @@ const std::vector<BranchingScheme::Insertion>& BranchingScheme::insertions(
             }
         }
         const Instance& instance = this->instance(new_bin);
-        BinTypeId bin_type_id = instance.bin_type_id(new_bin_pos);
+        BinTypeId bin_type_id = bin_type_ids_[new_bin_pos];
         const BinType& bin_type = instance.bin_type(bin_type_id);
 
         // Items.
@@ -774,8 +806,8 @@ void BranchingScheme::insertion_item(
     const Instance& instance = this->instance(o);
     const ItemType& item_type = instance.item_type(item_type_id);
     BinTypeId bin_type_id = (new_bin == 0)?
-        instance.bin_type_id(parent->number_of_bins - 1):
-        instance.bin_type_id(new_bin_pos);
+        bin_type_ids_[parent->number_of_bins - 1]:
+        bin_type_ids_[new_bin_pos];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     Length xj = item_type.x(rotate);
     Length yj = item_type.y(rotate);
@@ -910,7 +942,7 @@ void BranchingScheme::insertion_item_fixed(
     Direction o = parent->last_bin_direction;
     const Instance& instance = this->instance(o);
     const ItemType& item_type = instance.item_type(item_type_id);
-    BinTypeId bin_type_id = instance.bin_type_id(parent->number_of_bins - 1);
+    BinTypeId bin_type_id = bin_type_ids_[parent->number_of_bins - 1];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     Length xj = item_type.x(rotate);
     Length yj = item_type.y(rotate);
@@ -1102,7 +1134,7 @@ bool BranchingScheme::bound(
             bin_pos++;
             if (bin_pos >= instance().number_of_bins())
                 return true;
-            BinTypeId bin_type_id = instance().bin_type_id(bin_pos);
+            BinTypeId bin_type_id = bin_type_ids_[bin_pos];
             a -= instance().bin_type(bin_type_id).area();
         }
         return (bin_pos + 1 >= node_2->number_of_bins);
@@ -1166,7 +1198,7 @@ Solution BranchingScheme::to_solution(
         // Bins that were skipped because no item fit in them are still
         // added to the solution, as empty bins.
         while (number_of_bins < current_node->number_of_bins) {
-            BinTypeId bin_type_id = instance().bin_type_id(number_of_bins);
+            BinTypeId bin_type_id = bin_type_ids_[number_of_bins];
             bin_pos = solution_builder.add_bin(bin_type_id, 1);
             number_of_bins++;
         }
@@ -1318,7 +1350,7 @@ nlohmann::json BranchingScheme::json_export(
     nlohmann::json plot;
     Counter i = 0;
     // Plot bin.
-    BinTypeId bin_type_id = instance().bin_type_id(node->number_of_bins - 1);
+    BinTypeId bin_type_id = bin_type_ids_[node->number_of_bins - 1];
     plot[i] = {
         {"Id",json_bins_init_ids_[bin_type_id]},
         {"X", 0},

--- a/src/rectangle/tree_search.hpp
+++ b/src/rectangle/tree_search.hpp
@@ -477,6 +477,19 @@ private:
 
     //bool unbounded_knapsack_ = false;
 
+    /**
+     * Bin type of the bin at each position, in the order in which bins are
+     * considered by the branching scheme.
+     *
+     * For the Knapsack objective, bins are considered by increasing space,
+     * regardless of the order in which they appear in the instance.
+     * Otherwise, this matches 'instance_.bin_type_id(bin_pos)'.
+     */
+    std::vector<BinTypeId> bin_type_ids_;
+
+    /** Total area of the bins preceding each position, in the same order as 'bin_type_ids_'. */
+    std::vector<Area> previous_bins_area_;
+
     std::vector<std::vector<ItemTypeId>> predecessors_;
 
     std::vector<std::vector<ItemTypeId>> predecessors_1_;

--- a/src/rectangleguillotine/tree_search.cpp
+++ b/src/rectangleguillotine/tree_search.cpp
@@ -8,6 +8,8 @@
 
 #include "shape/shape.hpp"
 
+#include <algorithm>
+#include <numeric>
 #include <sstream>
 
 using namespace packingsolver;
@@ -20,6 +22,36 @@ BranchingScheme::BranchingScheme(
     instance_flipper_(instance),
     parameters_(parameters)
 {
+    // Compute bin_type_ids_ and previous_bins_area_.
+    //
+    // For the Knapsack objective, bins are considered by increasing space,
+    // regardless of the order in which they appear in the instance.
+    // Otherwise, bins are considered in the order in which they appear in
+    // the instance.
+    {
+        std::vector<BinTypeId> bin_type_id_order(instance.number_of_bin_types());
+        std::iota(bin_type_id_order.begin(), bin_type_id_order.end(), 0);
+        if (instance.objective() == Objective::Knapsack) {
+            std::stable_sort(
+                    bin_type_id_order.begin(),
+                    bin_type_id_order.end(),
+                    [&instance](BinTypeId bin_type_id_1, BinTypeId bin_type_id_2)
+                    {
+                        return instance.bin_type(bin_type_id_1).space()
+                            < instance.bin_type(bin_type_id_2).space();
+                    });
+        }
+        Area previous_bin_area = 0;
+        for (BinTypeId bin_type_id: bin_type_id_order) {
+            const BinType& bin_type = instance.bin_type(bin_type_id);
+            for (BinPos copy = 0; copy < bin_type.copies; ++copy) {
+                bin_type_ids_.push_back(bin_type_id);
+                previous_bins_area_.push_back(previous_bin_area);
+                previous_bin_area += bin_type.area();
+            }
+        }
+    }
+
     // Compute first_stage_orientation_.
     CutOrientation first_stage_orientation = (instance.parameters().first_stage_orientation != CutOrientation::Any)?
         instance.parameters().first_stage_orientation:
@@ -160,7 +192,7 @@ bool BranchingScheme::bound(
             bin_pos++;
             if (bin_pos >= instance().number_of_bins())
                 return true;
-            BinTypeId bin_type_id = instance().bin_type_id(bin_pos);
+            BinTypeId bin_type_id = bin_type_ids_[bin_pos];
             a -= instance().bin_type(bin_type_id).area();
         }
         return (bin_pos + 1 >= node_2->number_of_bins);
@@ -279,7 +311,7 @@ Length BranchingScheme::x1_prev(const Node& node, Depth df) const
     } default: {
         const Instance& instance = this->instance(df);
         BinPos bin_pos = node.number_of_bins + (-df - 1) / 2;
-        BinTypeId bin_type_id = instance.bin_type_id(bin_pos);
+        BinTypeId bin_type_id = bin_type_ids_[bin_pos];
         return instance.bin_type(bin_type_id).left_trim;
     }
     }
@@ -297,7 +329,7 @@ Length BranchingScheme::x3_prev(const Node& node, Depth df) const
     } default: {
         const Instance& instance = this->instance(df);
         BinPos bin_pos = node.number_of_bins + (-df - 1) / 2;
-        BinTypeId bin_type_id = instance.bin_type_id(bin_pos);
+        BinTypeId bin_type_id = bin_type_ids_[bin_pos];
         return instance.bin_type(bin_type_id).left_trim;
     }
     }
@@ -308,7 +340,7 @@ Length BranchingScheme::y2_prev(const Node& node, Depth df) const
     switch (df) {
     case 0: {
         const Instance& instance = this->instance(node.first_stage_orientation);
-        BinTypeId bin_type_id = instance.bin_type_id(node.number_of_bins - 1);
+        BinTypeId bin_type_id = bin_type_ids_[node.number_of_bins - 1];
         return instance.bin_type(bin_type_id).bottom_trim;
     } case 1: {
         return node.y2_curr + instance().parameters().cut_thickness;
@@ -317,7 +349,7 @@ Length BranchingScheme::y2_prev(const Node& node, Depth df) const
     } default: {
         const Instance& instance = this->instance(df);
         BinPos bin_pos = node.number_of_bins + (-df - 1) / 2;
-        BinTypeId bin_type_id = instance.bin_type_id(bin_pos);
+        BinTypeId bin_type_id = bin_type_ids_[bin_pos];
         return instance.bin_type(bin_type_id).bottom_trim;
     }
     }
@@ -409,7 +441,7 @@ BranchingScheme::Node BranchingScheme::child_tmp(
 
     BinPos i = node.number_of_bins - 1;
     CutOrientation o = node.first_stage_orientation;
-    BinTypeId bin_type_id = instance.bin_type_id(i);
+    BinTypeId bin_type_id = bin_type_ids_[i];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     Length h = bin_type.rect.h
         - bin_type.top_trim
@@ -626,7 +658,7 @@ BranchingScheme::Node BranchingScheme::child_tmp(
     }
 
     // Update current_area_ and waste_
-    node.current_area = instance.previous_bin_area(i);
+    node.current_area = previous_bins_area_[i];
     if (full(node)) {
         node.current_area += (instance.parameters().number_of_stages >= 3)?
             (node.x1_curr - bin_type.left_trim) * h:
@@ -857,7 +889,7 @@ std::vector<std::shared_ptr<BranchingScheme::Node>> BranchingScheme::children(
                 insert_defect = false;
         }
         if (insert_defect) {
-            BinTypeId bin_type_id = instance.bin_type_id(i);
+            BinTypeId bin_type_id = bin_type_ids_[i];
             const BinType& bin_type = instance.bin_type(bin_type_id);
             for (DefectId defect_id = 0;
                     defect_id < (DefectId)bin_type.defects.size();
@@ -941,7 +973,7 @@ Area BranchingScheme::waste(
     BinPos i = last_bin(node, insertion.df);
     CutOrientation o = last_bin_orientation(node, insertion.df);
     const Instance& instance = this->instance(o);
-    BinTypeId bin_type_id = instance.bin_type_id(i);
+    BinTypeId bin_type_id = bin_type_ids_[i];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     Length h = bin_type.rect.h;
     Front f = front(node, insertion);
@@ -956,9 +988,9 @@ Area BranchingScheme::waste(
         item_area += instance.item_type(insertion.item_type_id_2).area();
     }
     Area current_area = (n == instance.number_of_items())?
-        instance.previous_bin_area(i)
+        previous_bins_area_[i]
         + (f.x1_curr * h):
-        instance.previous_bin_area(i)
+        previous_bins_area_[i]
         + f.x1_prev * h
         + (f.x1_curr - f.x1_prev) * f.y2_prev
         + (f.x3_curr - f.x1_prev) * (f.y2_curr - f.y2_prev);
@@ -972,7 +1004,7 @@ Length BranchingScheme::x1_max(const Node& node, Depth df) const
         BinPos i = node.number_of_bins - 1;
         CutOrientation o = node.first_stage_orientation;
         const Instance& instance = this->instance(o);
-        BinTypeId bin_type_id = instance.bin_type_id(i);
+        BinTypeId bin_type_id = bin_type_ids_[i];
         const BinType& bin_type = instance.bin_type(bin_type_id);
         Length x = (bin_type.right_trim_type == TrimType::Hard)?
             bin_type.rect.w - bin_type.right_trim:
@@ -985,7 +1017,7 @@ Length BranchingScheme::x1_max(const Node& node, Depth df) const
         BinPos i = node.number_of_bins - 1;
         CutOrientation o = node.first_stage_orientation;
         const Instance& instance = this->instance(o);
-        BinTypeId bin_type_id = instance.bin_type_id(i);
+        BinTypeId bin_type_id = bin_type_ids_[i];
         const BinType& bin_type = instance.bin_type(bin_type_id);
         Length x = node.x1_max;
         if (!instance.parameters().cut_through_defects)
@@ -1001,7 +1033,7 @@ Length BranchingScheme::x1_max(const Node& node, Depth df) const
     } default: {
         BinPos i = node.number_of_bins + (-df - 1) / 2;
         const Instance& instance = this->instance(df);
-        BinTypeId bin_type_id = instance.bin_type_id(i);
+        BinTypeId bin_type_id = bin_type_ids_[i];
         const BinType& bin_type = instance.bin_type(bin_type_id);
         Length x = (bin_type.right_trim_type == TrimType::Hard)?
             bin_type.rect.w - bin_type.right_trim:
@@ -1022,7 +1054,7 @@ Length BranchingScheme::y2_max(
     CutOrientation o = last_bin_orientation(node, df);
     BinPos i = last_bin(node, df);
     const Instance& instance = this->instance(o);
-    BinTypeId bin_type_id = instance.bin_type_id(i);
+    BinTypeId bin_type_id = bin_type_ids_[i];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     Length y = (df == 2)?
         node.y2_max:
@@ -1073,7 +1105,7 @@ void BranchingScheme::insertion_1_item(
     const rectangleguillotine::ItemType& item_type = instance.item_type(item_type_id);
     Length x = x3_prev(parent, df) + item_type.width(rotate);
     Length y = y2_prev(parent, df) + item_type.height(rotate);
-    BinTypeId bin_type_id = instance.bin_type_id(i);
+    BinTypeId bin_type_id = bin_type_ids_[i];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     Length w = bin_type.rect.w - bin_type.right_trim;
     Length h = bin_type.rect.h - bin_type.top_trim;
@@ -1145,7 +1177,7 @@ void BranchingScheme::insertion_2_items(
     const Instance& instance = this->instance(o);
     const ItemType& item_type_1 = instance.item_type(item_type_id_1);
     const ItemType& item_type_2 = instance.item_type(item_type_id_2);
-    BinTypeId bin_type_id = instance.bin_type_id(i);
+    BinTypeId bin_type_id = bin_type_ids_[i];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     Length w = bin_type.rect.w - bin_type.right_trim;
     Length h = bin_type.rect.h - bin_type.top_trim;
@@ -1195,7 +1227,7 @@ void BranchingScheme::insertion_defect(
     CutOrientation o = last_bin_orientation(parent, df);
     BinPos i = last_bin(parent, df);
     const Instance& instance = this->instance(o);
-    BinTypeId bin_type_id = instance.bin_type_id(i);
+    BinTypeId bin_type_id = bin_type_ids_[i];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     const Defect& defect = bin_type.defects[defect_id];
     Length w = bin_type.rect.w - bin_type.right_trim;
@@ -1235,7 +1267,7 @@ void BranchingScheme::update(
     const Instance& instance = this->instance(o);
     Length min_waste = instance.parameters().minimum_waste_length;
     Length cut_thickness = instance.parameters().cut_thickness;
-    BinTypeId bin_type_id = instance.bin_type_id(i);
+    BinTypeId bin_type_id = bin_type_ids_[i];
     const BinType& bin_type = instance.bin_type(bin_type_id);
     Length w_orig = bin_type.rect.w;
     Length h_orig = bin_type.rect.h;
@@ -1834,7 +1866,7 @@ Solution BranchingScheme::to_solution(
             } else {
                 number_of_bins = current_node->number_of_bins;
             }
-            BinTypeId bin_type_id = instance().bin_type_id(number_of_bins - 1);
+            BinTypeId bin_type_id = bin_type_ids_[number_of_bins - 1];
             solution_builder.add_bin(
                     bin_type_id,
                     1,
@@ -1861,7 +1893,7 @@ Solution BranchingScheme::to_solution(
                 }
                 solution_builder.add_node(1, subplate1_curr_x1);
 
-                BinTypeId bin_type_id = instance().bin_type_id(number_of_bins - 1);
+                BinTypeId bin_type_id = bin_type_ids_[number_of_bins - 1];
                 const BinType& bin_type = instance().bin_type(bin_type_id);
                 if (bin_type.bottom_trim_type == TrimType::Soft
                         && bin_type.bottom_trim > 0) {
@@ -2147,7 +2179,7 @@ nlohmann::json BranchingScheme::json_export(
     nlohmann::json plot;
     Counter i = 0;
     // Plot bin.
-    BinTypeId bin_type_id = instance().bin_type_id(node->number_of_bins - 1);
+    BinTypeId bin_type_id = bin_type_ids_[node->number_of_bins - 1];
     plot[i] = {
         {"Id",json_bins_init_ids_[bin_type_id]},
         {"X", 0},

--- a/src/rectangleguillotine/tree_search.hpp
+++ b/src/rectangleguillotine/tree_search.hpp
@@ -408,6 +408,19 @@ private:
     /** Parameters. */
     Parameters parameters_;
 
+    /**
+     * Bin type of the bin at each position, in the order in which bins are
+     * considered by the branching scheme.
+     *
+     * For the Knapsack objective, bins are considered by increasing space,
+     * regardless of the order in which they appear in the instance.
+     * Otherwise, this matches 'instance_.bin_type_id(bin_pos)'.
+     */
+    std::vector<BinTypeId> bin_type_ids_;
+
+    /** Total area of the bins preceding each position, in the same order as 'bin_type_ids_'. */
+    std::vector<Area> previous_bins_area_;
+
     /** First stage orientation. */
     CutOrientation first_stage_orientation_ = CutOrientation::Any;
 
@@ -544,7 +557,7 @@ private:
         const Instance& instance = this->instance(node.first_stage_orientation);
         BinPos i = node.number_of_bins - 1;
         CutOrientation o = node.first_stage_orientation;
-        BinTypeId bin_type_id = instance.bin_type_id(i);
+        BinTypeId bin_type_id = bin_type_ids_[i];
         const BinType& bin_type = instance.bin_type(bin_type_id);
         return (instance_.parameters().number_of_stages >= 3)?
             (node.x1_curr - node.x1_prev)
@@ -696,7 +709,7 @@ inline bool BranchingScheme::dominates(
                 && f1.x1_curr <= f2.x1_curr
                 && f1.y2_curr <= f2.y2_prev)
             return true;
-        BinTypeId bin_type_id = instance.bin_type_id(f1.i);
+        BinTypeId bin_type_id = bin_type_ids_[f1.i];
         const BinType& bin_type = instance.bin_type(bin_type_id);
         Length h = bin_type.rect.h;
         if (f1.y2_curr != h


### PR DESCRIPTION
For multiple knapsack instances, the branching scheme and SVC used to try bin types strictly in the order they were declared in the instance. Each branching scheme now builds its own bin-position-to-bin-type ordering (sorted by ascending space for Knapsack, unchanged declaration order otherwise), leaving the instance's own bin declaration order untouched for reporting/output.