### PR TITLE
onedimensional: add a JSON writer for Instance, alongside the existing CSV one

### DIFF
--- a/include/packingsolver/onedimensional/instance.hpp
+++ b/include/packingsolver/onedimensional/instance.hpp
@@ -9,6 +9,23 @@ namespace packingsolver
 namespace onedimensional
 {
 
+/** File format for 'Instance::write'. */
+enum class InstanceFormat
+{
+    /**
+     * Three CSV files (items, bins, parameters), matching
+     * 'InstanceBuilder::read_item_types'/'read_bin_types'/'read_parameters'.
+     * Cannot represent resources, eligibility, or item type precedences;
+     * 'write' throws if the instance has any of these.
+     */
+    Csv,
+    /**
+     * A single JSON file, matching 'InstanceBuilder::read' - the only
+     * format that can represent every feature of the instance.
+     */
+    Json,
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 ///////////////////////// Item type, Bin type, Defect //////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -331,8 +348,19 @@ public:
             std::ostream& os,
             int verbosity_level = 1) const;
 
-    /** Write the instance to a file. */
-    void write(const std::string& instance_path) const;
+    /**
+     * Write the instance to a file, in the given format (default 'Csv',
+     * matching the previous behavior). See 'InstanceFormat'.
+     */
+    void write(
+            const std::string& instance_path,
+            InstanceFormat format = InstanceFormat::Csv) const;
+
+    /** Write the instance as three CSV files; see 'InstanceFormat::Csv'. */
+    void write_csv(const std::string& instance_path) const;
+
+    /** Write the instance as a single JSON file; see 'InstanceFormat::Json'. */
+    void write_json(const std::string& instance_path) const;
 
 private:
 

--- a/src/onedimensional/instance.cpp
+++ b/src/onedimensional/instance.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <iomanip>
+#include <sstream>
 
 using namespace packingsolver;
 using namespace packingsolver::onedimensional;
@@ -173,8 +174,70 @@ std::ostream& Instance::format(
 }
 
 void Instance::write(
+        const std::string& instance_path,
+        InstanceFormat format) const
+{
+    switch (format) {
+    case InstanceFormat::Csv:
+        write_csv(instance_path);
+        break;
+    case InstanceFormat::Json:
+        write_json(instance_path);
+        break;
+    }
+}
+
+void Instance::write_csv(
         const std::string& instance_path) const
 {
+    // Check every feature of the instance can actually be represented in
+    // the CSV format before writing anything (so a rejected write doesn't
+    // leave partial files behind).
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < number_of_item_types();
+            ++item_type_id) {
+        if (this->item_type(item_type_id).eligibility_id != -1) {
+            throw std::invalid_argument(
+                    FUNC_SIGNATURE + ": "
+                    "item type " + std::to_string(item_type_id) + " has an "
+                    "eligibility id, which the CSV format cannot represent; "
+                    "use 'InstanceFormat::Json' instead.");
+        }
+    }
+    if (!precedences().empty()) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "the instance has item type precedences, which the CSV "
+                "format cannot represent; use 'InstanceFormat::Json' "
+                "instead.");
+    }
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < number_of_bin_types();
+            ++bin_type_id) {
+        const BinType& bin_type = this->bin_type(bin_type_id);
+        if (bin_type.number_of_resources() > 0) {
+            throw std::invalid_argument(
+                    FUNC_SIGNATURE + ": "
+                    "bin type " + std::to_string(bin_type_id) + " has "
+                    "resources, which the CSV format cannot represent; use "
+                    "'InstanceFormat::Json' instead.");
+        }
+        if (!bin_type.eligibility_ids.empty()) {
+            throw std::invalid_argument(
+                    FUNC_SIGNATURE + ": "
+                    "bin type " + std::to_string(bin_type_id) + " has "
+                    "eligibility ids, which the CSV format cannot "
+                    "represent; use 'InstanceFormat::Json' instead.");
+        }
+        if (!bin_type.fixed_items.empty()) {
+            throw std::invalid_argument(
+                    FUNC_SIGNATURE + ": "
+                    "bin type " + std::to_string(bin_type_id) + " has fixed "
+                    "items, which the CSV format cannot represent; use "
+                    "'InstanceFormat::Json' instead.");
+        }
+    }
+
     std::string items_path = instance_path + "_items.csv";
     std::string bins_path = instance_path + "_bins.csv";
     std::string parameters_path = instance_path + "_parameters.csv";
