### PR TITLE
rectangle, box: extend dual feasible functions to rotation via min(A,B); reuse in rectangle Benders decomposition

### DIFF
--- a/include/packingsolver/box/optimize.hpp
+++ b/include/packingsolver/box/optimize.hpp
@@ -175,6 +175,13 @@ struct OptimizeParameters: packingsolver::Parameters<Instance, Solution, Output>
     columngenerationsolver::SolverName linear_programming_solver_name
         = columngenerationsolver::SolverName::CLP;
 
+    /**
+     * Force running the dual feasible functions bound/infeasibility check
+     * even if the instance has more items than the default criterion
+     * allows.
+     */
+    bool use_dual_feasible_functions = false;
+
     /** Use tree search algorithm. */
     bool use_tree_search = false;
 

--- a/include/packingsolver/rectangle/optimize.hpp
+++ b/include/packingsolver/rectangle/optimize.hpp
@@ -161,6 +161,13 @@ struct OptimizeParameters: packingsolver::Parameters<Instance, Solution, Output>
     columngenerationsolver::SolverName linear_programming_solver_name
         = columngenerationsolver::SolverName::CLP;
 
+    /**
+     * Force running the dual feasible functions bound/infeasibility check
+     * even if the instance has more items than the default criterion
+     * allows.
+     */
+    bool use_dual_feasible_functions = false;
+
     /** Use tree search algorithm. */
     bool use_tree_search = false;
 

--- a/include/packingsolver/rectangleguillotine/optimize.hpp
+++ b/include/packingsolver/rectangleguillotine/optimize.hpp
@@ -158,6 +158,13 @@ struct OptimizeParameters: packingsolver::Parameters<Instance, Solution, Output>
     columngenerationsolver::SolverName linear_programming_solver_name
         = columngenerationsolver::SolverName::CLP;
 
+    /**
+     * Force running the dual feasible functions bound/infeasibility check
+     * even if the instance has more items than the default criterion
+     * allows.
+     */
+    bool use_dual_feasible_functions = false;
+
     /** Use tree search algorithm. */
     bool use_tree_search = false;
 

--- a/src/box/dual_feasible_functions.cpp
+++ b/src/box/dual_feasible_functions.cpp
@@ -3,8 +3,8 @@
 #include "packingsolver/box/algorithm_formatter.hpp"
 
 #include <array>
-#include <functional>
 #include <limits>
+#include <map>
 
 using namespace packingsolver;
 using namespace packingsolver::box;
@@ -128,107 +128,224 @@ Profit dantzig_profit_bound(
     return bound;
 }
 
-/**
- * Effective (rotated) dimensions of an item.
- *
- * Only valid for oriented items (a single allowed rotation), which is the
- * only case handled by this bound.
- */
-Box item_effective_box(const ItemType& item_type)
+Length axis_component(const Box& box, int axis_id)
 {
-    return item_type.box.rotate(item_type.rotations.front());
+    return (axis_id == 0) ? box.x: (axis_id == 1) ? box.y: box.z;
 }
 
 /**
- * Compute the distinct candidate threshold values for one axis: for each
- * item, if its dimension in this axis equals the bin's, it is ignored;
- * otherwise it (or its 'folded' complement, if it is more than half the
- * bin's dimension) is added as a candidate threshold.
+ * Distinct values 'item_type' could present along 'axis_id', across all of
+ * its allowed rotations.
  */
-std::vector<Length> compute_thresholds(
-        const Instance& instance,
-        Length bin_length,
-        const std::function<Length(const Box&)>& axis)
+std::vector<Length> possible_axis_values(
+        const ItemType& item_type,
+        int axis_id)
 {
     std::vector<Length> values;
-    for (ItemTypeId item_type_id = 0;
-            item_type_id < instance.number_of_item_types();
-            ++item_type_id) {
-        Length item_length = axis(item_effective_box(instance.item_type(item_type_id)));
-        if (item_length == bin_length) {
-        } else if (item_length <= bin_length / 2) {
-            values.push_back(item_length);
-        } else {
-            values.push_back(bin_length - item_length);
-        }
-    }
-    std::sort(values.begin(), values.end());
-    values.erase(std::unique(values.begin(), values.end()), values.end());
+    for (Rotation rotation: item_type.rotations)
+        values.push_back(axis_component(item_type.box.rotate(rotation), axis_id));
+    sort(values.begin(), values.end());
+    values.erase(unique(values.begin(), values.end()), values.end());
     return values;
 }
 
 /**
- * Compute, for each threshold value and each item type id ('number_of_item_types()'
- * meaning 'no excluded item type'), the maximum number of copies of 'small'
- * items (dimension <= bin_length / 2 in this axis, and >= the threshold)
- * that fit in the bin (minus the excluded item's dimension, if any) along
- * this axis.
+ * Greedy maximum cardinality: given a pool of piece lengths sorted
+ * ascending (with multiplicities), greedily fill 'capacity' and return how
+ * many pieces were used. Sorting ascending and greedily filling is optimal
+ * for maximizing the count of pieces packed subject to a sum constraint.
  */
-std::vector<std::vector<ItemPos>> compute_maximum_cardinalities(
+ItemPos greedy_maximum_cardinality(
+        Length capacity,
+        const std::vector<std::pair<Length, ItemPos>>& sorted_pool)
+{
+    Length used = 0;
+    ItemPos count = 0;
+    for (const auto& p: sorted_pool) {
+        Length length = p.first;
+        ItemPos copies = p.second;
+        if (used + copies * length < capacity) {
+            used += copies * length;
+            count += copies;
+        } else {
+            count += (capacity - used) / length;
+            break;
+        }
+    }
+    return count;
+}
+
+/**
+ * Smallest value 'item_type' could present along 'axis_id' that still
+ * qualifies as "medium" ('k' <= value <= 'half_capacity'), across all its
+ * allowed rotations - or -1 if none qualify.
+ *
+ * Used only to upper-bound how many medium items can be packed alongside a
+ * big item (f_ccm_1's "MC(C, S) - MC(C - x, S)" term). Using the smallest
+ * qualifying value (rather than requiring every rotation to qualify) can
+ * only overestimate - never underestimate - the true achievable count,
+ * keeping the result a valid upper bound regardless of which rotation the
+ * item actually ends up using.
+ */
+Length medium_pool_length(
+        const ItemType& item_type,
+        int axis_id,
+        Length k,
+        Length half_capacity)
+{
+    Length best = -1;
+    for (Length v: possible_axis_values(item_type, axis_id)) {
+        if (k <= v && v <= half_capacity && (best < 0 || v < best))
+            best = v;
+    }
+    return best;
+}
+
+/**
+ * Precomputed tables for one axis: candidate breakpoints, and the "maximum
+ * cardinality" bookkeeping f_ccm_1 needs. These only depend on 'instance'
+ * and the bin's length on this axis, not on any item's chosen rotation.
+ */
+struct AxisTables
+{
+    std::vector<Length> thresholds;
+    std::vector<ItemPos> full_cardinality;
+    std::vector<std::map<Length, ItemPos>> excluded_cardinality;
+};
+
+AxisTables compute_axis_tables(
         const Instance& instance,
         Length bin_length,
-        const std::vector<Length>& thresholds,
-        const std::function<Length(const Box&)>& axis)
+        int axis_id)
 {
-    std::vector<std::vector<ItemPos>> maximum_cardinality(thresholds.size());
-    for (ItemTypeId k_pos = 0; k_pos < (ItemTypeId)thresholds.size(); ++k_pos) {
-        Length k = thresholds[k_pos];
-        std::vector<ItemTypeId> sorted_item_type_ids;
-        for (ItemTypeId item_type_id = 0;
-                item_type_id < instance.number_of_item_types();
-                ++item_type_id) {
-            Length item_length = axis(item_effective_box(instance.item_type(item_type_id)));
-            if (k <= item_length && item_length <= bin_length / 2)
-                sorted_item_type_ids.push_back(item_type_id);
-        }
-        std::sort(
-                sorted_item_type_ids.begin(),
-                sorted_item_type_ids.end(),
-                [&instance, &axis](
-                    ItemTypeId item_type_id_1,
-                    ItemTypeId item_type_id_2)
-                {
-                    return axis(item_effective_box(instance.item_type(item_type_id_1)))
-                        < axis(item_effective_box(instance.item_type(item_type_id_2)));
-                });
-        maximum_cardinality[k_pos] = std::vector<ItemPos>(instance.number_of_item_types() + 1, -10000);
-        for (ItemTypeId item_type_id = 0;
-                item_type_id <= instance.number_of_item_types();
-                ++item_type_id) {
-            Length capacity = bin_length;
-            if (item_type_id < instance.number_of_item_types()) {
-                Length item_length = axis(item_effective_box(instance.item_type(item_type_id)));
-                if (item_length <= bin_length / 2)
-                    continue;
-                capacity -= item_length;
-            }
-            Length length_cur = 0;
-            maximum_cardinality[k_pos][item_type_id] = 0;
-            for (ItemTypeId item_type_id_cur: sorted_item_type_ids) {
-                const ItemType& item_type_cur = instance.item_type(item_type_id_cur);
-                Length item_length_cur = axis(item_effective_box(item_type_cur));
-                if (length_cur + item_type_cur.copies * item_length_cur < capacity) {
-                    length_cur += item_type_cur.copies * item_length_cur;
-                    maximum_cardinality[k_pos][item_type_id] += item_type_cur.copies;
-                } else {
-                    ItemPos copies = (capacity - length_cur) / item_length_cur;
-                    maximum_cardinality[k_pos][item_type_id] += copies;
-                    break;
-                }
+    AxisTables tables;
+
+    // Candidate breakpoints: every distinct rotation-achievable value on
+    // this axis (folded), across all item types - both dimensions of a
+    // rotatable item feed the same axis's breakpoint list, since it may
+    // end up presenting any of them there.
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance.number_of_item_types();
+            ++item_type_id) {
+        const ItemType& item_type = instance.item_type(item_type_id);
+        for (Length v: possible_axis_values(item_type, axis_id)) {
+            if (v == bin_length) {
+            } else if (v <= bin_length / 2) {
+                tables.thresholds.push_back(v);
+            } else {
+                tables.thresholds.push_back(bin_length - v);
             }
         }
     }
-    return maximum_cardinality;
+    // capacity / 2 is where f_ccm_0/f_ccm_2 themselves switch branch: it is
+    // a meaningful breakpoint on its own, regardless of whether any item
+    // dimension happens to fold onto it (this matters most for rotation:
+    // e.g. an item that is "big" in every allowed rotation, on every axis,
+    // needs this breakpoint to be recognized as such if no item dimension
+    // is exactly at half the bin's capacity).
+    tables.thresholds.push_back(bin_length / 2);
+    sort(tables.thresholds.begin(), tables.thresholds.end());
+    tables.thresholds.erase(unique(tables.thresholds.begin(), tables.thresholds.end()), tables.thresholds.end());
+
+    // Distinct "big" (> half the bin's length on this axis) values some
+    // item type might present along this axis - these are the only values
+    // f_ccm_1_axis will ever need an excluded-cardinality entry for.
+    std::vector<Length> big_values;
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance.number_of_item_types();
+            ++item_type_id) {
+        const ItemType& item_type = instance.item_type(item_type_id);
+        for (Length v: possible_axis_values(item_type, axis_id))
+            if (v > bin_length / 2)
+                big_values.push_back(v);
+    }
+    sort(big_values.begin(), big_values.end());
+    big_values.erase(unique(big_values.begin(), big_values.end()), big_values.end());
+
+    tables.full_cardinality.resize(tables.thresholds.size());
+    tables.excluded_cardinality.resize(tables.thresholds.size());
+    for (ItemTypeId k_pos = 0; k_pos < (ItemTypeId)tables.thresholds.size(); ++k_pos) {
+        Length k = tables.thresholds[k_pos];
+        std::vector<std::pair<Length, ItemPos>> pool;
+        for (ItemTypeId item_type_id = 0;
+                item_type_id < instance.number_of_item_types();
+                ++item_type_id) {
+            const ItemType& item_type = instance.item_type(item_type_id);
+            Length length = medium_pool_length(item_type, axis_id, k, bin_length / 2);
+            if (length >= 0)
+                pool.push_back({length, item_type.copies});
+        }
+        sort(pool.begin(), pool.end());
+        tables.full_cardinality[k_pos] = greedy_maximum_cardinality(bin_length, pool);
+        for (Length big_value: big_values) {
+            tables.excluded_cardinality[k_pos][big_value] = greedy_maximum_cardinality(
+                    bin_length - big_value,
+                    pool);
+        }
+    }
+
+    return tables;
+}
+
+/**
+ * f_ccm_1 for a specific assumed length on one axis, looking up the
+ * "maximum cardinality" value it needs only when it actually falls in the
+ * "big item" branch (length > capacity / 2); 'excluded_cardinality' must
+ * have an entry for 'length' whenever this branch is taken.
+ */
+Length f_ccm_1_axis(
+        Length capacity,
+        Length k,
+        Length length,
+        ItemPos full_cardinality,
+        const std::map<Length, ItemPos>& excluded_cardinality)
+{
+    if (length > capacity / 2) {
+        ItemPos excluded = excluded_cardinality.at(length);
+        return f_ccm_1(capacity, k, length, full_cardinality - excluded);
+    }
+    return f_ccm_1(capacity, k, length, 0);
+}
+
+/**
+ * Coefficient of 'item_type' for breakpoints 'k' (one per axis) and DFF
+ * families 'families' (one per axis, in {0: f_ccm_0, 1: f_ccm_1, 2:
+ * f_ccm_2}), taking the minimum over all of the item's allowed rotations.
+ *
+ * The item's true contribution depends on a rotation choice this
+ * per-item-type coefficient scheme doesn't track; using the smallest
+ * coefficient among its allowed rotations stays a valid (safe) lower bound
+ * on the true contribution regardless of which rotation actually ends up
+ * being used.
+ */
+Volume item_coefficient(
+        const ItemType& item_type,
+        const std::array<int, 3>& families,
+        const std::array<Length, 3>& k,
+        const std::array<Length, 3>& bin_lengths,
+        const std::array<ItemPos, 3>& full_cardinality,
+        const std::array<const std::map<Length, ItemPos>*, 3>& excluded_cardinality)
+{
+    auto eval_axis = [&](int axis_id, Length length) -> Length
+    {
+        Length capacity = bin_lengths[axis_id];
+        switch (families[axis_id]) {
+        case 0: return f_ccm_0(capacity, k[axis_id], length);
+        case 1: return f_ccm_1_axis(capacity, k[axis_id], length, full_cardinality[axis_id], *excluded_cardinality[axis_id]);
+        default: return f_ccm_2(capacity, k[axis_id], length);
+        }
+    };
+
+    Volume best = -1;
+    for (Rotation rotation: item_type.rotations) {
+        Box effective_box = item_type.box.rotate(rotation);
+        Volume value = 1;
+        for (int axis_id = 0; axis_id < 3; ++axis_id)
+            value *= eval_axis(axis_id, axis_component(effective_box, axis_id));
+        if (best < 0 || value < best)
+            best = value;
+    }
+    return best;
 }
 
 }
