### PR TITLE
Add a variable-sized bin packing trivial bound and report primal/dual/gap

### DIFF
--- a/include/packingsolver/algorithms/common.hpp
+++ b/include/packingsolver/algorithms/common.hpp
@@ -259,6 +259,27 @@ private:
 };
 
 /**
+ * Print a "Primal bound" / "Dual bound" / "Gap" block for a pair of bound
+ * values on the same scale (which one is the primal and which is the dual
+ * doesn't matter here: only their difference relative to the primal value is
+ * used).
+ */
+template <typename T>
+void write_bound(
+        std::ostream& os,
+        int width,
+        T primal_bound,
+        T dual_bound)
+{
+    os << std::setw(width) << std::left << "Primal bound: " << primal_bound << std::endl;
+    os << std::setw(width) << std::left << "Dual bound: " << dual_bound << std::endl;
+    double gap = (primal_bound != 0)?
+        100.0 * std::abs((double)primal_bound - (double)dual_bound) / std::abs((double)primal_bound):
+        ((dual_bound != 0)? 100.0: 0.0);
+    os << std::setw(width) << std::left << "Gap: " << gap << "%" << std::endl;
+}
+
+/**
  * Output stucture for packing optimization algorithms.
  */
 template <typename Instance, typename Solution>
@@ -283,7 +304,19 @@ struct Output: optimizationtools::Output
         };
     }
 
