### PR TITLE
release: mark rolling master build as latest instead of pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
           Automatically built from master @ ${{ github.event.workflow_run.head_sha }}.
 
           These binaries are rebuilt on every successful commit to master and are not versioned releases.
-        prerelease: true
-        make_latest: false
+        prerelease: false
+        make_latest: true
         target_commitish: ${{ github.event.workflow_run.head_sha }}
         files: dist/**/*


### PR DESCRIPTION
prerelease:true kept the rolling build out of GitHub's "latest release" slot, so it never showed on the repo homepage. Switching to prerelease:false + make_latest:true surfaces it there.