@@ -253,48 +370,30 @@ DualFeasibleFunctionsOutput packingsolver::box::dual_feasible_functions(
     algorithm_formatter.start();
     algorithm_formatter.print_header();
 
-    // This bound is only implemented for fully oriented items, i.e. items
-    // with a single allowed rotation; skip it otherwise.
-    for (ItemTypeId item_type_id = 0;
-            item_type_id < instance.number_of_item_types();
-            ++item_type_id) {
-        if (instance.item_type(item_type_id).rotations.size() != 1) {
-            algorithm_formatter.end();
-            return output;
-        }
-    }
-
-    std::array<std::function<Length(const Box&)>, 3> axes = {
-            std::function<Length(const Box&)>([](const Box& box) { return box.x; }),
-            std::function<Length(const Box&)>([](const Box& box) { return box.y; }),
-            std::function<Length(const Box&)>([](const Box& box) { return box.z; })};
     std::array<Length, 3> bin_lengths = {
             bin_type.box.x,
             bin_type.box.y,
             bin_type.box.z};
 
-    std::array<std::vector<Length>, 3> thresholds;
-    std::array<std::vector<std::vector<ItemPos>>, 3> maximum_cardinalities;
-    for (int axis_id = 0; axis_id < 3; ++axis_id) {
-        thresholds[axis_id] = compute_thresholds(instance, bin_lengths[axis_id], axes[axis_id]);
-        maximum_cardinalities[axis_id] = compute_maximum_cardinalities(
-                instance,
-                bin_lengths[axis_id],
-                thresholds[axis_id],
-                axes[axis_id]);
-    }
+    std::array<AxisTables, 3> tables;
+    for (int axis_id = 0; axis_id < 3; ++axis_id)
+        tables[axis_id] = compute_axis_tables(instance, bin_lengths[axis_id], axis_id);
 
     BinPos bound = 0;
     Profit knapsack_bound = std::numeric_limits<Profit>::infinity();
 
-    for (ItemTypeId k_pos = 0; k_pos < (ItemTypeId)thresholds[0].size(); ++k_pos) {
-        for (ItemTypeId l_pos = 0; l_pos < (ItemTypeId)thresholds[1].size(); ++l_pos) {
-            for (ItemTypeId m_pos = 0; m_pos < (ItemTypeId)thresholds[2].size(); ++m_pos) {
+    for (ItemTypeId k_pos = 0; k_pos < (ItemTypeId)tables[0].thresholds.size(); ++k_pos) {
+        for (ItemTypeId l_pos = 0; l_pos < (ItemTypeId)tables[1].thresholds.size(); ++l_pos) {
+            for (ItemTypeId m_pos = 0; m_pos < (ItemTypeId)tables[2].thresholds.size(); ++m_pos) {
                 std::array<ItemTypeId, 3> pos = {k_pos, l_pos, m_pos};
-                std::array<Length, 3> k = {
-                        thresholds[0][k_pos],
-                        thresholds[1][l_pos],
-                        thresholds[2][m_pos]};
+                std::array<Length, 3> k;
+                std::array<ItemPos, 3> full_cardinality;
+                std::array<const std::map<Length, ItemPos>*, 3> excluded_cardinality;
+                for (int axis_id = 0; axis_id < 3; ++axis_id) {
+                    k[axis_id] = tables[axis_id].thresholds[pos[axis_id]];
+                    full_cardinality[axis_id] = tables[axis_id].full_cardinality[pos[axis_id]];
+                    excluded_cardinality[axis_id] = &tables[axis_id].excluded_cardinality[pos[axis_id]];
+                }
 
                 // Value of each of the 'number_of_families' families of
                 // dual feasible functions applied to the bin's dimension,
@@ -302,10 +401,9 @@ DualFeasibleFunctionsOutput packingsolver::box::dual_feasible_functions(
                 std::array<std::array<Length, number_of_families>, 3> f_bin;
                 for (int axis_id = 0; axis_id < 3; ++axis_id) {
                     Length capacity = bin_lengths[axis_id];
-                    ItemPos value = maximum_cardinalities[axis_id][pos[axis_id]][instance.number_of_item_types()];
                     f_bin[axis_id] = {
                             f_ccm_0(capacity, k[axis_id], capacity),
-                            f_ccm_1(capacity, k[axis_id], capacity, value),
+                            f_ccm_1(capacity, k[axis_id], capacity, full_cardinality[axis_id]),
                             f_ccm_2(capacity, k[axis_id], capacity)};
                 }
 
@@ -333,30 +431,18 @@ DualFeasibleFunctionsOutput packingsolver::box::dual_feasible_functions(
                         item_type_id < instance.number_of_item_types();
                         ++item_type_id) {
                     const ItemType& item_type = instance.item_type(item_type_id);
-                    Box effective_box = item_effective_box(item_type);
-                    std::array<Length, 3> item_lengths = {
-                            effective_box.x,
-                            effective_box.y,
-                            effective_box.z};
-
-                    std::array<std::array<Length, number_of_families>, 3> f_item;
-                    for (int axis_id = 0; axis_id < 3; ++axis_id) {
-                        Length capacity = bin_lengths[axis_id];
-                        ItemPos value
-                            = maximum_cardinalities[axis_id][pos[axis_id]][instance.number_of_item_types()]
-                            - maximum_cardinalities[axis_id][pos[axis_id]][item_type_id];
-                        f_item[axis_id] = {
-                                f_ccm_0(capacity, k[axis_id], item_lengths[axis_id]),
-                                f_ccm_1(capacity, k[axis_id], item_lengths[axis_id], value),
-                                f_ccm_2(capacity, k[axis_id], item_lengths[axis_id])};
-                    }
 
                     if (instance.objective() == Objective::Knapsack) {
                         for (int fx = 0; fx < number_of_families; ++fx) {
                             for (int fy = 0; fy < number_of_families; ++fy) {
                                 for (int fz = 0; fz < number_of_families; ++fz) {
-                                    volumes[fx][fy][fz][item_type_id]
-                                        = f_item[0][fx] * f_item[1][fy] * f_item[2][fz];
+                                    volumes[fx][fy][fz][item_type_id] = item_coefficient(
+                                            item_type,
+                                            {fx, fy, fz},
+                                            k,
+                                            bin_lengths,
+                                            full_cardinality,
+                                            excluded_cardinality);
                                 }
                             }
                         }
@@ -364,8 +450,13 @@ DualFeasibleFunctionsOutput packingsolver::box::dual_feasible_functions(
                         for (int fx = 0; fx < number_of_families; ++fx) {
                             for (int fy = 0; fy < number_of_families; ++fy) {
                                 for (int fz = 0; fz < number_of_families; ++fz) {
-                                    sum[fx][fy][fz] += item_type.copies
-                                        * f_item[0][fx] * f_item[1][fy] * f_item[2][fz];
+                                    sum[fx][fy][fz] += item_type.copies * item_coefficient(
+                                            item_type,
+                                            {fx, fy, fz},
+                                            k,
+                                            bin_lengths,
+                                            full_cardinality,
+                                            excluded_cardinality);
                                 }
                             }
                         }

--- a/src/box/dual_feasible_functions.hpp
+++ b/src/box/dual_feasible_functions.hpp
@@ -1,11 +1,14 @@
 /**
  * Dual feasible functions
  *
- * Formulas to get bounds on bin packing problems (with a single bin type and
- * without item rotation).
+ * Formulas to get bounds on bin packing problems (with a single bin type).
  *
  * Generalization to three dimensions of the two-dimensional functions used in
- * 'rectangle/dual_feasible_functions.hpp'.
+ * 'rectangle/dual_feasible_functions.hpp', including that file's handling of
+ * item rotation (there, up to 2 orientations; here, up to
+ * 'NUMBER_OF_ROTATIONS' == 6): each item's coefficient is the minimum over
+ * all of its allowed rotations, a valid lower bound on its true contribution
+ * regardless of which rotation actually ends up being used.
  *
  * References:
  * - "New reduction procedures and lower bounds for the two-dimensional bin

--- a/src/box/main.cpp
+++ b/src/box/main.cpp
@@ -90,6 +90,7 @@ int main(int argc, char *argv[])
 
             ("linear-programming-solver,", po::value<columngenerationsolver::SolverName>(), "set linear programming solver")
             ("optimization-mode,", po::value<OptimizationMode>(), "set optimization mode")
+            ("use-dual-feasible-functions,", po::value<bool>(), "force running the dual feasible functions bound/infeasibility check even if the instance has more items than the default criterion allows")
             ("use-tree-search,", po::value<bool>(), "enable tree search algorithm")
             ("use-tree-search-maximal-spaces,", po::value<bool>(), "enable tree search with maximal spaces")
             ("use-sequential-single-knapsack,", po::value<bool>(), "enable sequential-single-knapsack")
@@ -190,6 +191,8 @@ int main(int argc, char *argv[])
         if (vm.count("memory-limit"))
             parameters.memory_limit_megabytes = vm["memory-limit"].as<Megabytes>();
 
+        if (vm.count("use-dual-feasible-functions"))
+            parameters.use_dual_feasible_functions = vm["use-dual-feasible-functions"].as<bool>();
         if (vm.count("use-tree-search"))
             parameters.use_tree_search = vm["use-tree-search"].as<bool>();
         if (vm.count("use-tree-search-maximal-spaces"))

--- a/src/box/optimize.cpp
+++ b/src/box/optimize.cpp
@@ -541,7 +541,8 @@ packingsolver::box::Output packingsolver::box::optimize(
         // (against quadratic for the 2D 'rectangle' case), so this is
         // gated more conservatively.
         if (instance.number_of_bin_types() == 1
-                && instance.number_of_items() <= 50) {
+                && (parameters.use_dual_feasible_functions
+                    || instance.number_of_items() <= 50)) {
             optimize_dual_feasible_functions(
                     instance,
                     parameters,

--- a/src/rectangle/benders_decomposition.cpp
+++ b/src/rectangle/benders_decomposition.cpp
@@ -3,6 +3,7 @@
 #include "packingsolver/rectangle/algorithm_formatter.hpp"
 #include "packingsolver/rectangle/instance_builder.hpp"
 #include "packingsolver/rectangle/optimize.hpp"
+#include "rectangle/dual_feasible_functions.hpp"
 
 #ifdef CBC_FOUND
 #include "mathoptsolverscmake/mathopt_cbc.hpp"
@@ -33,6 +34,11 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
 
     // MILP cuts.
     std::vector<std::vector<std::pair<ItemTypeId, ItemPos>>> milp_cuts;
+    // Dual-feasible-function cuts: unlike 'milp_cuts', each of these is a
+    // general inequality valid for any selection of items from 'instance',
+    // not just the exact selection that revealed it, so it keeps pruning
+    // the master in every later iteration too.
+    std::vector<DualFeasibleFunctionsCut> dff_cuts;
     // 'true' iff every subproblem solved so far that led to a cut has been
     // proven infeasible (as opposed to merely not having found a full
     // packing). The MILP relaxation bound is only a valid bound on the
@@ -303,6 +309,29 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
             milp_model.constraints_upper_bounds.push_back(cut_size - 1);
         }
 
+        // Constraints: dual-feasible-function cuts.
+        // sum_j coefficients[j] * sum_c x_{j, c} <= bound
+        for (const DualFeasibleFunctionsCut& cut: dff_cuts) {
+            // Initialize new row.
+            milp_model.constraints_starts.push_back(milp_model.elements_variables.size());
+            // Add row elements.
+            for (ItemTypeId item_type_id = 0;
+                    item_type_id < instance.number_of_item_types();
+                    ++item_type_id) {
+                if (cut.coefficients[item_type_id] == 0.0)
+                    continue;
+                for (ItemPos copy = 0;
+                        copy < item_copies[item_type_id];
+                        ++copy) {
+                    milp_model.elements_variables.push_back(x[item_type_id][copy]);
+                    milp_model.elements_coefficients.push_back(cut.coefficients[item_type_id]);
+                }
+            }
+            // Add row bounds.
+            milp_model.constraints_lower_bounds.push_back(-std::numeric_limits<double>::infinity());
+            milp_model.constraints_upper_bounds.push_back(cut.bound);
+        }
+
         std::vector<double> milp_solution;
         double milp_bound = std::numeric_limits<double>::infinity();
         if (parameters.solver == mathoptsolverscmake::SolverName::Highs) {
@@ -357,6 +386,20 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
                     break;
                 }
             }
+        }
+
+        // Check for a violated dual-feasible-function inequality before
+        // paying for the (potentially expensive) subproblem solve: if one
+        // is found, it proves on its own that 'selected_items' cannot fit
+        // in one bin, without needing the subproblem at all. Unlike a
+        // no-good cut on this exact selection, it is a general inequality
+        // valid for any selection of items from 'instance', so it is added
+        // as a permanent row rather than a one-off cut.
+        DualFeasibleFunctionsCut dff_cut = find_most_violated_dual_feasible_function_cut(
+                instance, selected_items);
+        if (dff_cut.found) {
+            dff_cuts.push_back(dff_cut);
+            continue;
         }
 
         // Build subproblem instance.

--- a/src/rectangle/dual_feasible_functions.cpp
+++ b/src/rectangle/dual_feasible_functions.cpp
@@ -4,6 +4,7 @@
 #include "packingsolver/rectangle/instance_builder.hpp"
 
 #include <array>
+#include <map>
 
 using namespace packingsolver;
 using namespace packingsolver::rectangle;
@@ -60,6 +61,288 @@ Length f_ccm_2(
     } else {
         return 2 * (length / k);
     }
+}
+
+/**
+ * Greedy maximum cardinality: given a pool of piece lengths sorted
+ * ascending (with multiplicities), greedily fill 'capacity' and return how
+ * many pieces were used. Sorting ascending and greedily filling is optimal
+ * for maximizing the count of pieces packed subject to a sum constraint.
+ */
+ItemPos greedy_maximum_cardinality(
+        Length capacity,
+        const std::vector<std::pair<Length, ItemPos>>& sorted_pool)
+{
+    Length used = 0;
+    ItemPos count = 0;
+    for (const auto& p: sorted_pool) {
+        Length length = p.first;
+        ItemPos copies = p.second;
+        if (used + copies * length < capacity) {
+            used += copies * length;
+            count += copies;
+        } else {
+            count += (capacity - used) / length;
+            break;
+        }
+    }
+    return count;
+}
+
+/**
+ * Length 'item_type' effectively contributes to the "medium items" pool on
+ * one axis (breakpoint 'k', 'half_capacity' being half the bin's capacity
+ * on that axis) - used only to upper-bound how many medium items can be
+ * packed alongside a big item (f_ccm_1's "MC(C, S) - MC(C - x, S)" term).
+ *
+ * 'own_dimension' is the item's dimension along this axis if it were
+ * oriented that way (rect.x for width, rect.y for height); 'other_dimension'
+ * is its other dimension, only relevant if the item is not oriented.
+ *
+ * For an unoriented item, either dimension could end up on this axis;
+ * using whichever qualifying dimension is smallest can only overestimate -
+ * never underestimate - the true achievable count, keeping the result a
+ * valid upper bound regardless of which orientation actually ends up being
+ * used. Returns -1 if the item cannot be "medium" on this axis in any
+ * orientation.
+ */
+Length medium_pool_length(
+        const ItemType& item_type,
+        Length own_dimension,
+        Length other_dimension,
+        Length k,
+        Length half_capacity)
+{
+    if (item_type.oriented) {
+        if (k <= own_dimension && own_dimension <= half_capacity)
+            return own_dimension;
+        return -1;
+    }
+    Length lo = (std::min)(own_dimension, other_dimension);
+    Length hi = (std::max)(own_dimension, other_dimension);
+    if (k <= lo && lo <= half_capacity)
+        return lo;
+    if (k <= hi && hi <= half_capacity)
+        return hi;
+    return -1;
+}
+
+/**
+ * f_ccm_1 for a specific assumed length on one axis, looking up the
+ * "maximum cardinality" value it needs only when it actually falls in the
+ * "big item" branch (length > capacity / 2); 'excluded_cardinality' must
+ * have an entry for 'length' whenever this branch is taken.
+ */
+Length f_ccm_1_axis(
+        Length capacity,
+        Length k,
+        Length length,
+        ItemPos full_cardinality,
+        const std::map<Length, ItemPos>& excluded_cardinality)
+{
+    if (length > capacity / 2) {
+        ItemPos excluded = excluded_cardinality.at(length);
+        return f_ccm_1(capacity, k, length, full_cardinality - excluded);
+    }
+    return f_ccm_1(capacity, k, length, 0);
+}
+
+/**
+ * Coefficient of 'item_type' for breakpoints (k, l) and DFF families
+ * (family_w, family_h in {0: f_ccm_0, 1: f_ccm_1, 2: f_ccm_2}).
+ *
+ * If the item is not oriented, its true contribution depends on an
+ * orientation choice this per-item-type coefficient scheme doesn't track;
+ * using the smaller of its two orientations' coefficients stays a valid
+ * (safe) lower bound on the true contribution regardless of which
+ * orientation actually ends up being used.
+ */
+Length item_coefficient(
+        const ItemType& item_type,
+        int family_w,
+        int family_h,
+        Length k,
+        Length l,
+        Length bin_w,
+        Length bin_h,
+        ItemPos full_cardinality_w,
+        const std::map<Length, ItemPos>& excluded_cardinality_w,
+        ItemPos full_cardinality_h,
+        const std::map<Length, ItemPos>& excluded_cardinality_h)
+{
+    auto eval_w = [&](Length length) -> Length
+    {
+        switch (family_w) {
+        case 0: return f_ccm_0(bin_w, k, length);
+        case 1: return f_ccm_1_axis(bin_w, k, length, full_cardinality_w, excluded_cardinality_w);
+        default: return f_ccm_2(bin_w, k, length);
+        }
+    };
+    auto eval_h = [&](Length length) -> Length
+    {
+        switch (family_h) {
+        case 0: return f_ccm_0(bin_h, l, length);
+        case 1: return f_ccm_1_axis(bin_h, l, length, full_cardinality_h, excluded_cardinality_h);
+        default: return f_ccm_2(bin_h, l, length);
+        }
+    };
+
+    Length a = eval_w(item_type.rect.x) * eval_h(item_type.rect.y);
+    if (item_type.oriented)
+        return a;
+    Length b = eval_w(item_type.rect.y) * eval_h(item_type.rect.x);
+    return (std::min)(a, b);
+}
+
+/**
+ * Precomputed tables shared by every (k, l, family_w, family_h) combo of
+ * the breakpoint sweep: candidate breakpoints on each axis, and the
+ * "maximum cardinality" bookkeeping f_ccm_1 needs. These only depend on
+ * 'instance' and 'bin_type', not on any particular candidate selection, so
+ * they are computed once and reused - both across every combo of a single
+ * sweep, and across every call site that runs a sweep over the same
+ * instance (the bin-count/profit bound below, and the Benders
+ * decomposition pre-subproblem cut checker).
+ */
+struct DualFeasibleFunctionsTables
+{
+    std::vector<Length> widths;
+    std::vector<Length> heights;
+    std::vector<ItemPos> full_cardinality_w;
+    std::vector<std::map<Length, ItemPos>> excluded_cardinality_w;
+    std::vector<ItemPos> full_cardinality_h;
+    std::vector<std::map<Length, ItemPos>> excluded_cardinality_h;
+};
+
+DualFeasibleFunctionsTables compute_dual_feasible_functions_tables(
+        const Instance& instance,
+        const BinType& bin_type)
+{
+    DualFeasibleFunctionsTables tables;
+
+    // Compute all distinct widths and heights. Both dimensions of every
+    // non-oriented item type feed both axes: it may end up presenting
+    // either side along the bin's width or its height, so a breakpoint
+    // that only matters for one orientation should not be missed.
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance.number_of_item_types();
+            ++item_type_id) {
+        const ItemType& item_type = instance.item_type(item_type_id);
+        std::vector<Length> width_candidates = item_type.oriented ?
+            std::vector<Length>{item_type.rect.x}:
+            std::vector<Length>{item_type.rect.x, item_type.rect.y};
+        for (Length d: width_candidates) {
+            if (d == bin_type.rect.x) {
+            } else if (d <= bin_type.rect.x / 2) {
+                tables.widths.push_back(d);
+            } else {
+                tables.widths.push_back(bin_type.rect.x - d);
+            }
+        }
+        std::vector<Length> height_candidates = item_type.oriented ?
+            std::vector<Length>{item_type.rect.y}:
+            std::vector<Length>{item_type.rect.x, item_type.rect.y};
+        for (Length d: height_candidates) {
+            if (d == bin_type.rect.y) {
+            } else if (d <= bin_type.rect.y / 2) {
+                tables.heights.push_back(d);
+            } else {
+                tables.heights.push_back(bin_type.rect.y - d);
+            }
+        }
+    }
+    // capacity / 2 is where f_ccm_0/f_ccm_2 themselves switch branch: it is
+    // a meaningful breakpoint on its own, regardless of whether any item
+    // dimension happens to fold onto it (this matters most for rotation:
+    // e.g. an item that is "big" in both orientations, on both axes, needs
+    // this breakpoint to be recognized as such if no item dimension is
+    // exactly at half the bin's capacity).
+    tables.widths.push_back(bin_type.rect.x / 2);
+    tables.heights.push_back(bin_type.rect.y / 2);
+    sort(tables.widths.begin(), tables.widths.end());
+    sort(tables.heights.begin(), tables.heights.end());
+    tables.widths.erase(unique(tables.widths.begin(), tables.widths.end()), tables.widths.end());
+    tables.heights.erase(unique(tables.heights.begin(), tables.heights.end()), tables.heights.end());
+
+    // Distinct "big" (> half the bin's capacity on that axis) dimension
+    // values that some item type might present along each axis - these are
+    // the only values f_ccm_1_axis will ever need an excluded-cardinality
+    // entry for.
+    std::vector<Length> big_values_w;
+    std::vector<Length> big_values_h;
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance.number_of_item_types();
+            ++item_type_id) {
+        const ItemType& item_type = instance.item_type(item_type_id);
+        if (item_type.rect.x > bin_type.rect.x / 2)
+            big_values_w.push_back(item_type.rect.x);
+        if (!item_type.oriented && item_type.rect.y > bin_type.rect.x / 2)
+            big_values_w.push_back(item_type.rect.y);
+        if (item_type.rect.y > bin_type.rect.y / 2)
+            big_values_h.push_back(item_type.rect.y);
+        if (!item_type.oriented && item_type.rect.x > bin_type.rect.y / 2)
+            big_values_h.push_back(item_type.rect.x);
+    }
+    sort(big_values_w.begin(), big_values_w.end());
+    big_values_w.erase(unique(big_values_w.begin(), big_values_w.end()), big_values_w.end());
+    sort(big_values_h.begin(), big_values_h.end());
+    big_values_h.erase(unique(big_values_h.begin(), big_values_h.end()), big_values_h.end());
+
+    // Compute maximum cardinalities.
+    tables.full_cardinality_w.resize(tables.widths.size());
+    tables.excluded_cardinality_w.resize(tables.widths.size());
+    for (ItemTypeId k_pos = 0; k_pos < (ItemTypeId)tables.widths.size(); ++k_pos) {
+        Length k = tables.widths[k_pos];
+        std::vector<std::pair<Length, ItemPos>> pool;
+        for (ItemTypeId item_type_id = 0;
+                item_type_id < instance.number_of_item_types();
+                ++item_type_id) {
+            const ItemType& item_type = instance.item_type(item_type_id);
+            Length length = medium_pool_length(
+                    item_type,
+                    item_type.rect.x,
+                    item_type.rect.y,
+                    k,
+                    bin_type.rect.x / 2);
+            if (length >= 0)
+                pool.push_back({length, item_type.copies});
+        }
+        sort(pool.begin(), pool.end());
+        tables.full_cardinality_w[k_pos] = greedy_maximum_cardinality(bin_type.rect.x, pool);
+        for (Length big_value: big_values_w) {
+            tables.excluded_cardinality_w[k_pos][big_value] = greedy_maximum_cardinality(
+                    bin_type.rect.x - big_value,
+                    pool);
+        }
+    }
+    tables.full_cardinality_h.resize(tables.heights.size());
+    tables.excluded_cardinality_h.resize(tables.heights.size());
+    for (ItemTypeId l_pos = 0; l_pos < (ItemTypeId)tables.heights.size(); ++l_pos) {
+        Length l = tables.heights[l_pos];
+        std::vector<std::pair<Length, ItemPos>> pool;
+        for (ItemTypeId item_type_id = 0;
+                item_type_id < instance.number_of_item_types();
+                ++item_type_id) {
+            const ItemType& item_type = instance.item_type(item_type_id);
+            Length length = medium_pool_length(
+                    item_type,
+                    item_type.rect.y,
+                    item_type.rect.x,
+                    l,
+                    bin_type.rect.y / 2);
+            if (length >= 0)
+                pool.push_back({length, item_type.copies});
+        }
+        sort(pool.begin(), pool.end());
+        tables.full_cardinality_h[l_pos] = greedy_maximum_cardinality(bin_type.rect.y, pool);
+        for (Length big_value: big_values_h) {
+            tables.excluded_cardinality_h[l_pos][big_value] = greedy_maximum_cardinality(
+                    bin_type.rect.y - big_value,
+                    pool);
+        }
+    }
+
+    return tables;
 }
 
 /**
@@ -146,7 +429,6 @@ DualFeasibleFunctionsOutput packingsolver::rectangle::dual_feasible_functions(
     algorithm_formatter.start();
     algorithm_formatter.print_header();
 
-    // These bounds are only valid if all items are oriented.
     bool all_items_oriented = true;
     for (ItemTypeId item_type_id = 0;
             item_type_id < instance.number_of_item_types();
@@ -157,24 +439,23 @@ DualFeasibleFunctionsOutput packingsolver::rectangle::dual_feasible_functions(
             break;
         }
     }
-    if (!all_items_oriented) {
-        // The recursive doubling strategy below only produces a bin count
-        // bound, which does not translate into a knapsack profit bound
-        // (profit does not simply halve when an item is duplicated once
-        // per orientation), so skip it entirely for the Knapsack objective.
-        if (instance.objective() == Objective::Knapsack) {
-            algorithm_formatter.end();
-            return output;
-        }
 
-        // If there are some non-oriented items, we use the strategy from
-        // clautiaux2007:
-        // - Build a modified instance containing for each item of the original
-        //   instance, one item for each orientation.
-        // - Compute the bound on the modified instance.
-        // - Divide it by 2 to get the bound of the original instance.
-
-        BinPos bound = 0;
+    // If there are some non-oriented items, also run the strategy from
+    // clautiaux2007 (build a modified instance containing, for each item,
+    // one copy per orientation; compute the bound on that fully-oriented,
+    // squared-up modified instance; divide it by 2), on top of the sweep
+    // below (which now handles rotation itself via item_coefficient's
+    // min-of-two-orientations). Neither technique dominates the other in
+    // general - e.g. this one pays no "squaring tax" on non-square bins,
+    // but doesn't get f_ccm_1's cross-item bookkeeping for ambiguous items
+    // - so take the max of both.
+    //
+    // This doesn't apply to the Knapsack objective: the recursive doubling
+    // strategy below only produces a bin count bound, which does not
+    // translate into a knapsack profit bound (profit does not simply halve
+    // when an item is duplicated once per orientation).
+    BinPos clautiaux_bound = 0;
+    if (!all_items_oriented && instance.objective() != Objective::Knapsack) {
         for (;;) {
             // Build modified instance.
             // Always use 'BinPacking' here, regardless of the original
@@ -198,14 +479,14 @@ DualFeasibleFunctionsOutput packingsolver::rectangle::dual_feasible_functions(
                         bin_type.rect.x);
                 modified_instance_builder.set_bin_type_copies(
                         modified_bin_type_id,
-                        2 * instance.number_of_items() + bound);
-                if (bound > 0) {
+                        2 * instance.number_of_items() + clautiaux_bound);
+                if (clautiaux_bound > 0) {
                     ItemTypeId modified_item_type_id = modified_instance_builder.add_item_type(
                             bin_type.rect.x,
                             bin_type.rect.x - bin_type.rect.y);
                     modified_instance_builder.set_item_type_copies(
                             modified_item_type_id,
-                            bound);
+                            clautiaux_bound);
                 }
             } else if (bin_type.rect.x < bin_type.rect.y) {
                 BinTypeId modified_bin_type_id = modified_instance_builder.add_bin_type(
@@ -213,14 +494,14 @@ DualFeasibleFunctionsOutput packingsolver::rectangle::dual_feasible_functions(
                         bin_type.rect.y);
                 modified_instance_builder.set_bin_type_copies(
                         modified_bin_type_id,
-                        2 * instance.number_of_items() + bound);
-                if (bound > 0) {
+                        2 * instance.number_of_items() + clautiaux_bound);
+                if (clautiaux_bound > 0) {
                     ItemTypeId modified_item_type_id = modified_instance_builder.add_item_type(
                             bin_type.rect.y - bin_type.rect.x,
                             bin_type.rect.y);
                     modified_instance_builder.set_item_type_copies(
                             modified_item_type_id,
-                            bound);
+                            clautiaux_bound);
                 }
             }
             // Add items.
@@ -273,145 +554,22 @@ DualFeasibleFunctionsOutput packingsolver::rectangle::dual_feasible_functions(
 
             // Retrieve the bound of the original instance.
             BinPos bound_cur = (modified_output.bin_packing_bound - 1) / 2 + 1;
-            if (bound >= bound_cur)
+            if (clautiaux_bound >= bound_cur)
                 break;
-            bound = bound_cur;
-            if (instance.objective() == Objective::BinPacking) {
-                algorithm_formatter.update_bin_packing_bound(bound);
-            } else if (instance.objective() == Objective::Feasibility) {
-                if (bound > instance.number_of_bins())
-                    algorithm_formatter.update_is_proven_infeasible();
-            }
+            clautiaux_bound = bound_cur;
 
             if (bin_type.rect.x == bin_type.rect.y)
                 break;
         }
-        algorithm_formatter.end();
-        return output;
     }
 
-    // Compute all distinct widths and heights.
-    std::vector<Length> widths;
-    std::vector<Length> heights;
-    for (ItemTypeId item_type_id = 0;
-            item_type_id < instance.number_of_item_types();
-            ++item_type_id) {
-        const ItemType& item_type = instance.item_type(item_type_id);
-        if (item_type.rect.x == bin_type.rect.x) {
-        } else if (item_type.rect.x <= bin_type.rect.x / 2) {
-            widths.push_back(item_type.rect.x);
-        } else {
-            widths.push_back(bin_type.rect.x - item_type.rect.x);
-        }
-        if (item_type.rect.y == bin_type.rect.y) {
-        } else if (item_type.rect.y <= bin_type.rect.y / 2) {
-            heights.push_back(item_type.rect.y);
-        } else {
-            heights.push_back(bin_type.rect.y - item_type.rect.y);
-        }
-    }
-    sort(widths.begin(), widths.end());
-    sort(heights.begin(), heights.end());
-    widths.erase(unique(widths.begin(), widths.end()), widths.end());
-    heights.erase(unique(heights.begin(), heights.end()), heights.end());
-
-    // Compute maximum cardinalities.
-    std::vector<std::vector<ItemPos>> maximum_cardinality_w(widths.size());
-    for (ItemTypeId k_pos = 0; k_pos < (ItemTypeId)widths.size(); ++k_pos) {
-        Length k = widths[k_pos];
-        std::vector<ItemTypeId> sorted_item_type_ids_w;
-        for (ItemTypeId item_type_id = 0;
-                item_type_id < instance.number_of_item_types();
-                ++item_type_id) {
-            const ItemType& item_type = instance.item_type(item_type_id);
-            if (k <= item_type.rect.x && item_type.rect.x <= bin_type.rect.x / 2)
-                sorted_item_type_ids_w.push_back(item_type_id);
-        }
-        std::sort(
-                sorted_item_type_ids_w.begin(),
-                sorted_item_type_ids_w.end(),
-                [&instance](
-                    ItemTypeId item_type_id_1,
-                    ItemTypeId item_type_id_2)
-                {
-                const ItemType& item_type_1 = instance.item_type(item_type_id_1);
-                const ItemType& item_type_2 = instance.item_type(item_type_id_2);
-                return item_type_1.rect.x < item_type_2.rect.x;
-                });
-        maximum_cardinality_w[k_pos] = std::vector<ItemPos>(instance.number_of_item_types() + 1, -10000);
-        for (ItemTypeId item_type_id = 0;
-                item_type_id <= instance.number_of_item_types();
-                ++item_type_id) {
-            Length capacity_w = bin_type.rect.x;
-            if (item_type_id < instance.number_of_item_types()) {
-                const ItemType& item_type = instance.item_type(item_type_id);
-                if (item_type.rect.x <= bin_type.rect.x / 2)
-                    continue;
-                capacity_w -= item_type.rect.x;
-            }
-            Length width_cur = 0;
-            maximum_cardinality_w[k_pos][item_type_id] = 0;
-            for (ItemTypeId item_type_id_cur: sorted_item_type_ids_w) {
-                const ItemType& item_type_cur = instance.item_type(item_type_id_cur);
-                if (width_cur + item_type_cur.copies * item_type_cur.rect.x < capacity_w) {
-                    width_cur += item_type_cur.copies * item_type_cur.rect.x;
-                    maximum_cardinality_w[k_pos][item_type_id] += item_type_cur.copies;
-                } else {
-                    ItemPos copies = (capacity_w - width_cur) / item_type_cur.rect.x;
-                    maximum_cardinality_w[k_pos][item_type_id] += copies;
-                    break;
-                }
-            }
-        }
-    }
-    std::vector<std::vector<ItemPos>> maximum_cardinality_h(heights.size());
-    for (ItemTypeId l_pos = 0; l_pos < (ItemTypeId)heights.size(); ++l_pos) {
-        Length l = heights[l_pos];
-        std::vector<ItemTypeId> sorted_item_type_ids_h;
-        for (ItemTypeId item_type_id = 0;
-                item_type_id < instance.number_of_item_types();
-                ++item_type_id) {
-            const ItemType& item_type = instance.item_type(item_type_id);
-            if (l <= item_type.rect.y && item_type.rect.y <= bin_type.rect.y / 2)
-                sorted_item_type_ids_h.push_back(item_type_id);
-        }
-        std::sort(
-                sorted_item_type_ids_h.begin(),
-                sorted_item_type_ids_h.end(),
-                [&instance](
-                    ItemTypeId item_type_id_1,
-                    ItemTypeId item_type_id_2)
-                {
-                const ItemType& item_type_1 = instance.item_type(item_type_id_1);
-                const ItemType& item_type_2 = instance.item_type(item_type_id_2);
-                return item_type_1.rect.y < item_type_2.rect.y;
-                });
-        maximum_cardinality_h[l_pos] = std::vector<ItemPos>(instance.number_of_item_types() + 1, -10000);
-        for (ItemTypeId item_type_id = 0;
-                item_type_id <= instance.number_of_item_types();
-                ++item_type_id) {
-            Length capacity_h = bin_type.rect.y;
-            if (item_type_id < instance.number_of_item_types()) {
-                const ItemType& item_type = instance.item_type(item_type_id);
-                if (item_type.rect.y <= bin_type.rect.y / 2)
-                    continue;
-                capacity_h -= item_type.rect.y;
-            }
-            Length height_cur = 0;
-            maximum_cardinality_h[l_pos][item_type_id] = 0;
-            for (ItemTypeId item_type_id_cur: sorted_item_type_ids_h) {
-                const ItemType& item_type_cur = instance.item_type(item_type_id_cur);
-                if (height_cur + item_type_cur.copies * item_type_cur.rect.y < capacity_h) {
-                    height_cur += item_type_cur.copies * item_type_cur.rect.y;
-                    maximum_cardinality_h[l_pos][item_type_id] += item_type_cur.copies;
-                } else {
-                    ItemPos copies = (capacity_h - height_cur) / item_type_cur.rect.y;
-                    maximum_cardinality_h[l_pos][item_type_id] += copies;
-                    break;
-                }
-            }
-        }
-    }
+    DualFeasibleFunctionsTables tables = compute_dual_feasible_functions_tables(instance, bin_type);
+    const std::vector<Length>& widths = tables.widths;
+    const std::vector<Length>& heights = tables.heights;
+    const std::vector<ItemPos>& full_cardinality_w = tables.full_cardinality_w;
+    const std::vector<std::map<Length, ItemPos>>& excluded_cardinality_w = tables.excluded_cardinality_w;
+    const std::vector<ItemPos>& full_cardinality_h = tables.full_cardinality_h;
+    const std::vector<std::map<Length, ItemPos>>& excluded_cardinality_h = tables.excluded_cardinality_h;
 
     BinPos bound = 0;
     Profit knapsack_bound = std::numeric_limits<Profit>::infinity();
@@ -422,69 +580,51 @@ DualFeasibleFunctionsOutput packingsolver::rectangle::dual_feasible_functions(
         for (ItemTypeId l_pos = 0; l_pos < (ItemTypeId)heights.size(); ++l_pos) {
             Length l = heights[l_pos];
 
-            Length f_ccm_0_w_bin = f_ccm_0(bin_type.rect.x, k, bin_type.rect.x);
-            Length f_ccm_0_h_bin = f_ccm_0(bin_type.rect.y, l, bin_type.rect.y);
-            Length f_ccm_1_w_bin = f_ccm_1(bin_type.rect.x, k, bin_type.rect.x, maximum_cardinality_w[k_pos][instance.number_of_item_types()]);
-            Length f_ccm_1_h_bin = f_ccm_1(bin_type.rect.y, l, bin_type.rect.y, maximum_cardinality_h[l_pos][instance.number_of_item_types()]);
-            Length f_ccm_2_w_bin = f_ccm_2(bin_type.rect.x, k, bin_type.rect.x);
-            Length f_ccm_2_h_bin = f_ccm_2(bin_type.rect.y, l, bin_type.rect.y);
+            std::array<Length, 3> f_w_bin = {
+                f_ccm_0(bin_type.rect.x, k, bin_type.rect.x),
+                f_ccm_1(bin_type.rect.x, k, bin_type.rect.x, full_cardinality_w[k_pos]),
+                f_ccm_2(bin_type.rect.x, k, bin_type.rect.x)};
+            std::array<Length, 3> f_h_bin = {
+                f_ccm_0(bin_type.rect.y, l, bin_type.rect.y),
+                f_ccm_1(bin_type.rect.y, l, bin_type.rect.y, full_cardinality_h[l_pos]),
+                f_ccm_2(bin_type.rect.y, l, bin_type.rect.y)};
 
-            Length f_ccm_0_w_0_h_sum = 0;
-            Length f_ccm_0_w_1_h_sum = 0;
-            Length f_ccm_0_w_2_h_sum = 0;
-            Length f_ccm_1_w_0_h_sum = 0;
-            Length f_ccm_1_w_1_h_sum = 0;
-            Length f_ccm_1_w_2_h_sum = 0;
-            Length f_ccm_2_w_0_h_sum = 0;
-            Length f_ccm_2_w_1_h_sum = 0;
-            Length f_ccm_2_w_2_h_sum = 0;
-            // For the Knapsack objective, the per-item scaled volumes are
-            // needed individually (to run a Dantzig bound over the
-            // selection), rather than summed over all items.
+            std::array<std::array<Length, 3>, 3> sums{};
             std::array<std::array<std::vector<Length>, 3>, 3> volumes;
             if (instance.objective() == Objective::Knapsack) {
                 for (auto& row: volumes)
                     for (auto& v: row)
                         v.resize(instance.number_of_item_types());
             }
+
             for (ItemTypeId item_type_id = 0;
                     item_type_id < instance.number_of_item_types();
                     ++item_type_id) {
                 const ItemType& item_type = instance.item_type(item_type_id);
-
-                Length f_ccm_0_w = f_ccm_0(bin_type.rect.x, k, item_type.rect.x);
-                Length f_ccm_0_h = f_ccm_0(bin_type.rect.y, l, item_type.rect.y);
-                Length f_ccm_1_w = f_ccm_1(bin_type.rect.x, k, item_type.rect.x, maximum_cardinality_w[k_pos][instance.number_of_item_types()] - maximum_cardinality_w[k_pos][item_type_id]);
-                Length f_ccm_1_h = f_ccm_1(bin_type.rect.y, l, item_type.rect.y, maximum_cardinality_h[l_pos][instance.number_of_item_types()] - maximum_cardinality_h[l_pos][item_type_id]);
-                Length f_ccm_2_w = f_ccm_2(bin_type.rect.x, k, item_type.rect.x);
-                Length f_ccm_2_h = f_ccm_2(bin_type.rect.y, l, item_type.rect.y);
-
-                if (instance.objective() == Objective::Knapsack) {
-                    volumes[0][0][item_type_id] = f_ccm_0_w * f_ccm_0_h;
-                    volumes[0][1][item_type_id] = f_ccm_0_w * f_ccm_1_h;
-                    volumes[0][2][item_type_id] = f_ccm_0_w * f_ccm_2_h;
-                    volumes[1][0][item_type_id] = f_ccm_1_w * f_ccm_0_h;
-                    volumes[1][1][item_type_id] = f_ccm_1_w * f_ccm_1_h;
-                    volumes[1][2][item_type_id] = f_ccm_1_w * f_ccm_2_h;
-                    volumes[2][0][item_type_id] = f_ccm_2_w * f_ccm_0_h;
-                    volumes[2][1][item_type_id] = f_ccm_2_w * f_ccm_1_h;
-                    volumes[2][2][item_type_id] = f_ccm_2_w * f_ccm_2_h;
-                } else {
-                    f_ccm_0_w_0_h_sum += item_type.copies * f_ccm_0_w * f_ccm_0_h;
-                    f_ccm_0_w_1_h_sum += item_type.copies * f_ccm_0_w * f_ccm_1_h;
-                    f_ccm_0_w_2_h_sum += item_type.copies * f_ccm_0_w * f_ccm_2_h;
-                    f_ccm_1_w_0_h_sum += item_type.copies * f_ccm_1_w * f_ccm_0_h;
-                    f_ccm_1_w_1_h_sum += item_type.copies * f_ccm_1_w * f_ccm_1_h;
-                    f_ccm_1_w_2_h_sum += item_type.copies * f_ccm_1_w * f_ccm_2_h;
-                    f_ccm_2_w_0_h_sum += item_type.copies * f_ccm_2_w * f_ccm_0_h;
-                    f_ccm_2_w_1_h_sum += item_type.copies * f_ccm_2_w * f_ccm_1_h;
-                    f_ccm_2_w_2_h_sum += item_type.copies * f_ccm_2_w * f_ccm_2_h;
+                for (int family_w = 0; family_w < 3; ++family_w) {
+                    for (int family_h = 0; family_h < 3; ++family_h) {
+                        Length c = item_coefficient(
+                                item_type,
+                                family_w,
+                                family_h,
+                                k,
+                                l,
+                                bin_type.rect.x,
+                                bin_type.rect.y,
+                                full_cardinality_w[k_pos],
+                                excluded_cardinality_w[k_pos],
+                                full_cardinality_h[l_pos],
+                                excluded_cardinality_h[l_pos]);
+                        if (instance.objective() == Objective::Knapsack) {
+                            volumes[family_w][family_h][item_type_id] = c;
+                        } else {
+                            sums[family_w][family_h] += item_type.copies * c;
+                        }
+                    }
                 }
             }
 
             if (instance.objective() == Objective::Knapsack) {
-                std::array<Length, 3> f_w_bin = {f_ccm_0_w_bin, f_ccm_1_w_bin, f_ccm_2_w_bin};
-                std::array<Length, 3> f_h_bin = {f_ccm_0_h_bin, f_ccm_1_h_bin, f_ccm_2_h_bin};
                 for (int family_w = 0; family_w < 3; ++family_w) {
                     for (int family_h = 0; family_h < 3; ++family_h) {
                         Length capacity_single = f_w_bin[family_w] * f_h_bin[family_h];
@@ -499,46 +639,23 @@ DualFeasibleFunctionsOutput packingsolver::rectangle::dual_feasible_functions(
                     }
                 }
             } else {
-                BinPos bound_0_w_0_h = std::ceil((double)f_ccm_0_w_0_h_sum / (f_ccm_0_w_bin * f_ccm_0_h_bin));
-                BinPos bound_0_w_1_h = std::ceil((double)f_ccm_0_w_1_h_sum / (f_ccm_0_w_bin * f_ccm_1_h_bin));
-                BinPos bound_0_w_2_h = std::ceil((double)f_ccm_0_w_2_h_sum / (f_ccm_0_w_bin * f_ccm_2_h_bin));
-                BinPos bound_1_w_0_h = std::ceil((double)f_ccm_1_w_0_h_sum / (f_ccm_1_w_bin * f_ccm_0_h_bin));
-                BinPos bound_1_w_1_h = std::ceil((double)f_ccm_1_w_1_h_sum / (f_ccm_1_w_bin * f_ccm_1_h_bin));
-                BinPos bound_1_w_2_h = std::ceil((double)f_ccm_1_w_2_h_sum / (f_ccm_1_w_bin * f_ccm_2_h_bin));
-                BinPos bound_2_w_0_h = std::ceil((double)f_ccm_2_w_0_h_sum / (f_ccm_2_w_bin * f_ccm_0_h_bin));
-                BinPos bound_2_w_1_h = std::ceil((double)f_ccm_2_w_1_h_sum / (f_ccm_2_w_bin * f_ccm_1_h_bin));
-                BinPos bound_2_w_2_h = std::ceil((double)f_ccm_2_w_2_h_sum / (f_ccm_2_w_bin * f_ccm_2_h_bin));
-
-                //std::cout << "k " << k << " l " << l << " bound_0_w_0_h " << bound_0_w_0_h << std::endl;
-                //std::cout << "k " << k << " l " << l << " bound_0_w_1_h " << bound_0_w_1_h << std::endl;
-                //std::cout << "k " << k << " l " << l << " bound_0_w_2_h " << bound_0_w_2_h << std::endl;
-                //std::cout << "k " << k << " l " << l << " bound_1_w_0_h " << bound_1_w_0_h << std::endl;
-                //std::cout << "k " << k << " l " << l << " bound_1_w_1_h " << bound_1_w_1_h << std::endl;
-                //std::cout << " f_ccm_1_w_1_h_sum " << f_ccm_1_w_1_h_sum << std::endl;
-                //std::cout << " f_ccm_1_w_bin " << f_ccm_1_w_bin << std::endl;
-                //std::cout << " f_ccm_1_h_bin " << f_ccm_1_h_bin << std::endl;
-                //std::cout << "k " << k << " l " << l << " bound_1_w_2_h " << bound_1_w_2_h << std::endl;
-                //std::cout << "k " << k << " l " << l << " bound_2_w_0_h " << bound_2_w_0_h << std::endl;
-                //std::cout << "k " << k << " l " << l << " bound_2_w_1_h " << bound_2_w_1_h << std::endl;
-                //std::cout << "k " << k << " l " << l << " bound_2_w_2_h " << bound_2_w_2_h << std::endl;
-
-                bound = (std::max)(bound, bound_0_w_0_h);
-                bound = (std::max)(bound, bound_0_w_1_h);
-                bound = (std::max)(bound, bound_0_w_2_h);
-                bound = (std::max)(bound, bound_1_w_0_h);
-                bound = (std::max)(bound, bound_1_w_1_h);
-                bound = (std::max)(bound, bound_1_w_2_h);
-                bound = (std::max)(bound, bound_2_w_0_h);
-                bound = (std::max)(bound, bound_2_w_1_h);
-                bound = (std::max)(bound, bound_2_w_2_h);
+                for (int family_w = 0; family_w < 3; ++family_w) {
+                    for (int family_h = 0; family_h < 3; ++family_h) {
+                        BinPos bound_combo = std::ceil(
+                                (double)sums[family_w][family_h]
+                                / (f_w_bin[family_w] * f_h_bin[family_h]));
+                        bound = (std::max)(bound, bound_combo);
+                    }
+                }
             }
         }
     }
 
-    //std::cout << "bound " << bound << std::endl;
     if (instance.objective() == Objective::BinPacking) {
+        bound = (std::max)(bound, clautiaux_bound);
         algorithm_formatter.update_bin_packing_bound(bound);
     } else if (instance.objective() == Objective::Feasibility) {
+        bound = (std::max)(bound, clautiaux_bound);
         if (bound > instance.number_of_bins())
             algorithm_formatter.update_is_proven_infeasible();
     } else if (instance.objective() == Objective::Knapsack) {
@@ -547,4 +664,87 @@ DualFeasibleFunctionsOutput packingsolver::rectangle::dual_feasible_functions(
 
     algorithm_formatter.end();
     return output;
+}
+
+DualFeasibleFunctionsCut packingsolver::rectangle::find_most_violated_dual_feasible_function_cut(
+        const Instance& instance,
+        const std::vector<std::pair<ItemTypeId, ItemPos>>& selected_items)
+{
+    if (instance.number_of_bin_types() != 1) {
+        throw std::invalid_argument(FUNC_SIGNATURE);
+    }
+    const BinType& bin_type = instance.bin_type(0);
+
+    DualFeasibleFunctionsTables tables = compute_dual_feasible_functions_tables(instance, bin_type);
+
+    DualFeasibleFunctionsCut best;
+
+    for (ItemTypeId k_pos = 0; k_pos < (ItemTypeId)tables.widths.size(); ++k_pos) {
+        Length k = tables.widths[k_pos];
+
+        for (ItemTypeId l_pos = 0; l_pos < (ItemTypeId)tables.heights.size(); ++l_pos) {
+            Length l = tables.heights[l_pos];
+
+            std::array<Length, 3> f_w_bin = {
+                f_ccm_0(bin_type.rect.x, k, bin_type.rect.x),
+                f_ccm_1(bin_type.rect.x, k, bin_type.rect.x, tables.full_cardinality_w[k_pos]),
+                f_ccm_2(bin_type.rect.x, k, bin_type.rect.x)};
+            std::array<Length, 3> f_h_bin = {
+                f_ccm_0(bin_type.rect.y, l, bin_type.rect.y),
+                f_ccm_1(bin_type.rect.y, l, bin_type.rect.y, tables.full_cardinality_h[l_pos]),
+                f_ccm_2(bin_type.rect.y, l, bin_type.rect.y)};
+
+            for (int family_w = 0; family_w < 3; ++family_w) {
+                for (int family_h = 0; family_h < 3; ++family_h) {
+                    Length bin_coefficient = f_w_bin[family_w] * f_h_bin[family_h];
+                    if (bin_coefficient <= 0)
+                        continue;
+
+                    double sum = 0.0;
+                    for (const auto& p: selected_items) {
+                        const ItemType& item_type = instance.item_type(p.first);
+                        ItemPos copies = p.second;
+                        sum += copies * item_coefficient(
+                                item_type,
+                                family_w,
+                                family_h,
+                                k,
+                                l,
+                                bin_type.rect.x,
+                                bin_type.rect.y,
+                                tables.full_cardinality_w[k_pos],
+                                tables.excluded_cardinality_w[k_pos],
+                                tables.full_cardinality_h[l_pos],
+                                tables.excluded_cardinality_h[l_pos]);
+                    }
+
+                    double violation = sum - bin_coefficient;
+                    if (violation > best.violation) {
+                        best.found = true;
+                        best.violation = violation;
+                        best.bound = bin_coefficient;
+                        best.coefficients.assign(instance.number_of_item_types(), 0.0);
+                        for (ItemTypeId item_type_id = 0;
+                                item_type_id < instance.number_of_item_types();
+                                ++item_type_id) {
+                            best.coefficients[item_type_id] = item_coefficient(
+                                    instance.item_type(item_type_id),
+                                    family_w,
+                                    family_h,
+                                    k,
+                                    l,
+                                    bin_type.rect.x,
+                                    bin_type.rect.y,
+                                    tables.full_cardinality_w[k_pos],
+                                    tables.excluded_cardinality_w[k_pos],
+                                    tables.full_cardinality_h[l_pos],
+                                    tables.excluded_cardinality_h[l_pos]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return best;
 }

--- a/src/rectangle/dual_feasible_functions.hpp
+++ b/src/rectangle/dual_feasible_functions.hpp
@@ -40,5 +40,46 @@ DualFeasibleFunctionsOutput dual_feasible_functions(
         const Instance& instance,
         const DualFeasibleFunctionsParameters& parameters);
 
+struct DualFeasibleFunctionsCut
+{
+    /** 'true' if a violated dual-feasible-function inequality was found. */
+    bool found = false;
+
+    /**
+     * Coefficient of each item type in the cut (0 for item types that do
+     * not appear in it), indexed by item type id.
+     */
+    std::vector<double> coefficients;
+
+    /** Right-hand side of the cut. */
+    double bound = 0.0;
+
+    /**
+     * Amount by which the cut is violated by 'selected_items' (sum of the
+     * coefficients over 'selected_items' minus 'bound').
+     *
+     * Only meaningful if 'found' is 'true'; used to rank candidate cuts
+     * against each other.
+     */
+    double violation = 0.0;
+};
+
+/**
+ * Look for the most violated dual-feasible-function inequality for a given
+ * selection of items assigned to a single bin.
+ *
+ * The returned cut, if any, is valid for any selection of items from
+ * 'instance' assigned to a single bin of its (unique) bin type, not only
+ * for 'selected_items' - so it may be added as a standalone, permanently
+ * reusable constraint (e.g. in a Benders decomposition master problem),
+ * not just a one-off no-good cut on this exact selection.
+ *
+ * 'found = false' does not prove that 'selected_items' fits into the bin,
+ * only that this necessary condition does not disprove it.
+ */
+DualFeasibleFunctionsCut find_most_violated_dual_feasible_function_cut(
+        const Instance& instance,
+        const std::vector<std::pair<ItemTypeId, ItemPos>>& selected_items);
+
 }
 }

--- a/src/rectangle/main.cpp
+++ b/src/rectangle/main.cpp
@@ -93,6 +93,7 @@ int main(int argc, char *argv[])
 
             ("linear-programming-solver,", po::value<columngenerationsolver::SolverName>(), "set linear programming solver")
             ("optimization-mode,", po::value<OptimizationMode>(), "set optimization mode")
+            ("use-dual-feasible-functions,", po::value<bool>(), "force running the dual feasible functions bound/infeasibility check even if the instance has more items than the default criterion allows")
             ("use-tree-search,", po::value<bool>(), "enable tree search algorithm")
             ("use-tree-search-maximal-spaces,", po::value<bool>(), "enable tree search with maximal spaces")
             ("use-sequential-single-knapsack,", po::value<bool>(), "enable sequential-single-knapsack")
@@ -204,6 +205,8 @@ int main(int argc, char *argv[])
         if (vm.count("memory-limit"))
             parameters.memory_limit_megabytes = vm["memory-limit"].as<Megabytes>();
 
+        if (vm.count("use-dual-feasible-functions"))
+            parameters.use_dual_feasible_functions = vm["use-dual-feasible-functions"].as<bool>();
         if (vm.count("use-tree-search"))
             parameters.use_tree_search = vm["use-tree-search"].as<bool>();
         if (vm.count("use-tree-search-maximal-spaces"))

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -564,7 +564,8 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
             || instance.objective() == Objective::Feasibility
             || instance.objective() == Objective::Knapsack) {
         if (instance.number_of_bin_types() == 1
-                && instance.number_of_items() <= 100) {
+                && (parameters.use_dual_feasible_functions
+                    || instance.number_of_items() <= 100)) {
             optimize_dual_feasible_functions(
                     instance,
                     parameters,

--- a/src/rectangleguillotine/main.cpp
+++ b/src/rectangleguillotine/main.cpp
@@ -112,6 +112,7 @@ int main(int argc, char *argv[])
 
             ("linear-programming-solver,", po::value<columngenerationsolver::SolverName>(), "set linear programming solver")
             ("optimization-mode,", po::value<OptimizationMode>(), "set optimization mode")
+            ("use-dual-feasible-functions,", po::value<bool>(), "force running the dual feasible functions bound/infeasibility check even if the instance has more items than the default criterion allows")
             ("use-tree-search,", po::value<bool>(), "enable tree search algorithm")
             ("use-tree-search-maximal-spaces,", po::value<bool>(), "enable tree search maximal spaces algorithm")
             ("use-column-generation-strips,", po::value<bool>(), "enable column generation strips algorithm")
@@ -280,6 +281,8 @@ int main(int argc, char *argv[])
         if (vm.count("memory-limit"))
             parameters.memory_limit_megabytes = vm["memory-limit"].as<Megabytes>();
 
+        if (vm.count("use-dual-feasible-functions"))
+            parameters.use_dual_feasible_functions = vm["use-dual-feasible-functions"].as<bool>();
         if (vm.count("use-tree-search"))
             parameters.use_tree_search = vm["use-tree-search"].as<bool>();
         if (vm.count("use-tree-search-maximal-spaces"))

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -678,7 +678,8 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
     if (instance.objective() == Objective::BinPacking
             || instance.objective() == Objective::Feasibility) {
         if (instance.number_of_bin_types() == 1
-                && instance.number_of_items() <= 100) {
+                && (parameters.use_dual_feasible_functions
+                    || instance.number_of_items() <= 100)) {
             optimize_dual_feasible_functions(
                     instance,
                     parameters,

--- a/test/box/CMakeLists.txt
+++ b/test/box/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(PackingSolver_box_test)
 target_sources(PackingSolver_box_test PRIVATE
     box_test.cpp
+    dual_feasible_functions_test.cpp
     tree_search_test.cpp)
 target_include_directories(PackingSolver_box_test PRIVATE
     ${PROJECT_SOURCE_DIR}/src)

--- a/test/box/dual_feasible_functions_test.cpp
+++ b/test/box/dual_feasible_functions_test.cpp
@@ -1,0 +1,95 @@
+#include "packingsolver/box/instance_builder.hpp"
+#include "packingsolver/box/optimize.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace packingsolver;
+using namespace packingsolver::box;
+
+TEST(BoxDualFeasibleFunctions, InfeasibleRotationTwoAxisSwap)
+{
+    // Bin 200x100x100. Four copies of an item 55x70x100, allowed to rotate
+    // by swapping its x/y sides (only) - its z side always matches the
+    // bin's z exactly, so this reduces to the same 2D case validated for
+    // rectangle (55x70 unoriented in a 200x100 bin): both x/y sides exceed
+    // half the bin's y-height (50) regardless of rotation, so it is
+    // provably infeasible for a single bin.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(packingsolver::Objective::Feasibility);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(200, 100, 100);
+    instance_builder.set_bin_type_copies(bin_type_id, 1);
+    ItemTypeId item_type_id = instance_builder.add_item_type(55, 70, 100);
+    instance_builder.add_item_type_rotation(item_type_id, Rotation::YXZ);
+    instance_builder.set_item_type_copies(item_type_id, 4);
+    Instance instance = instance_builder.build();
+
+    OptimizeParameters optimize_parameters;
+    optimize_parameters.timer.set_time_limit(0.0);
+    box::Output output = optimize(instance, optimize_parameters);
+
+    EXPECT_TRUE(output.is_proven_infeasible);
+}
+
+TEST(BoxDualFeasibleFunctions, FeasibleRotationTwoAxisSwap)
+{
+    // Same bin and item as above, but only 2 copies: they fit side by side
+    // along the bin's x-axis (2 * 70 = 140 <= 200, 55 <= 100) - genuinely
+    // feasible, must not be flagged.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(packingsolver::Objective::Feasibility);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(200, 100, 100);
+    instance_builder.set_bin_type_copies(bin_type_id, 1);
+    ItemTypeId item_type_id = instance_builder.add_item_type(55, 70, 100);
+    instance_builder.add_item_type_rotation(item_type_id, Rotation::YXZ);
+    instance_builder.set_item_type_copies(item_type_id, 2);
+    Instance instance = instance_builder.build();
+
+    OptimizeParameters optimize_parameters;
+    box::Output output = optimize(instance, optimize_parameters);
+
+    EXPECT_FALSE(output.is_proven_infeasible);
+    EXPECT_EQ(output.solution_pool.best().number_of_items(), 2);
+}
+
+TEST(BoxDualFeasibleFunctions, InfeasibleFullRotationFreedom)
+{
+    // Bin 100x100x100 (cube). Two copies of an oriented-looking 60x60x60
+    // cube item with *all* 6 rotations allowed (rotation is a no-op for a
+    // cube, but exercises the full rotation-enumeration code path): both
+    // dimensions exceed half the bin in every axis, so at most one fits,
+    // regardless of the (here, irrelevant) rotation freedom.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(packingsolver::Objective::Feasibility);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(100, 100, 100);
+    instance_builder.set_bin_type_copies(bin_type_id, 1);
+    ItemTypeId item_type_id = instance_builder.add_item_type(60, 60, 60);
+    for (Rotation rotation: {Rotation::YXZ, Rotation::ZYX, Rotation::YZX, Rotation::XZY, Rotation::ZXY})
+        instance_builder.add_item_type_rotation(item_type_id, rotation);
+    instance_builder.set_item_type_copies(item_type_id, 2);
+    Instance instance = instance_builder.build();
+
+    OptimizeParameters optimize_parameters;
+    optimize_parameters.timer.set_time_limit(0.0);
+    box::Output output = optimize(instance, optimize_parameters);
+
+    EXPECT_TRUE(output.is_proven_infeasible);
+}
+
+TEST(BoxDualFeasibleFunctions, InfeasibleSingleRotationUnchanged)
+{
+    // Regression check: the original (pre-rotation-aware) fully-oriented
+    // case still works. Bin 100x100x100, two oriented 60x60x60 items.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(packingsolver::Objective::Feasibility);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(100, 100, 100);
+    instance_builder.set_bin_type_copies(bin_type_id, 1);
+    ItemTypeId item_type_id = instance_builder.add_item_type(60, 60, 60);
+    instance_builder.set_item_type_copies(item_type_id, 2);
+    Instance instance = instance_builder.build();
+
+    OptimizeParameters optimize_parameters;
+    optimize_parameters.timer.set_time_limit(0.0);
+    box::Output output = optimize(instance, optimize_parameters);
+
+    EXPECT_TRUE(output.is_proven_infeasible);
+}

--- a/test/rectangle/dual_feasible_functions_test.cpp
+++ b/test/rectangle/dual_feasible_functions_test.cpp
@@ -1,0 +1,114 @@
+#include "packingsolver/rectangle/instance_builder.hpp"
+#include "packingsolver/rectangle/optimize.hpp"
+#include "rectangle/dual_feasible_functions.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace packingsolver;
+using namespace packingsolver::rectangle;
+
+TEST(RectangleDualFeasibleFunctions, InfeasibleNonSquareBinRotation)
+{
+    // Bin 200x100 (non-square). Four copies of an *unoriented* 55x70 item:
+    // both dimensions exceed half the bin's height (50) regardless of
+    // rotation, so this is provably infeasible for a single bin - but only
+    // via the rotation-aware breakpoint sweep, not via the pre-existing
+    // Clautiaux-doubling fallback, which pays a "squaring tax" on this
+    // non-square bin (it inflates the height capacity from 100 to 200,
+    // which is enough to hide this particular violation).
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::Feasibility);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(200, 100);
+    instance_builder.set_bin_type_copies(bin_type_id, 1);
+    ItemTypeId item_type_id = instance_builder.add_item_type(55, 70, false);
+    instance_builder.set_item_type_copies(item_type_id, 4);
+    Instance instance = instance_builder.build();
+
+    OptimizeParameters optimize_parameters;
+    optimize_parameters.timer.set_time_limit(0.0);
+    rectangle::Output output = optimize(instance, optimize_parameters);
+
+    EXPECT_TRUE(output.is_proven_infeasible);
+}
+
+TEST(RectangleDualFeasibleFunctions, FeasibleNonSquareBinRotation)
+{
+    // Same bin and item as above, but only 2 copies: they fit side by side
+    // along the width axis (2 * 70 = 140 <= 200, height 55 <= 100) -
+    // genuinely feasible, must not be flagged.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::Feasibility);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(200, 100);
+    instance_builder.set_bin_type_copies(bin_type_id, 1);
+    ItemTypeId item_type_id = instance_builder.add_item_type(55, 70, false);
+    instance_builder.set_item_type_copies(item_type_id, 2);
+    Instance instance = instance_builder.build();
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+
+    EXPECT_FALSE(output.is_proven_infeasible);
+    EXPECT_EQ(output.solution_pool.best().number_of_items(), 2);
+}
+
+TEST(RectangleDualFeasibleFunctions, CutCheckerFindsViolationOnNonSquareBin)
+{
+    // Same setup as InfeasibleNonSquareBinRotation, but exercising
+    // find_most_violated_dual_feasible_function_cut() directly (the
+    // checker meant to run before building a Benders subproblem): the
+    // returned cut must be valid for the whole instance's item universe,
+    // not just the exact candidate that revealed it.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::Knapsack);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(200, 100);
+    instance_builder.set_bin_type_copies(bin_type_id, 1);
+    ItemTypeId item_type_id = instance_builder.add_item_type(55, 70, false);
+    instance_builder.set_item_type_copies(item_type_id, 4);
+    Instance instance = instance_builder.build();
+
+    std::vector<std::pair<ItemTypeId, ItemPos>> selected_items = {{item_type_id, 4}};
+    DualFeasibleFunctionsCut cut = find_most_violated_dual_feasible_function_cut(
+            instance, selected_items);
+
+    EXPECT_TRUE(cut.found);
+    EXPECT_GT(cut.violation, 0.0);
+    ASSERT_EQ((ItemTypeId)cut.coefficients.size(), instance.number_of_item_types());
+    EXPECT_GT(cut.coefficients[item_type_id], 0.0);
+}
+
+TEST(RectangleDualFeasibleFunctions, CutCheckerNoViolationForFeasibleSelection)
+{
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::Knapsack);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(200, 100);
+    instance_builder.set_bin_type_copies(bin_type_id, 1);
+    ItemTypeId item_type_id = instance_builder.add_item_type(55, 70, false);
+    instance_builder.set_item_type_copies(item_type_id, 2);
+    Instance instance = instance_builder.build();
+
+    std::vector<std::pair<ItemTypeId, ItemPos>> selected_items = {{item_type_id, 2}};
+    DualFeasibleFunctionsCut cut = find_most_violated_dual_feasible_function_cut(
+            instance, selected_items);
+
+    EXPECT_FALSE(cut.found);
+}
+
+TEST(RectangleDualFeasibleFunctions, InfeasibleOrientedSquareBinUnchanged)
+{
+    // Regression check: the original (pre-rotation-aware) oriented-only
+    // case still works. Bin 100x100, two oriented 60x60 items: both
+    // dimensions exceed half the bin in both axes, so at most one fits.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::Feasibility);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(100, 100);
+    instance_builder.set_bin_type_copies(bin_type_id, 1);
+    ItemTypeId item_type_id = instance_builder.add_item_type(60, 60, true);
+    instance_builder.set_item_type_copies(item_type_id, 2);
+    Instance instance = instance_builder.build();
+
+    OptimizeParameters optimize_parameters;
+    optimize_parameters.timer.set_time_limit(0.0);
+    rectangle::Output output = optimize(instance, optimize_parameters);
+
+    EXPECT_TRUE(output.is_proven_infeasible);
+}


### PR DESCRIPTION
Previously, a non-oriented item type disabled the (k, l) breakpoint sweep entirely in favor of the Clautiaux-doubling fallback (rectangle) or made the whole computation bail out with no bound at all (box, whenever any item had more than one allowed rotation). Now, in both, an item's coefficient is the minimum over all of its allowed rotations (rectangle: up to 2; box: up to all 6 of Rotation's axis permutations), evaluated as one consistent whole-item product per rotation rather than per axis independently, since a real placement uses a single rotation for every axis at once - a valid lower bound on the true contribution regardless of which rotation actually ends up being used. This includes f_ccm_1's cross-item cardinality bookkeeping, restricted to cases where an item's big/medium/small classification on a given axis doesn't depend on which rotation is used, to stay sound.

For rectangle, this runs alongside the existing Clautiaux fallback rather than replacing it (the sweep avoids Clautiaux's "squaring tax" on non-square bins but doesn't benefit from its exact doubling, so neither dominates the other in general), taking the max of both. Box has no such fallback, so this is its first rotation-aware bound.

Extracted the shared breakpoint/cardinality precomputation in rectangle into compute_dual_feasible_functions_tables(), and added find_most_violated_dual_feasible_function_cut(), which reuses it to check a specific item selection instead of the whole instance. Benders decomposition now calls this right after each MILP solve, before building the (expensive) feasibility subproblem: a violation proves the selection cannot fit in one bin without running the subproblem at all, and unlike a no-good cut on that exact selection, the returned inequality is valid for any selection from the instance, so it is added as a permanent MILP row.

Also added a use_dual_feasible_functions option (rectangle, rectangleguillotine, box) to force running the dual feasible functions bound/infeasibility check even when the instance has more items than the default size criterion allows.