-    virtual int format_width() const { return 11; }
+    virtual int format_width() const
+    {
+        switch (solution_pool.best().instance().objective()) {
+        case Objective::Feasibility:
+            // Fits "Is proven infeasible: ", the only line printed for this
+            // objective besides "Time (s): ".
+            return 23;
+        default:
+            // Fits "Primal bound: ", the longest of the "Primal bound" /
+            // "Dual bound" / "Gap" lines printed for every other objective.
+            return 15;
+        }
+    }
 
     virtual void format(std::ostream& os) const
     {

--- a/include/packingsolver/box/optimize.hpp
+++ b/include/packingsolver/box/optimize.hpp
@@ -129,22 +129,22 @@ struct Output: packingsolver::Output<Instance, Solution>
         int width = format_width();
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
-            os << std::setw(width) << std::left << "Knapsack bound: " << knapsack_bound << std::endl;
+            write_bound(os, width, solution_pool.best().profit(), knapsack_bound);
             break;
         case Objective::BinPacking:
-            os << std::setw(width) << std::left << "Bin packing bound: " << bin_packing_bound << std::endl;
+            write_bound(os, width, solution_pool.best().number_of_bins(), bin_packing_bound);
             break;
         case Objective::VariableSizedBinPacking:
-            os << std::setw(width) << std::left << "Variable-sized bin packing bound: " << variable_sized_bin_packing_bound << std::endl;
+            write_bound(os, width, solution_pool.best().cost(), variable_sized_bin_packing_bound);
             break;
         case Objective::OpenDimensionX:
-            os << std::setw(width) << std::left << "Open dimension X bound: " << open_dimension_x_bound << std::endl;
+            write_bound(os, width, solution_pool.best().x_max(), open_dimension_x_bound);
             break;
         case Objective::OpenDimensionY:
-            os << std::setw(width) << std::left << "Open dimension Y bound: " << open_dimension_y_bound << std::endl;
+            write_bound(os, width, solution_pool.best().y_max(), open_dimension_y_bound);
             break;
         case Objective::OpenDimensionZ:
-            os << std::setw(width) << std::left << "Open dimension Z bound: " << open_dimension_z_bound << std::endl;
+            write_bound(os, width, solution_pool.best().z_max(), open_dimension_z_bound);
             break;
         case Objective::Feasibility:
             os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;

--- a/include/packingsolver/boxstacks/optimize.hpp
+++ b/include/packingsolver/boxstacks/optimize.hpp
@@ -63,13 +63,13 @@ struct Output: packingsolver::Output<Instance, Solution>
         int width = format_width();
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
-            os << std::setw(width) << std::left << "Knapsack bound: " << knapsack_bound << std::endl;
+            write_bound(os, width, solution_pool.best().profit(), knapsack_bound);
             break;
         case Objective::BinPacking:
-            os << std::setw(width) << std::left << "Bin packing bound: " << bin_packing_bound << std::endl;
+            write_bound(os, width, solution_pool.best().number_of_bins(), bin_packing_bound);
             break;
         case Objective::VariableSizedBinPacking:
-            os << std::setw(width) << std::left << "Variable-sized bin packing bound: " << variable_sized_bin_packing_bound << std::endl;
+            write_bound(os, width, solution_pool.best().cost(), variable_sized_bin_packing_bound);
             break;
         case Objective::Feasibility:
             os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;

--- a/include/packingsolver/irregular/optimize.hpp
+++ b/include/packingsolver/irregular/optimize.hpp
@@ -118,19 +118,19 @@ struct Output: packingsolver::Output<Instance, Solution>
         int width = format_width();
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
-            os << std::setw(width) << std::left << "Knapsack bound: " << knapsack_bound << std::endl;
+            write_bound(os, width, solution_pool.best().profit(), knapsack_bound);
             break;
         case Objective::BinPacking:
-            os << std::setw(width) << std::left << "Bin packing bound: " << bin_packing_bound << std::endl;
+            write_bound(os, width, solution_pool.best().number_of_bins(), bin_packing_bound);
             break;
         case Objective::VariableSizedBinPacking:
-            os << std::setw(width) << std::left << "Variable-sized bin packing bound: " << variable_sized_bin_packing_bound << std::endl;
+            write_bound(os, width, solution_pool.best().cost(), variable_sized_bin_packing_bound);
             break;
         case Objective::OpenDimensionX:
-            os << std::setw(width) << std::left << "Open dimension X bound: " << open_dimension_x_bound << std::endl;
+            write_bound(os, width, solution_pool.best().x_max(), open_dimension_x_bound);
             break;
         case Objective::OpenDimensionY:
-            os << std::setw(width) << std::left << "Open dimension Y bound: " << open_dimension_y_bound << std::endl;
+            write_bound(os, width, solution_pool.best().y_max(), open_dimension_y_bound);
             break;
         case Objective::Feasibility:
             os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;

--- a/include/packingsolver/onedimensional/optimize.hpp
+++ b/include/packingsolver/onedimensional/optimize.hpp
@@ -96,13 +96,13 @@ struct Output: packingsolver::Output<Instance, Solution>
         int width = format_width();
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
-            os << std::setw(width) << std::left << "Knapsack bound: " << knapsack_bound << std::endl;
+            write_bound(os, width, solution_pool.best().profit(), knapsack_bound);
             break;
         case Objective::BinPacking:
-            os << std::setw(width) << std::left << "Bin packing bound: " << bin_packing_bound << std::endl;
+            write_bound(os, width, solution_pool.best().number_of_bins(), bin_packing_bound);
             break;
         case Objective::VariableSizedBinPacking:
-            os << std::setw(width) << std::left << "Variable-sized bin packing bound: " << variable_sized_bin_packing_bound << std::endl;
+            write_bound(os, width, solution_pool.best().cost(), variable_sized_bin_packing_bound);
             break;
         case Objective::Feasibility:
             os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;

--- a/include/packingsolver/rectangle/optimize.hpp
+++ b/include/packingsolver/rectangle/optimize.hpp
@@ -118,19 +118,19 @@ struct Output: packingsolver::Output<Instance, Solution>
         int width = format_width();
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
-            os << std::setw(width) << std::left << "Knapsack bound: " << knapsack_bound << std::endl;
+            write_bound(os, width, solution_pool.best().profit(), knapsack_bound);
             break;
         case Objective::BinPacking:
-            os << std::setw(width) << std::left << "Bin packing bound: " << bin_packing_bound << std::endl;
+            write_bound(os, width, solution_pool.best().number_of_bins(), bin_packing_bound);
             break;
         case Objective::VariableSizedBinPacking:
-            os << std::setw(width) << std::left << "Variable-sized bin packing bound: " << variable_sized_bin_packing_bound << std::endl;
+            write_bound(os, width, solution_pool.best().cost(), variable_sized_bin_packing_bound);
             break;
         case Objective::OpenDimensionX:
-            os << std::setw(width) << std::left << "Open dimension X bound: " << open_dimension_x_bound << std::endl;
+            write_bound(os, width, solution_pool.best().x_max(), open_dimension_x_bound);
             break;
         case Objective::OpenDimensionY:
-            os << std::setw(width) << std::left << "Open dimension Y bound: " << open_dimension_y_bound << std::endl;
+            write_bound(os, width, solution_pool.best().y_max(), open_dimension_y_bound);
             break;
         case Objective::Feasibility:
             os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;

--- a/include/packingsolver/rectangleguillotine/optimize.hpp
+++ b/include/packingsolver/rectangleguillotine/optimize.hpp
@@ -118,19 +118,19 @@ struct Output: packingsolver::Output<Instance, Solution>
         int width = format_width();
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
-            os << std::setw(width) << std::left << "Knapsack bound: " << knapsack_bound << std::endl;
+            write_bound(os, width, solution_pool.best().profit(), knapsack_bound);
             break;
         case Objective::BinPacking:
-            os << std::setw(width) << std::left << "Bin packing bound: " << bin_packing_bound << std::endl;
+            write_bound(os, width, solution_pool.best().number_of_bins(), bin_packing_bound);
             break;
         case Objective::VariableSizedBinPacking:
-            os << std::setw(width) << std::left << "Variable-sized bin packing bound: " << variable_sized_bin_packing_bound << std::endl;
+            write_bound(os, width, solution_pool.best().cost(), variable_sized_bin_packing_bound);
             break;
         case Objective::OpenDimensionX:
-            os << std::setw(width) << std::left << "Open dimension X bound: " << open_dimension_x_bound << std::endl;
+            write_bound(os, width, solution_pool.best().width(), open_dimension_x_bound);
             break;
         case Objective::OpenDimensionY:
-            os << std::setw(width) << std::left << "Open dimension Y bound: " << open_dimension_y_bound << std::endl;
+            write_bound(os, width, solution_pool.best().height(), open_dimension_y_bound);
             break;
         case Objective::Feasibility:
             os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;

--- a/src/box/optimize.cpp
+++ b/src/box/optimize.cpp
@@ -5,6 +5,8 @@
 #include "box/tree_search.hpp"
 #include "box/tree_search_maximal_spaces.hpp"
 #include "box/dual_feasible_functions.hpp"
+#include "packingsolver/onedimensional/instance_builder.hpp"
+#include "packingsolver/onedimensional/optimize.hpp"
 #include "algorithms/dichotomic_search.hpp"
 #include "algorithms/sequential_value_correction.hpp"
 #include "algorithms/column_generation.hpp"
@@ -150,6 +152,69 @@ void optimize_trivial_bound(
         algorithm_formatter.update_open_dimension_y_bound(bound);
     } else {
         algorithm_formatter.update_open_dimension_z_bound(bound);
+    }
+}
+
+void optimize_onedimensional_bound(
+        const Instance& instance,
+        const OptimizeParameters& parameters,
+        AlgorithmFormatter& algorithm_formatter)
+{
+    // Relax the instance to 1D, keeping only bin/item volumes: any solution
+    // of the original instance is also a solution of this relaxation (with
+    // the same cost), so the bound the onedimensional solver finds for it
+    // (which runs the same dichotomic search) is a valid lower bound here.
+    onedimensional::InstanceBuilder onedim_instance_builder;
+    onedim_instance_builder.set_objective(instance.objective());
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < instance.number_of_bin_types();
+            ++bin_type_id) {
+        const BinType& bin_type = instance.bin_type(bin_type_id);
+        BinTypeId onedim_bin_type_id = onedim_instance_builder.add_bin_type(bin_type.volume());
+        onedim_instance_builder.set_bin_type_cost(onedim_bin_type_id, bin_type.cost);
+        onedim_instance_builder.set_bin_type_copies(onedim_bin_type_id, bin_type.copies);
+        onedim_instance_builder.set_bin_type_copies_min(onedim_bin_type_id, bin_type.copies_min);
+    }
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance.number_of_item_types();
+            ++item_type_id) {
+        const ItemType& item_type = instance.item_type(item_type_id);
+        if (item_type.volume() <= 0)
+            continue;
+        ItemTypeId onedim_item_type_id = onedim_instance_builder.add_item_type(item_type.volume());
+        onedim_instance_builder.set_item_type_profit(onedim_item_type_id, item_type.profit);
+        onedim_instance_builder.set_item_type_copies(onedim_item_type_id, item_type.copies);
+    }
+    onedimensional::Instance onedim_instance = onedim_instance_builder.build();
+
+    onedimensional::OptimizeParameters onedim_parameters;
+    onedim_parameters.verbosity_level = 0;
+    onedim_parameters.timer = parameters.timer;
+    onedim_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    onedim_parameters.optimization_mode = OptimizationMode::NotAnytime;
+    onedim_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
+    auto onedim_output = optimize(onedim_instance, onedim_parameters);
+
+    switch (instance.objective()) {
+    case Objective::BinPacking: {
+        algorithm_formatter.update_bin_packing_bound(
+                onedim_output.bin_packing_bound);
+        break;
+    } case Objective::Knapsack: {
+        algorithm_formatter.update_knapsack_bound(
+                onedim_output.knapsack_bound);
+        break;
+    } case Objective::VariableSizedBinPacking: {
+        algorithm_formatter.update_variable_sized_bin_packing_bound(
+                onedim_output.variable_sized_bin_packing_bound);
+        break;
+    } default: {
+        std::stringstream ss;
+        ss << FUNC_SIGNATURE << ": "
+            << "objective \""
+            << instance.objective() << "\" not supported.";
+        throw std::logic_error(ss.str());
+    }
     }
 }
 