@@ -200,7 +263,7 @@ void Instance::write(
     // Export items.
     f_items <<
         "ID,"
-        "LENGTH,"
+        "X,"
         "PROFIT,"
         "COPIES,"
         "WEIGHT,"
@@ -225,7 +288,7 @@ void Instance::write(
     // Export bins.
     f_bins <<
         "ID,"
-        "LENGTH,"
+        "X,"
         "COST,"
         "COPIES,"
         "COPIES_MIN,"
@@ -246,4 +309,100 @@ void Instance::write(
     // Export parameters.
     f_parameters << "NAME,VALUE" << std::endl
         << "objective," << objective() << std::endl;
+}
+
+void Instance::write_json(
+        const std::string& instance_path) const
+{
+    std::ofstream file(instance_path);
+    if (!file.good()) {
+        throw std::runtime_error(
+                FUNC_SIGNATURE + ": "
+                "unable to open file \"" + instance_path + "\".");
+    }
+
+    nlohmann::json json;
+
+    std::stringstream objective_ss;
+    objective_ss << objective();
+    json["objective"] = objective_ss.str();
+
+    json["bin_types"] = nlohmann::json::array();
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < number_of_bin_types();
+            ++bin_type_id) {
+        const BinType& bin_type = this->bin_type(bin_type_id);
+        nlohmann::json json_bin_type;
+        json_bin_type["length"] = bin_type.length;
+        json_bin_type["cost"] = bin_type.cost;
+        json_bin_type["copies"] = bin_type.copies;
+        json_bin_type["copies_min"] = bin_type.copies_min;
+        if (bin_type.maximum_weight != std::numeric_limits<Weight>::infinity())
+            json_bin_type["maximum_weight"] = bin_type.maximum_weight;
+        if (!bin_type.eligibility_ids.empty())
+            json_bin_type["eligibility_ids"] = bin_type.eligibility_ids;
+        if (bin_type.number_of_resources() > 0) {
+            nlohmann::json json_resources = nlohmann::json::array();
+            for (ResourceId resource_id = 0;
+                    resource_id < bin_type.number_of_resources();
+                    ++resource_id) {
+                nlohmann::json json_resource;
+                json_resource["capacity"] = bin_type.resource_capacities[resource_id];
+                nlohmann::json json_consumptions = nlohmann::json::array();
+                const std::vector<std::vector<double>>& consumptions
+                    = bin_type.item_resource_consumptions[resource_id];
+                for (ItemTypeId item_type_id = 0;
+                        item_type_id < (ItemTypeId)consumptions.size();
+                        ++item_type_id) {
+                    const std::vector<double>& schedule = consumptions[item_type_id];
+                    if (schedule.empty())
+                        continue;
+                    nlohmann::json json_consumption;
+                    json_consumption["item_type_id"] = item_type_id;
+                    if (schedule.size() == 1) {
+                        json_consumption["consumption"] = schedule[0];
+                    } else {
+                        json_consumption["consumption_schedule"] = schedule;
+                    }
+                    json_consumptions.push_back(json_consumption);
+                }
+                json_resource["consumptions"] = json_consumptions;
+                json_resources.push_back(json_resource);
+            }
+            json_bin_type["resources"] = json_resources;
+        }
+        json["bin_types"].push_back(json_bin_type);
+    }
+
+    json["item_types"] = nlohmann::json::array();
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < number_of_item_types();
+            ++item_type_id) {
+        const ItemType& item_type = this->item_type(item_type_id);
+        nlohmann::json json_item_type;
+        json_item_type["length"] = item_type.length;
+        json_item_type["profit"] = item_type.profit;
+        json_item_type["weight"] = item_type.weight;
+        json_item_type["copies"] = item_type.copies;
+        json_item_type["nesting_length"] = item_type.nesting_length;
+        if (item_type.maximum_stackability != std::numeric_limits<ItemPos>::max())
+            json_item_type["maximum_stackability"] = item_type.maximum_stackability;
+        if (item_type.maximum_weight_after != std::numeric_limits<Weight>::infinity())
+            json_item_type["maximum_weight_after"] = item_type.maximum_weight_after;
+        if (item_type.eligibility_id != -1)
+            json_item_type["eligibility_id"] = item_type.eligibility_id;
+        json["item_types"].push_back(json_item_type);
+    }
+
+    if (!precedences().empty()) {
+        json["precedences"] = nlohmann::json::array();
+        for (const Precedence& precedence: precedences()) {
+            nlohmann::json json_precedence;
+            json_precedence["dominated_item_type_id"] = precedence.dominated_item_type_id;
+            json_precedence["dominating_item_type_id"] = precedence.dominating_item_type_id;
+            json["precedences"].push_back(json_precedence);
+        }
+    }
+
+    file << std::setw(4) << json << std::endl;
 }