@@ -459,6 +524,15 @@ packingsolver::box::Output packingsolver::box::optimize(
     algorithm_formatter.print_header();
 
     optimize_trivial_bound(instance, algorithm_formatter);
+
+    if (instance.objective() == Objective::BinPacking
+            || instance.objective() == Objective::Knapsack
+            || instance.objective() == Objective::VariableSizedBinPacking) {
+        optimize_onedimensional_bound(
+                instance,
+                parameters,
+                algorithm_formatter);
+    }
 
     if (instance.objective() == Objective::BinPacking
             || instance.objective() == Objective::Feasibility

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -21,6 +21,7 @@ namespace
 
 void optimize_trivial_bound(
         const Instance& instance,
+        const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter)
 {
     if (instance.objective() == Objective::Knapsack) {
@@ -119,6 +120,79 @@ void optimize_trivial_bound(
             remaining_item_length -= bins_used * bin_type.length;
         }
         algorithm_formatter.update_bin_packing_bound(bound);
+        return;
+    }
+
+    if (instance.objective() == Objective::VariableSizedBinPacking) {
+        // Same bin-selection knapsack as the one solved by the dichotomic
+        // search (see 'algorithms/dichotomic_search.hpp'), but solved once
+        // at zero waste instead of iteratively: a real solution can never
+        // have negative waste, so the minimum cost of a bin selection whose
+        // total length covers the (nesting-reduced) item lengths exactly is
+        // a valid lower bound on the actual solution's cost.
+        //
+        // Bin copies beyond 'copies_min' are knapsack items (weight =
+        // length, profit = cost); leaving a bin out of the knapsack means
+        // using it, so maximizing the profit (cost) of the bins put in the
+        // knapsack (i.e. left unused) is equivalent to minimizing the cost
+        // of the bins actually used.
+        Length bin_length = 0;
+        Length bin_min_length = 0;
+        Profit total_cost = 0;
+        for (BinTypeId bin_type_id = 0;
+                bin_type_id < instance.number_of_bin_types();
+                ++bin_type_id) {
+            const BinType& bin_type = instance.bin_type(bin_type_id);
+            bin_length += bin_type.length * bin_type.copies;
+            bin_min_length += bin_type.length * bin_type.copies_min;
+            total_cost += bin_type.cost * bin_type.copies;
+        }
+        Length item_length = 0;
+        for (ItemTypeId item_type_id = 0;
+                item_type_id < instance.number_of_item_types();
+                ++item_type_id) {
+            const ItemType& item_type = instance.item_type(item_type_id);
+            item_length += item_type.copies
+                * (item_type.length - std::max(item_type.nesting_length, (Length)0));
+        }
+
+        Length kp_capacity = bin_length - bin_min_length - item_length;
+        if (kp_capacity <= 0) {
+            // No bin can be left unused: they are all needed just to cover
+            // the item lengths.
+            algorithm_formatter.update_variable_sized_bin_packing_bound(total_cost);
+            return;
+        }
+
+        InstanceBuilder kp_instance_builder;
+        kp_instance_builder.set_objective(Objective::Knapsack);
+        kp_instance_builder.add_bin_type(kp_capacity);
+        for (BinTypeId bin_type_id = 0;
+                bin_type_id < instance.number_of_bin_types();
+                ++bin_type_id) {
+            const BinType& bin_type = instance.bin_type(bin_type_id);
+            BinPos optional_copies = bin_type.copies - bin_type.copies_min;
+            if (optional_copies <= 0
+                    || bin_type.length <= 0
+                    || bin_type.length > kp_capacity) {
+                continue;
+            }
+            ItemTypeId kp_item_type_id = kp_instance_builder.add_item_type(bin_type.length);
+            kp_instance_builder.set_item_type_profit(kp_item_type_id, bin_type.cost);
+            kp_instance_builder.set_item_type_copies(kp_item_type_id, optional_copies);
+        }
+        Instance kp_instance = kp_instance_builder.build();
+
+        OptimizeParameters kp_parameters;
+        kp_parameters.verbosity_level = 0;
+        kp_parameters.timer = parameters.timer;
+        kp_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+        kp_parameters.optimization_mode = OptimizationMode::NotAnytime;
+        kp_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
+        auto kp_output = optimize(kp_instance, kp_parameters);
+
+        algorithm_formatter.update_variable_sized_bin_packing_bound(
+                total_cost - kp_output.solution_pool.best().profit());
         return;
     }
 }
@@ -440,7 +514,7 @@ packingsolver::onedimensional::Output packingsolver::onedimensional::optimize(
     algorithm_formatter.start();
     algorithm_formatter.print_header();
 
-    optimize_trivial_bound(instance, algorithm_formatter);
+    optimize_trivial_bound(instance, parameters, algorithm_formatter);
 
     if (instance.number_of_bins() == 1
             && instance.objective() == Objective::Knapsack) {

--- a/src/rectangle/CMakeLists.txt
+++ b/src/rectangle/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(PackingSolver_rectangle PRIVATE
     ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries(PackingSolver_rectangle PUBLIC
     PackingSolver_algorithms
+    PackingSolver_onedimensional
     TreeSearchSolver::treesearchsolver
     Shape::shape
     MathOptSolversCMake::mathopt

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -6,6 +6,8 @@
 #include "rectangle/tree_search_maximal_spaces.hpp"
 #include "rectangle/benders_decomposition.hpp"
 #include "rectangle/dual_feasible_functions.hpp"
+#include "packingsolver/onedimensional/instance_builder.hpp"
+#include "packingsolver/onedimensional/optimize.hpp"
 #include "algorithms/dichotomic_search.hpp"
 #include "algorithms/sequential_value_correction.hpp"
 #include "algorithms/column_generation.hpp"
@@ -147,6 +149,69 @@ void optimize_trivial_bound(
         algorithm_formatter.update_open_dimension_x_bound(bound);
     } else {
         algorithm_formatter.update_open_dimension_y_bound(bound);
+    }
+}
+
+void optimize_onedimensional_bound(
+        const Instance& instance,
+        const OptimizeParameters& parameters,
+        AlgorithmFormatter& algorithm_formatter)
+{
+    // Relax the instance to 1D, keeping only bin/item areas: any solution of
+    // the original instance is also a solution of this relaxation (with the
+    // same cost), so the bound the onedimensional solver finds for it
+    // (which runs the same dichotomic search) is a valid lower bound here.
+    onedimensional::InstanceBuilder onedim_instance_builder;
+    onedim_instance_builder.set_objective(instance.objective());
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < instance.number_of_bin_types();
+            ++bin_type_id) {
+        const BinType& bin_type = instance.bin_type(bin_type_id);
+        BinTypeId onedim_bin_type_id = onedim_instance_builder.add_bin_type(bin_type.area());
+        onedim_instance_builder.set_bin_type_cost(onedim_bin_type_id, bin_type.cost);
+        onedim_instance_builder.set_bin_type_copies(onedim_bin_type_id, bin_type.copies);
+        onedim_instance_builder.set_bin_type_copies_min(onedim_bin_type_id, bin_type.copies_min);
+    }
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance.number_of_item_types();
+            ++item_type_id) {
+        const ItemType& item_type = instance.item_type(item_type_id);
+        if (item_type.area() <= 0)
+            continue;
+        ItemTypeId onedim_item_type_id = onedim_instance_builder.add_item_type(item_type.area());
+        onedim_instance_builder.set_item_type_profit(onedim_item_type_id, item_type.profit);
+        onedim_instance_builder.set_item_type_copies(onedim_item_type_id, item_type.copies);
+    }
+    onedimensional::Instance onedim_instance = onedim_instance_builder.build();
+
+    onedimensional::OptimizeParameters onedim_parameters;
+    onedim_parameters.verbosity_level = 0;
+    onedim_parameters.timer = parameters.timer;
+    onedim_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    onedim_parameters.optimization_mode = OptimizationMode::NotAnytime;
+    onedim_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
+    auto onedim_output = optimize(onedim_instance, onedim_parameters);
+
+    switch (instance.objective()) {
+    case Objective::BinPacking: {
+        algorithm_formatter.update_bin_packing_bound(
+                onedim_output.bin_packing_bound);
+        break;
+    } case Objective::Knapsack: {
+        algorithm_formatter.update_knapsack_bound(
+                onedim_output.knapsack_bound);
+        break;
+    } case Objective::VariableSizedBinPacking: {
+        algorithm_formatter.update_variable_sized_bin_packing_bound(
+                onedim_output.variable_sized_bin_packing_bound);
+        break;
+    } default: {
+        std::stringstream ss;
+        ss << FUNC_SIGNATURE << ": "
+            << "objective \""
+            << instance.objective() << "\" not supported.";
+        throw std::logic_error(ss.str());
+    }
     }
 }
 
@@ -485,6 +550,15 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
     algorithm_formatter.print_header();
 
     optimize_trivial_bound(instance, algorithm_formatter);
+
+    if (instance.objective() == Objective::BinPacking
+            || instance.objective() == Objective::Knapsack
+            || instance.objective() == Objective::VariableSizedBinPacking) {
+        optimize_onedimensional_bound(
+                instance,
+                parameters,
+                algorithm_formatter);
+    }
 
     if (instance.objective() == Objective::BinPacking
             || instance.objective() == Objective::Feasibility

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -10,6 +10,8 @@
 #include "rectangleguillotine/tree_search_hypergraph.hpp"
 #include "rectangle/dual_feasible_functions.hpp"
 #include "packingsolver/rectangle/instance_builder.hpp"
+#include "packingsolver/onedimensional/instance_builder.hpp"
+#include "packingsolver/onedimensional/optimize.hpp"
 #include "algorithms/dichotomic_search.hpp"
 #include "algorithms/sequential_value_correction.hpp"
 #include "algorithms/column_generation.hpp"
@@ -141,6 +143,69 @@ void optimize_trivial_bound(
         algorithm_formatter.update_open_dimension_x_bound(bound);
     } else {
         algorithm_formatter.update_open_dimension_y_bound(bound);
+    }
+}
+
+void optimize_onedimensional_bound(
+        const Instance& instance,
+        const OptimizeParameters& parameters,
+        AlgorithmFormatter& algorithm_formatter)
+{
+    // Relax the instance to 1D, keeping only bin/item areas: any solution of
+    // the original instance is also a solution of this relaxation (with the
+    // same cost), so the bound the onedimensional solver finds for it
+    // (which runs the same dichotomic search) is a valid lower bound here.
+    onedimensional::InstanceBuilder onedim_instance_builder;
+    onedim_instance_builder.set_objective(instance.objective());
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < instance.number_of_bin_types();
+            ++bin_type_id) {
+        const BinType& bin_type = instance.bin_type(bin_type_id);
+        BinTypeId onedim_bin_type_id = onedim_instance_builder.add_bin_type(bin_type.area());
+        onedim_instance_builder.set_bin_type_cost(onedim_bin_type_id, bin_type.cost);
+        onedim_instance_builder.set_bin_type_copies(onedim_bin_type_id, bin_type.copies);
+        onedim_instance_builder.set_bin_type_copies_min(onedim_bin_type_id, bin_type.copies_min);
+    }
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance.number_of_item_types();
+            ++item_type_id) {
+        const ItemType& item_type = instance.item_type(item_type_id);
+        if (item_type.area() <= 0)
+            continue;
+        ItemTypeId onedim_item_type_id = onedim_instance_builder.add_item_type(item_type.area());
+        onedim_instance_builder.set_item_type_profit(onedim_item_type_id, item_type.profit);
+        onedim_instance_builder.set_item_type_copies(onedim_item_type_id, item_type.copies);
+    }
+    onedimensional::Instance onedim_instance = onedim_instance_builder.build();
+
+    onedimensional::OptimizeParameters onedim_parameters;
+    onedim_parameters.verbosity_level = 0;
+    onedim_parameters.timer = parameters.timer;
+    onedim_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
+    onedim_parameters.optimization_mode = OptimizationMode::NotAnytime;
+    onedim_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
+    auto onedim_output = optimize(onedim_instance, onedim_parameters);
+
+    switch (instance.objective()) {
+    case Objective::BinPacking: {
+        algorithm_formatter.update_bin_packing_bound(
+                onedim_output.bin_packing_bound);
+        break;
+    } case Objective::Knapsack: {
+        algorithm_formatter.update_knapsack_bound(
+                onedim_output.knapsack_bound);
+        break;
+    } case Objective::VariableSizedBinPacking: {
+        algorithm_formatter.update_variable_sized_bin_packing_bound(
+                onedim_output.variable_sized_bin_packing_bound);
+        break;
+    } default: {
+        std::stringstream ss;
+        ss << FUNC_SIGNATURE << ": "
+            << "objective \""
+            << instance.objective() << "\" not supported.";
+        throw std::logic_error(ss.str());
+    }
     }
 }
 
@@ -600,6 +665,15 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
     algorithm_formatter.print_header();
 
     optimize_trivial_bound(instance, algorithm_formatter);
+
+    if (instance.objective() == Objective::BinPacking
+            || instance.objective() == Objective::Knapsack
+            || instance.objective() == Objective::VariableSizedBinPacking) {
+        optimize_onedimensional_bound(
+                instance,
+                parameters,
+                algorithm_formatter);
+    }
 
     if (instance.objective() == Objective::BinPacking
             || instance.objective() == Objective::Feasibility) {


### PR DESCRIPTION
Adds a cheap trivial bound for the VariableSizedBinPacking objective: the onedimensional module solves the same bin-selection knapsack as the dichotomic search (at zero waste) by recursing into its own solver, and rectangle/rectangleguillotine/box relax to 1D and delegate to the onedimensional solver for their BinPacking/Knapsack/VariableSizedBinPacking bounds (boxstacks inherits this through box). rectangle now links PackingSolver_onedimensional to support this.

Also reworks the final-statistics bound line into "Primal bound" / "Dual bound" / "Gap", replacing the previous single objective-specific "XXX bound" line, via a shared write_bound() helper and an objective-dependent format_width().