--- a/test/onedimensional/onedimensional_test.cpp
+++ b/test/onedimensional/onedimensional_test.cpp
@@ -45,6 +45,117 @@ TEST(OneDimensional, ResourceConsumptionCopiedFromOriginalInstance)
             5.0);
 }
 
+TEST(OneDimensional, WriteCsvRoundTrip)
+{
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(packingsolver::Objective::BinPacking);
+    packingsolver::BinTypeId bin_type_id = instance_builder.add_bin_type(100);
+    instance_builder.set_bin_type_cost(bin_type_id, 7);
+    instance_builder.set_bin_type_copies(bin_type_id, 3);
+    packingsolver::ItemTypeId item_type_id = instance_builder.add_item_type(10);
+    instance_builder.set_item_type_profit(item_type_id, 42);
+    instance_builder.set_item_type_copies(item_type_id, 5);
+    const Instance instance = instance_builder.build();
+
+    fs::path path = fs::temp_directory_path() / fs::unique_path();
+    instance.write(path.string(), InstanceFormat::Csv);
+
+    InstanceBuilder read_instance_builder;
+    read_instance_builder.read_item_types(path.string() + "_items.csv");
+    read_instance_builder.read_bin_types(path.string() + "_bins.csv");
+    read_instance_builder.read_parameters(path.string() + "_parameters.csv");
+    const Instance read_instance = read_instance_builder.build();
+
+    fs::remove(path.string() + "_items.csv");
+    fs::remove(path.string() + "_bins.csv");
+    fs::remove(path.string() + "_parameters.csv");
+
+    EXPECT_EQ(read_instance.objective(), packingsolver::Objective::BinPacking);
+    ASSERT_EQ(read_instance.number_of_bin_types(), 1);
+    EXPECT_EQ(read_instance.bin_type(0).length, 100);
+    EXPECT_EQ(read_instance.bin_type(0).cost, 7);
+    EXPECT_EQ(read_instance.bin_type(0).copies, 3);
+    ASSERT_EQ(read_instance.number_of_item_types(), 1);
+    EXPECT_EQ(read_instance.item_type(0).length, 10);
+    EXPECT_EQ(read_instance.item_type(0).profit, 42);
+    EXPECT_EQ(read_instance.item_type(0).copies, 5);
+}
+
+TEST(OneDimensional, WriteJsonRoundTripWithResource)
+{
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(packingsolver::Objective::BinPacking);
+    packingsolver::BinTypeId bin_type_id = instance_builder.add_bin_type(100);
+    packingsolver::ResourceId resource_id = instance_builder.add_bin_type_resource(bin_type_id, 10);
+    packingsolver::ItemTypeId item_type_id = instance_builder.add_item_type(10);
+    instance_builder.set_item_type_copies(item_type_id, 3);
+    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, 0, 5);
+    const Instance instance = instance_builder.build();
+
+    fs::path path = fs::temp_directory_path() / fs::unique_path();
+    std::string json_path = path.string() + ".json";
+    instance.write(json_path, InstanceFormat::Json);
+
+    InstanceBuilder read_instance_builder;
+    read_instance_builder.read(json_path);
+    const Instance read_instance = read_instance_builder.build();
+
+    fs::remove(json_path);
+
+    EXPECT_EQ(read_instance.objective(), packingsolver::Objective::BinPacking);
+    ASSERT_EQ(read_instance.number_of_bin_types(), 1);
+    EXPECT_EQ(read_instance.bin_type(0).number_of_resources(), 1);
+    EXPECT_EQ(read_instance.bin_type(0).resource_capacities[0], 10.0);
+    EXPECT_EQ(read_instance.bin_type(0).item_resource_consumption(0, 0, 0), 5.0);
+}
+
+TEST(OneDimensional, WriteCsvThrowsOnResource)
+{
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(packingsolver::Objective::BinPacking);
+    packingsolver::BinTypeId bin_type_id = instance_builder.add_bin_type(100);
+    instance_builder.add_bin_type_resource(bin_type_id, 10);
+    instance_builder.add_item_type(10);
+    const Instance instance = instance_builder.build();
+
+    fs::path path = fs::temp_directory_path() / fs::unique_path();
+    EXPECT_THROW(
+            instance.write(path.string(), InstanceFormat::Csv),
+            std::invalid_argument);
+}
+
+TEST(OneDimensional, WriteCsvThrowsOnEligibility)
+{
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(packingsolver::Objective::BinPacking);
+    packingsolver::BinTypeId bin_type_id = instance_builder.add_bin_type(100);
+    instance_builder.add_bin_type_eligibility(bin_type_id, 0);
+    packingsolver::ItemTypeId item_type_id = instance_builder.add_item_type(10);
+    instance_builder.set_item_type_eligibility(item_type_id, 0);
+    const Instance instance = instance_builder.build();
+
+    fs::path path = fs::temp_directory_path() / fs::unique_path();
+    EXPECT_THROW(
+            instance.write(path.string(), InstanceFormat::Csv),
+            std::invalid_argument);
+}
+
+TEST(OneDimensional, WriteCsvThrowsOnPrecedence)
+{
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(packingsolver::Objective::Knapsack);
+    instance_builder.add_bin_type(100);
+    packingsolver::ItemTypeId item_type_id_1 = instance_builder.add_item_type(10);
+    packingsolver::ItemTypeId item_type_id_2 = instance_builder.add_item_type(20);
+    instance_builder.add_item_type_precedence(item_type_id_1, item_type_id_2);
+    const Instance instance = instance_builder.build();
+
+    fs::path path = fs::temp_directory_path() / fs::unique_path();
+    EXPECT_THROW(
+            instance.write(path.string(), InstanceFormat::Csv),
+            std::invalid_argument);
+}
+
 TEST(OneDimensional, Users_2023_08_01)
 {
     InstanceBuilder instance_builder;


### PR DESCRIPTION
Add an InstanceFormat parameter (Csv, default; or Json) to Instance::write, and expose write_csv/write_json as public methods in their own right.

write_json writes a single file matching exactly the schema InstanceBuilder::read already parses (objective, bin types with resources/ eligibility, item types, and item type precedences for inspection, even though the reader does not consume that field yet), the only format that can represent every feature of the instance.

write_csv throws std::invalid_argument up front if the instance has any feature the CSV format cannot express (resources, eligibility, item type precedences), rather than silently dropping it. Also fixes the CSV item/ bin type header using "LENGTH" where the reader expects "X", which meant the previous output could never actually be read back.