### PR TITLE
rectangle: add "packing and removing some items" reduction (Cote, Haouari & Iori 2019, Sec 4.2)

### DIFF
--- a/include/packingsolver/rectangle/optimize.hpp
+++ b/include/packingsolver/rectangle/optimize.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "packingsolver/rectangle/solution.hpp"
+#include "packingsolver/rectangle/reduction.hpp"
 
 #include "columngenerationsolver/commons.hpp"
 
@@ -156,6 +157,9 @@ struct OptimizeParameters: packingsolver::Parameters<Instance, Solution, Output>
 
     /** Fixed items. */
     Solution* fixed_items = nullptr;
+
+    /** Parameters for the instance reduction. */
+    ReductionParameters reduction_parameters;
 
     /** Linear programming solver. */
     columngenerationsolver::SolverName linear_programming_solver_name

--- a/include/packingsolver/rectangle/reduction.hpp
+++ b/include/packingsolver/rectangle/reduction.hpp
@@ -1,0 +1,1110 @@
+#pragma once
+
+#include "packingsolver/rectangle/solution.hpp"
+
+#include "optimizationtools/utils/parameters.hpp"
+
+namespace packingsolver
+{
+namespace rectangle
+{
+
+/** Defined in 'src/rectangle/solution_builder.hpp'; only used here by pointer/reference. */
+class SolutionBuilder;
+
+/**
+ * Structure passed as parameters of the reduction algorithm.
+ *
+ * Deliberately does not inherit from 'packingsolver::Parameters<Instance,
+ * Solution, Output>' (unlike most other "*Parameters" structs in this
+ * codebase): 'Reduction' is wired into 'optimize()' itself (see
+ * 'optimize.hpp'/'optimize.cpp'), so inheriting from a type parameterized
+ * on 'rectangle::Output' would create a circular include between this
+ * header and 'optimize.hpp'. 'optimizationtools::Parameters' already
+ * provides everything actually needed here (a 'Timer', 'verbosity_level',
+ * ...) without that dependency.
+ */
+struct ReductionParameters: optimizationtools::Parameters
+{
+    /** Boolean indicating if the reduction should be performed. */
+    bool reduce = true;
+
+    /** Maximum number of rounds of the outer fixpoint loop. */
+    Counter maximum_number_of_rounds = 999;
+
+    /**
+     * Size of the tree search queue used for the companion-bin feasibility
+     * checks (see 'Reduction').
+     */
+    NodeId subproblem_queue_size = 32;
+};
+
+/**
+ * "Packing and removing some items" reduction (Côté, Haouari & Iori 2019,
+ * "A Primal Decomposition Algorithm for the Two-dimensional Bin Packing
+ * Problem", Section 4.2).
+ *
+ * Only meaningful for the 'BinPacking', 'VariableSizedBinPacking' and
+ * 'Feasibility' objectives (every item must be packed there, which is what
+ * makes the reduction sound - see below), and only for instances with a
+ * single bin type (the paper's 2D-BPP has one bin size; classifying an item
+ * as "wide"/"tall" depends on which bin's dimensions it is compared to, and
+ * a reduction valid for one bin type isn't obviously valid for another).
+ *
+ * Also skipped whenever the instance has defects, a finite bin weight
+ * capacity together with non-trivial item weights, or a non-'None'
+ * unloading constraint - every check this class performs (the companion-bin
+ * 'Objective::Feasibility' solves, and the direct dimension-only matches in
+ * 'reduce_full_bin_items'/'reduce_perfect_pairs') reasons purely about
+ * geometry, which none of these three respect: a defect sitting where a
+ * companion needs to go is invisible to a plain empty-rectangle check;
+ * total bin weight and unloading order are *whole-bin* properties over
+ * every item that ends up sharing a bin, but a validated-enlarged item's
+ * real companions are invisibly removed from the reduced instance and only
+ * reinserted by 'unreduce_solution' after the downstream solve has already
+ * finished, so that solve can never verify either one still holds once it
+ * additionally places other items - never part of the isolated companion
+ * check - into that same bin.
+ *
+ * For every excluded case, this is a no-op: 'instance()' returns a copy of
+ * the original instance, and 'unreduce_solution' is the identity function.
+ *
+ * The idea: an item type whose width exceeds half the bin's width (a "wide"
+ * item) can only ever share its row of the bin with items narrow enough to
+ * fit in the leftover width. If *every* narrow-enough item type can be
+ * proven (via an actual 'Objective::Feasibility' solve, small time/node
+ * budget) to fit alongside the wide items, in the leftover "companion"
+ * strips beside them, then those narrow items can be removed from the
+ * instance entirely (their placement is fully determined by wherever their
+ * paired wide item ends up) and the wide items enlarged to the full bin
+ * width - a much smaller equivalent instance. The symmetric case is
+ * applied for items taller than half the bin's height, and a third case
+ * for items that are both wider than half the bin's width *and* taller
+ * than half its height (paired with a full bin instead of a strip). See
+ * 'reduction.cpp' for the exact algorithm (which follows the paper's
+ * sorted, incrementally-growing candidate search, but uses PackingSolver's
+ * own 'Objective::Feasibility' solver as the packing-check primitive
+ * instead of the paper's bespoke greedy heuristic).
+ *
+ * Soundness: every removed item is guaranteed packed whenever its paired
+ * big item is packed. This only preserves the number of bins used (and the
+ * feasibility of the built solution) if the big item is itself guaranteed
+ * to be packed - true for 'BinPacking'/'VariableSizedBinPacking' (every
+ * item must be packed) and 'Feasibility' (same), but *not* true for
+ * 'Knapsack' (an item may legitimately be left unpacked there), which is
+ * why 'Knapsack' is excluded.
+ */
+class Reduction
+{
+
+public:
+
+    /**
+     * 'true' iff the reduction is meaningful for 'instance'/'parameters' -
+     * everything the class-level doc comment's "Only meaningful for..."/
+     * "Also skipped whenever..." paragraphs describe (the objective,
+     * single-bin-type, defect-free, unloading-constraint-free, weight
+     * conditions, together with 'parameters.reduce' itself). Exposed as
+     * its own static method - rather than left as an internal, constructor-
+     * only check - so that a caller about to construct a 'Reduction' (see
+     * 'optimize()') can decide not to at all when it would just no-op:
+     * constructing one always does at least a full pass over every item
+     * type (to build the working representation and, even in the
+     * no-op case, immediately rebuild an identical 'Instance' from it),
+     * work worth skipping entirely rather than paying for and discarding.
+     */
+    static bool applies(
+            const Instance& instance,
+            const ReductionParameters& parameters);
+
+    /** Constructor. */
+    Reduction(
+            const Instance& instance,
+            const ReductionParameters& parameters = {});
+
+    /** Get the reduced instance. */
+    const Instance& instance() const { return instance_; }
+
+    /** Unreduce a solution of the reduced instance. */
+    Solution unreduce_solution(
+            const Solution& solution) const;
+
+    /**
+     * Number of dedicated bins set aside outside the reduced instance -
+     * holding a single item whose own dimensions already exactly match
+     * the bin's (see 'FullBinItem'), a "perfect pair" of two item types
+     * that together exactly tile the bin (see 'PerfectPair'), or a "both"
+     * group directly captured from a companion-bin check's own solution
+     * (see 'BothGroup'). Must be added to any bin-count bound computed on
+     * 'instance()' ('bin_packing_bound'; or, scaled by the bin type's
+     * cost, 'variable_sized_bin_packing_bound') to recover the bound for
+     * the original instance - unlike the wide/tall cases below, whose
+     * enlarged item types stay present in 'instance()' and so are already
+     * counted by any solve on it, these dedicated bins are entirely
+     * absent from 'instance()' and cannot be accounted for by any solve
+     * on it alone. Every other bound needs no such translation (in
+     * particular 'is_proven_infeasible': these bins' capacity is already
+     * subtracted from the reduced instance's own bin type copies in
+     * 'reduction_to_instance', so a 'Feasibility' solve on 'instance()'
+     * already answers for the original instance directly) - so a reduced
+     * instance's 'Output' otherwise already holds the original instance's
+     * bounds directly, in 'Output's own field layout (see
+     * 'AlgorithmFormatter::update_bounds'), unlike e.g.
+     * setcoveringsolver's 'Reduction', whose mandatory sets contribute an
+     * extra cost to every bound.
+     */
+    BinPos number_of_dedicated_bins() const;
+
+    /**
+     * 'true' iff the reduction alone already proves the original instance
+     * infeasible: a bin type's copies were exhausted by dedicated bins
+     * (see 'FullBinItem'/'PerfectPair') while real items were still left
+     * over needing to be packed (see 'reduction_to_instance'). Only ever
+     * possible for 'Feasibility' (the only objective with genuinely
+     * finite bin type copies in practice); always 'false' otherwise. When
+     * 'true', 'instance()' is not a meaningful reduced instance to solve
+     * at all - callers must check this first.
+     */
+    bool proven_infeasible() const { return proven_infeasible_; }
+
+private:
+
+    /*
+     * Private types
+     */
+
+    /**
+     * Which of the two sub-cases enlarged a given item type - "wide" or
+     * "tall" (see 'reduce_group'). The "both" sub-case has no enum value
+     * of its own: it needs different enough control flow from wide/tall
+     * (see 'reduce_both_groups'/'try_reduce_both_group') that every
+     * function below taking 'EnlargementCase' is only ever called with
+     * 'Wide'/'Tall' - "both" instead has its own dedicated, differently-
+     * named functions (e.g. 'could_fit_both' alongside 'could_fit'), so
+     * there is never a "both" branch to keep in sync (or leave
+     * unreachable) in any of them.
+     */
+    enum class EnlargementCase { Wide, Tall };
+
+    /**
+     * A companion item removed from the instance because it was proven to
+     * always fit alongside a bigger item.
+     *
+     * 'item_type_id' is in the *original* instance's item type id space:
+     * the working representation ('ReductionItemType' below) is a stable,
+     * never-reindexed 1:1 copy of the original instance's item types (only
+     * ever marking entries 'removed', never inserting/erasing slots), so
+     * its own indices already coincide with the original instance's ids.
+     */
+    struct CompanionItem
+    {
+        /** Item type id (original instance's id space) of the removed item. */
+        ItemTypeId item_type_id;
+
+        /** Position of the bottom-left corner relative to the big item's own bottom-left corner. */
+        Point offset;
+
+        /** Whether the removed item is rotated or not. */
+        bool rotate;
+
+        /**
+         * This companion's own real companions, captured directly (via
+         * 'extract_companions') at the moment it was itself absorbed here
+         * - empty unless it was already enlarged (on some other axis, in
+         * an earlier round) before being absorbed. A companion is no
+         * longer excluded from being an already-enlarged item type (see
+         * every R-candidate scan's own doc comment for why that
+         * exclusion was unsound), so this can legitimately be non-empty
+         * and needs to be resolved recursively when placing a solution -
+         * see 'place_item_and_companions'.
+         *
+         * Captured *directly here*, rather than looked up later via
+         * 'final_item_types_', because a single item type's own
+         * 'companions_by_copy' entries can end up split across several
+         * different absorptions (different copies of the same
+         * already-enlarged type going to different big items, or
+         * different copies within the same big item's own group) - only
+         * the specific copy captured for *this* occurrence is correct
+         * here; a later, id-based lookup has no way to tell which of
+         * several possible entries belongs to which occurrence.
+         */
+        std::vector<CompanionItem> nested_companions;
+    };
+
+    /**
+     * Working representation of an item type during the reduction process.
+     *
+     * Item types are never physically removed from this vector while the
+     * reduction is running (only marked 'removed'): this keeps every id
+     * stable across the whole (possibly multi-round) process, so that
+     * 'CompanionItem::item_type_id' references remain valid regardless of
+     * which round removed them, and so that this vector's own indices
+     * double as original-instance item type ids throughout. It is only
+     * compacted once, at the very end, when building the final reduced
+     * 'Instance' (see 'reduction_to_instance').
+     *
+     * Only ever holds what the reduction process can actually *change*
+     * ('rect', via enlargement; 'copies', via a partial 'PerfectPair' -
+     * see 'reduce_perfect_pairs') plus the bookkeeping needed to undo it
+     * ('removed'/'companions_by_copy'). Every other item type field
+     * (profit, group, orientation, ...) never changes during the process,
+     * so it is read directly from 'original_instance_' (indexable by the
+     * exact same id, per the invariant above) wherever needed, instead of
+     * being duplicated here.
+     */
+    struct ReductionItemType
+    {
+        bool removed = false;
+
+        /** Current (possibly enlarged) dimensions. */
+        Rectangle rect;
+
+        /**
+         * Current (possibly reduced) number of copies. Starts at the
+         * original instance's own copies and only ever decreases, when a
+         * 'PerfectPair' with an unequal-copies partner consumes
+         * 'min(copies_1, copies_2)' of it, leaving the item type itself
+         * present (not 'removed') with the leftover copies - see
+         * 'reduce_perfect_pairs'. Every copies-sensitive computation
+         * elsewhere in the class (building a 'try_reduce_group' check
+         * sub-instance, 'reduce_full_bin_items', building the final
+         * reduced instance, ...) must read this field, never
+         * 'original_instance_->item_type(id).copies' directly - offering
+         * more copies than truly remain to a validation solve could make
+         * an actually-infeasible reduction look feasible.
+         */
+        ItemPos copies = 0;
+
+        /**
+         * For each copy of this item type (in the order copies will be
+         * encountered while scanning a reduced solution), the companion
+         * items packed alongside it. This is the sole record of whether
+         * (and how) this item type was ever enlarged - there is no
+         * separate boolean: the whole outer vector is empty iff it never
+         * was, and non-empty (always exactly 'copies' entries, each
+         * possibly itself empty) from the moment it first is, in
+         * 'try_reduce_group''s own 'enlarge()' step (the only place this
+         * field is ever set for 'Wide'/'Tall' - "both" never mutates it
+         * in place at all, since an item absorbed via 'try_reduce_both_group'
+         * is removed outright, not enlarged - see 'BothGroup'). An item
+         * can be enlarged by more than one axis in turn (its current
+         * 'rect' and already-captured companions from an earlier axis
+         * directly feed the next axis's own search - see
+         * 'gather_sorted_big_items'), so 'enlarge()' appends to whatever
+         * is already here rather than overwriting it, keeping every
+         * axis's real companions intact regardless of how many
+         * contributed.
+         */
+        std::vector<std::vector<CompanionItem>> companions_by_copy;
+    };
+
+    /**
+     * Everything below (through 'gather_sorted_both_big_items') differs
+     * between the wide/tall sub-cases (sharing one function each, via a
+     * plain switch on 'enlargement_case') and the "both" sub-case (its
+     * own, separate, identically-purposed function, with an '_both'
+     * suffix) - which used to go through a single, three-way switch per
+     * function (or, before that, a 'GroupCaseConfig' struct of per-case
+     * lambdas) instead. Neither stayed a good fit once "both" needed
+     * genuinely different *control flow* (not just a different formula)
+     * from wide/tall for its own companion-bin construction: a three-way
+     * switch meant every wide/tall-only reader had to also read (and every
+     * wide/tall-only change had to route around) a "both" branch that
+     * lived in a completely different calling function, and vice versa.
+     * Splitting each into its natural two functions - one shared by
+     * 'reduce_group'/'try_reduce_group', one used only by
+     * 'reduce_both_groups'/'try_reduce_both_group' - keeps each
+     * function's own switch (if it has one at all) covering only the
+     * cases that are actually symmetric.
+     *
+     * 'bin_w'/'bin_h', threaded through every function below, are always
+     * the *shrunk* bin dimensions (equation (7), "shrinking the bins":
+     * see 'compute_shrunk_bin_sizes') - not the bin's true ones, for the
+     * same soundness reason every one of them needs: no achievable
+     * combination of the original items ever exceeds the shrunk value, so
+     * claiming exactly up to it already accounts for everything that
+     * could ever really share a row/column/bin with this item.
+     */
+
+    /**
+     * 'true' iff item type 'item_type_id' is eligible to be a "big" item
+     * for 'enlargement_case' (see 'gather_sorted_both_big_items' for the
+     * "both" equivalent, inlined there rather than a function of its own
+     * - see its own doc comment for why). Takes the id (alongside the
+     * working 'ReductionItemType') since it needs 'Instance::item_type's
+     * own 'oriented' field, which 'ReductionItemType' no longer
+     * duplicates.
+     *
+     * Requires the item to be 'oriented': 'Wide'/'Tall''s own enlargement
+     * fixes it at a specific declared-orientation position, so a
+     * non-oriented item's other orientation would otherwise be silently
+     * ignored - see 'reduce_group'.
+     */
+    bool is_big(
+            EnlargementCase enlargement_case,
+            ItemTypeId item_type_id,
+            const ReductionItemType& item,
+            Length bin_w,
+            Length bin_h) const;
+
+    /**
+     * Strict ordering used to sort big items for 'enlargement_case'
+     * non-increasing: 'true' iff 'item_1' should be considered before
+     * 'item_2' (see 'gather_sorted_both_big_items' for the "both"
+     * equivalent, inlined there rather than a function of its own).
+     */
+    bool size_greater(
+            EnlargementCase enlargement_case,
+            const ReductionItemType& item_1,
+            const ReductionItemType& item_2) const;
+
+    /**
+     * 'true' iff item type 'item_type_id' is worth offering alongside big
+     * item 'big_item' under 'enlargement_case' ('Wide'/'Tall' - see
+     * 'could_fit_both' for "both").
+     *
+     * When it returns 'true' for at least one candidate, this is only
+     * ever a necessary, not sufficient, geometric pre-filter used to keep
+     * 'try_reduce_group''s check candidate set small: the actual
+     * 'Objective::Feasibility' solve it builds from it is what actually
+     * proves feasibility, so an overly *generous* filter can never cause
+     * an unsound reduction there, only a slower/less effective search.
+     *
+     * But when it comes back 'false' for *every* candidate against a
+     * given big item, 'try_reduce_group' also relies on that as *proof*
+     * nothing could ever fit at all, with no verifying solve behind that
+     * claim (see its own doc comment for 'trivially_feasible') - so an
+     * overly *restrictive* filter (missing a combination that actually
+     * fits) is unsound in that direction specifically, not merely less
+     * effective.
+     */
+    bool could_fit(
+            EnlargementCase enlargement_case,
+            const ReductionItemType& big_item,
+            ItemTypeId item_type_id,
+            const ReductionItemType& item,
+            Length bin_w,
+            Length bin_h) const;
+
+    /**
+     * Same as 'could_fit', for a "both"-big item - see there for the
+     * general contract (necessary-not-sufficient pre-filter for
+     * 'try_reduce_both_group''s own real solve; proof of "nothing fits at
+     * all" for its own 'trivially_feasible').
+     *
+     * Takes 'big_item_type_id' in addition to 'big_item' (unlike
+     * 'could_fit', which only ever needs the *candidate*'s own 'oriented'
+     * flag): "both" uniquely also needs the *big* item's own 'oriented'
+     * flag, to know whether trying its rotated presentation is even
+     * allowed - checked against *every* orientation the big item could
+     * actually use, not just its declared form, since under-checking here
+     * would let 'trivially_feasible' wrongly "prove" a companion could
+     * never fit, when it actually could alongside the big item's rotated
+     * presentation - not merely a missed opportunity, but a real
+     * unsoundness.
+     */
+    bool could_fit_both(
+            ItemTypeId big_item_type_id,
+            const ReductionItemType& big_item,
+            ItemTypeId item_type_id,
+            const ReductionItemType& item,
+            Length bin_w,
+            Length bin_h) const;
+
+    /**
+     * Dimensions of the companion bin built around 'big_item' for
+     * 'enlargement_case'. Only ever 'Wide'/'Tall': "both"'s own companion
+     * bin is always just 'bin_w'x'bin_h' directly (see
+     * 'try_reduce_both_group'), too trivial a formula to need a function
+     * of its own.
+     */
+    Rectangle companion_bin_dimensions(
+            EnlargementCase enlargement_case,
+            const ReductionItemType& big_item,
+            Length bin_w,
+            Length bin_h) const;
+
+    /**
+     * Position, relative to the big item's own bottom-left corner in the
+     * final packing, of a companion item placed at 'bl_corner_in_check' in
+     * the companion-bin check, for 'enlargement_case'. Only ever
+     * 'Wide'/'Tall' (called by 'try_reduce_group'): "both" needs no
+     * relative offset at all, since 'try_reduce_both_group' captures and
+     * replays the check's own absolute positions directly - see
+     * 'BothGroup'.
+     */
+    Point compute_offset(
+            EnlargementCase enlargement_case,
+            const ReductionItemType& big_item,
+            Point bl_corner_in_check) const;
+
+    /**
+     * Not-yet-removed item types eligible as "big" items for
+     * 'enlargement_case' ('Wide'/'Tall' - see 'gather_sorted_both_big_items'
+     * for "both"), sorted non-increasing. Deliberately does not exclude
+     * already-enlarged item types: 'is_big'/'could_fit'/
+     * 'companion_bin_dimensions' all read the item's *current* dimensions,
+     * so an item already enlarged on one axis (say wide, now spanning the
+     * bin's full width) can still be genuinely "big" - or not - on another
+     * (tall); its current width simply becomes part of that other axis's
+     * own companion-strip search (a strictly more powerful search than
+     * using its original width would give, since the strip now spans the
+     * bin's full width too). An item already fully enlarged on a given
+     * axis (current dimension already at the target) is naturally handled
+     * by the existing degenerate-companion-bin path in 'try_reduce_group'
+     * (zero/negative area), not by excluding it here.
+     */
+    std::vector<ItemTypeId> gather_sorted_big_items(
+            const std::vector<ReductionItemType>& reduction_item_types,
+            EnlargementCase enlargement_case,
+            Length bin_w,
+            Length bin_h);
+
+    /**
+     * Same as 'gather_sorted_big_items', for "both"-big items. Its own
+     * "is big"/"strict ordering" logic (the "both" equivalent of
+     * 'is_big'/'size_greater') is inlined directly in the implementation
+     * rather than split into 'is_big_both'/'size_greater_both' functions
+     * of their own: each is only a few lines, with a single call site
+     * (this one), so a separate function would only add a name and a
+     * jump to follow without a matching gain in clarity.
+     *
+     * Unlike 'is_big', a non-oriented item is safe to admit as "both"-big:
+     * 'try_reduce_both_group' never pre-places or enlarges the big item
+     * in place at all - it captures and replays whatever
+     * position/rotation the companion-bin check itself found (see
+     * 'BothGroup'), so there is no shared, per-type state that would need
+     * a single orientation to stay consistent across every copy.
+     */
+    std::vector<ItemTypeId> gather_sorted_both_big_items(
+            const std::vector<ReductionItemType>& reduction_item_types,
+            Length bin_w,
+            Length bin_h);
+
+    /**
+     * 'true' iff 'companions_by_copy' (a candidate big item's
+     * not-yet-applied one) holds at least one real, solve-validated
+     * companion, as opposed to being entirely empty. Used by
+     * 'try_reduce_group' to decide whether a candidate that went through
+     * an actual companion-bin solve (alongside other candidates in the
+     * same group) ended up with anything assigned to it there - a
+     * candidate that didn't is left untouched, since nothing here proves
+     * its own strip couldn't have held something under a different
+     * grouping. Bypassed entirely when 'try_reduce_group''s own
+     * 'trivially_feasible' holds instead (see there): that case proves
+     * real emptiness up front, via the candidate scan itself rather than
+     * a solve, so every checked big item is enlarged unconditionally.
+     */
+    static bool has_validated_companions(
+            const std::vector<std::vector<CompanionItem>>& companions_by_copy);
+
+    /**
+     * Extracts (and removes) the first 'copies_to_consume' entries of
+     * 'item.companions_by_copy', for a caller about to consume that many
+     * of 'item''s copies into a 'FullBinItem'/'PerfectPair'/'BothGroup'
+     * (see whichever's own 'companions'/'companions_by_copy' field, or
+     * 'CompanionItem::nested_companions' when the caller is itself
+     * absorbing 'item' as a companion) - leaving the rest behind for
+     * whatever of 'item''s own copies still remain in the working
+     * representation afterwards. Returns 'copies_to_consume' empty
+     * placeholder entries if 'item.companions_by_copy' is itself empty
+     * (never enlarged; nothing to capture). Requires
+     * 'item.companions_by_copy.size() == item.copies' whenever it is
+     * non-empty (true by construction: 'try_reduce_group''s own
+     * 'enlarge()' step - the only place this field is ever grown, see
+     * 'ReductionItemType::companions_by_copy''s own doc comment - keeps
+     * it sized to the copies count at that moment, and every caller of
+     * this function keeps the two in lockstep by decrementing
+     * 'item.copies' by the same 'copies_to_consume' it extracts here).
+     */
+    static std::vector<std::vector<CompanionItem>> extract_companions(
+            ReductionItemType& item,
+            ItemPos copies_to_consume);
+
+    /**
+     * Shared implementation of the wide/tall sub-cases (see
+     * 'reduce_both_groups' for "both", which needs different enough
+     * control flow - captured-and-replayed dedicated bins instead of an
+     * in-place enlargement - not to share this): follows the paper's
+     * sorted, incrementally-growing candidate search (singletons, then
+     * growing multi-item groups, restarting after each success), using an
+     * 'Objective::Feasibility' solve (small time/node budget) as the
+     * packing-check primitive instead of the paper's bespoke greedy
+     * heuristic. Returns 'true' iff at least one item type was reduced.
+     */
+    bool reduce_group(
+            std::vector<ReductionItemType>& reduction_item_types,
+            const ReductionParameters& parameters,
+            EnlargementCase enlargement_case,
+            Length bin_w,
+            Length bin_h);
+
+    /**
+     * Attempt to prove that every not-yet-removed item type satisfying
+     * 'could_fit' for some item in 'candidate_big_item_ids' can be packed
+     * into the companion bins built around 'candidate_big_item_ids' (one
+     * bin type per candidate, 'copies' companion-bin instances each). On
+     * success, applies the reduction in place (marking absorbed items
+     * removed and appending the newly found companions onto each
+     * candidate's own 'companions_by_copy' - a candidate may already hold
+     * companions found by an earlier axis, which are kept, not discarded)
+     * and returns 'true'. Only ever called for 'EnlargementCase::Wide'/
+     * 'Tall' - see 'reduce_both_groups'/'try_reduce_both_group' for the
+     * "both" case's own, separate implementation.
+     *
+     * The R-candidate scan only ever excludes 'removed' item types, never
+     * merely already-'enlarged' ones - checking each candidate's
+     * *current* dimensions, which stay safe to use even though they may
+     * be inflated (an item can only ever be enlarged on an axis where it
+     * already qualified as "big" there, and "big" on an axis is exactly
+     * what disqualifies it from passing *any* companion check on that
+     * same axis - the foundational argument behind wide/tall/both itself
+     * - so its current size on that axis fails 'could_fit' for the same
+     * reason its original size would have). Excluding an enlarged item
+     * type here would mean concluding "nothing could fit" using a
+     * narrower candidate pool than the original problem actually offers,
+     * which is unsound: an item that only happens to already be spoken
+     * for elsewhere in *this* reduction's own bookkeeping could still
+     * have been the thing a true optimal solution shares this space with
+     * (found via a concrete counterexample: a 7x4 "wide" item and a 2x8
+     * "tall" item, in a 10x10 bin, each independently found companionless
+     * by their *own* strip check and enlarged to their respective full
+     * dimensions - but a 7-wide row and a full-height 2-wide column
+     * cannot coexist in one bin, even though the two *original* items
+     * did, since the 2x8 item was always a valid, if ultimately
+     * non-fitting, width-only candidate for the 7x4 item's own strip;
+     * excluding it because it happened to already be enlarged elsewhere
+     * let that candidate silently vanish from the scan). If absorbed
+     * here, an already-enlarged companion's own real companions (if any)
+     * are captured directly into 'CompanionItem::nested_companions' in
+     * the "apply" step below, rather than orphaned.
+     *
+     * When 'candidate_r_ids' comes back completely empty - genuinely
+     * nothing, from that same permissive candidate pool, passes
+     * 'could_fit' for *any* checked big item - every checked big item is
+     * unconditionally, safely enlarged with zero companions
+     * ('trivially_feasible' below): equation (8)'s ("enlarging the
+     * items", Côté, Haouari & Iori 2019/2021 Section 4.1) "empty group"
+     * case, proven here by the scan itself rather than by an actual
+     * solve. This never applies to a *degenerate* big item (zero/negative
+     * area companion bin - its own dimensions already reached the bin's
+     * on that axis): those are excluded from 'checked_big_item_ids' up
+     * front and never touched by this function at all, which is
+     * important - a degenerate companion bin means "no room to check",
+     * not "checked and found empty", so it must never by itself justify
+     * enlarging (that would burn the item type on a pure no-op for zero
+     * gain, while permanently excluding it from a possibly better later
+     * reduction - concretely, two items each already spanning the bin's
+     * full height, making their own "tall" companion strip degenerate,
+     * that together would have formed a real 'PerfectPair', except one of
+     * them got claimed here first, with zero benefit, before
+     * 'reduce_perfect_pairs' ever got a chance to see it).
+     */
+    bool try_reduce_group(
+            std::vector<ReductionItemType>& reduction_item_types,
+            const ReductionParameters& parameters,
+            EnlargementCase enlargement_case,
+            Length bin_w,
+            Length bin_h,
+            const std::vector<ItemTypeId>& candidate_big_item_ids);
+
+    /**
+     * A single dedicated bin built directly from a "both" companion-bin
+     * feasibility check (see 'try_reduce_both_group'): unlike the
+     * wide/tall cases (which enlarge a surviving big item type in place
+     * and record its companions relative to it - see
+     * 'CompanionItem::offset'), a "both" group is captured and replayed
+     * exactly as the check's own solution found it, the same way
+     * 'PerfectPair' captures two exactly-fitting item types directly
+     * instead of enlarging one of them.
+     *
+     * Different copies of the same big item type's companion bin can end
+     * up with genuinely different contents, or the big item placed with a
+     * different rotation (since the big item is offered to the check as
+     * an ordinary, freely placeable - and, if non-oriented, freely
+     * rotatable - item rather than pre-fixed at a single position; see
+     * 'try_reduce_both_group') - so, unlike 'FullBinItem'/'PerfectPair',
+     * there is no shared 'copies' count here: each dedicated bin this
+     * reduction found is its own separate entry.
+     */
+    struct BothGroup
+    {
+        struct PlacedItem
+        {
+            /** Item type id (original instance's id space). */
+            ItemTypeId item_type_id;
+
+            Point bl_corner;
+
+            bool rotate;
+
+            /**
+             * This item's own pre-existing real companions, if it was
+             * already enlarged (on a different axis, in an earlier
+             * round) before being absorbed into this group - captured
+             * the same way as 'FullBinItem::companions_by_copy' (see
+             * there), but a single copy's worth, since each 'BothGroup'
+             * is itself already one specific copy/dedicated bin.
+             */
+            std::vector<CompanionItem> companions;
+        };
+
+        /**
+         * Every item placed in this one dedicated bin: the big item
+         * itself plus whichever real companions the feasibility check
+         * found alongside it.
+         */
+        std::vector<PlacedItem> items;
+    };
+
+    /**
+     * "Both" group reduction: unlike 'reduce_group' (shared by the
+     * wide/tall cases), each companion-bin feasibility check's own
+     * solution is captured and replayed directly as one or more dedicated
+     * bins (see 'BothGroup' and 'try_reduce_both_group'), rather than
+     * enlarging a surviving big item type in place. Follows the same
+     * sorted, incrementally-growing candidate search as 'reduce_group'.
+     * Returns 'true' iff at least one dedicated bin was found.
+     */
+    bool reduce_both_groups(
+            std::vector<ReductionItemType>& reduction_item_types,
+            const ReductionParameters& parameters,
+            Length bin_w,
+            Length bin_h);
+
+    /**
+     * Attempt to prove that every not-yet-removed item type satisfying
+     * 'could_fit_both' for some item in 'candidate_big_item_ids' can be
+     * packed, alongside its own big item, into a companion bin of size
+     * 'bin_w'x'bin_h' (the "both" case's companion bin is always the full
+     * shrunk bin, never a strip). Unlike 'try_reduce_group', the big item
+     * is *not* pre-placed as a fixed item: it is offered to the check as
+     * an ordinary item, with its own true 'oriented' flag, free to be
+     * placed - and, if non-oriented, rotated - however the solve likes.
+     *
+     * Every candidate's own big item shares one single companion bin type
+     * with every other candidate in the group (rather than each getting
+     * its own, eligibility-restricted one, as an earlier version of this
+     * function did): nothing needs to keep two different candidates'
+     * big items from ever landing in the same bin instance, because
+     * geometry already guarantees it can't happen - two "both"-big items
+     * (each spanning more than half of *both* the bin's dimensions, by
+     * definition - see 'gather_sorted_both_big_items') can never
+     * simultaneously fit in one 'bin_w'x'bin_h' bin, regardless of where
+     * either is placed. So a
+     * solved bin instance holds at most one candidate's big item purely
+     * by construction, and the interpretation step below can just read
+     * off which one (if any) directly from that bin's own contents.
+     *
+     * On success, each distinct bin the check's own solution built becomes
+     * its own 'BothGroup' entry (see there for why no shared 'copies'
+     * count is used), and every item placed in it - the big item and
+     * every real companion - is removed from the working representation,
+     * capturing whatever companions it may already have had of its own.
+     * A candidate big item that ends up with zero bin instances actually
+     * used (possible, since the shared companion bin type's 'copies_min'
+     * is 0 - the solver only needs to use as many bin instances as it
+     * takes to place every big item and R-candidate somewhere) is left
+     * completely untouched, the same way 'try_reduce_group' leaves an
+     * unused candidate alone - though in practice, since every big item
+     * is itself mandatory and a bin holds at most one, exactly as many
+     * bin instances end up used as there are big item copies offered in
+     * total, so this only matters if the check fails to find a solution
+     * at all (handled separately, via 'check_solution.full()').
+     *
+     * Respects the same bin type copies cap as
+     * 'reduce_full_bin_items'/'reduce_perfect_pairs', since every group
+     * here becomes its own dedicated bin outside the reduced instance's
+     * own bin type copies - checked once, over the *total* number of
+     * dedicated bins this call would add across every candidate at once,
+     * declining the whole batch if it would not fit rather than partially
+     * committing: an R-candidate's own copies can end up split across
+     * several different big items' companion bins by the check, with no
+     * simple way to tell which specific placement belongs to which
+     * candidate once only some of them are declined ("sound, just less
+     * effective" - as elsewhere in this class).
+     *
+     * When 'candidate_r_ids' comes back completely empty - genuinely
+     * nothing, from the same 'removed'-only-excluded candidate pool,
+     * passes 'could_fit_both' for *any* candidate big item - each
+     * candidate is independently, unconditionally captured as its own
+     * single-item dedicated bin (still subject to the same bin type
+     * copies cap, and to determining which orientation actually fits,
+     * per candidate):
+     * equation (8)'s ("enlarging the items", Côté, Haouari & Iori
+     * 2019/2021 Section 4.1) "empty group" case, proven here by the scan
+     * itself rather than by an actual solve - no group solve is needed
+     * (or possible: "both"'s companion bin is always the full 'bin_w'x
+     * 'bin_h' bin, never degenerate, so there is no analogous
+     * degenerate/checked-empty distinction to make the way
+     * 'try_reduce_group' must for its own strips).
+     *
+     * Returns 'true' iff at least one dedicated bin was found this way.
+     */
+    bool try_reduce_both_group(
+            std::vector<ReductionItemType>& reduction_item_types,
+            const ReductionParameters& parameters,
+            Length bin_w,
+            Length bin_h,
+            const std::vector<ItemTypeId>& candidate_big_item_ids);
+
+    /**
+     * A single item type whose own dimensions (in some allowed
+     * orientation) already exactly match the bin's: it fills a bin by
+     * itself, so nothing else could ever share a bin with it (see
+     * 'reduce_full_bin_items'). Set aside as 'copies' dedicated bins the
+     * same way as a 'PerfectPair', just with one item per bin instead of
+     * two.
+     *
+     * In practice, such an item is already "both"-big (an exact match
+     * trivially satisfies the "both"-big condition on both axes - see
+     * 'gather_sorted_both_big_items') with no room left for any companion
+     * (its own dimensions already consume the entire companion bin), so
+     * 'try_reduce_both_group' - which runs earlier in the same round, in
+     * the constructor's own outer fixpoint loop - already captures it
+     * directly via its own 'trivially_feasible' path (see there) before
+     * 'reduce_full_bin_items' ever gets a turn.
+     * 'reduce_full_bin_items' remains as the direct, explicit dimension
+     * check regardless - simpler and more obviously correct to state on
+     * its own terms than reasoning transitively through "both"'s own
+     * companion-search machinery, even if the latter now reaches the same
+     * conclusion first in the common case.
+     */
+    struct FullBinItem
+    {
+        /** Item type id (original instance's id space). */
+        ItemTypeId item_type_id;
+
+        /** Whether the item is rotated to match the bin. */
+        bool rotate;
+
+        /** Number of dedicated bins (one per copy of the item type). */
+        BinPos copies;
+
+        /**
+         * Companions of 'item_type_id' itself, one entry per copy
+         * consumed here, captured (moved out of the working
+         * 'ReductionItemType::companions_by_copy') at the moment this
+         * item type was claimed - empty entries if it was never enlarged.
+         * An item type reaching this point can already carry real,
+         * solve-validated companions of its own (see
+         * 'reduce_full_bin_items''s own doc comment for why that is no
+         * longer excluded): those companions still need to end up
+         * somewhere in the final solution, so they travel with this
+         * record instead of being silently dropped, and 'unreduce_solution'
+         * places them recursively alongside 'item_type_id'.
+         */
+        std::vector<std::vector<CompanionItem>> companions_by_copy;
+    };
+
+    /**
+     * For every not yet removed item type whose *current* dimensions (in
+     * some allowed orientation) exactly match 'bin_w'x'bin_h', removes it
+     * from the instance and records it in 'full_bin_items_'. Returns
+     * 'true' iff at least one item type was reduced.
+     *
+     * 'bin_w'/'bin_h' are the *shrunk* bin dimensions (equation (7),
+     * "shrinking the bins": see 'compute_shrunk_bin_sizes'), not the
+     * bin's true ones - the largest achievable combination of *original*
+     * item widths/heights not exceeding the true bin's. If an item's width already equals
+     * that maximum, no other item's width can be small enough to add
+     * anything to it without exceeding the maximum itself - a
+     * contradiction - so the true bin's remaining margin on that axis is
+     * guaranteed permanently unusable by anything else, symmetrically for
+     * height, jointly covering the entire L-shaped leftover region around
+     * the item. This is why a single "current dimensions" check suffices
+     * here, unlike an earlier version of this function, which separately
+     * checked an item's *current* dimensions against the *true* bin
+     * *and* its *original* dimensions against the *shrunk* bin as two
+     * independent regimes: once every enlargement target in the class
+     * uses the same shrunk value ('bin_w'/'bin_h', passed uniformly to
+     * every wide/tall/both helper - see 'is_big' and friends above), an
+     * item that was never touched already has current == original
+     * dimensions, and an item that *was* enlarged already has its current
+     * dimensions reflecting that same shrunk target - so checking current
+     * dimensions against the (now uniformly shrunk) 'bin_w'/'bin_h'
+     * covers both cases at once.
+     *
+     * An item type here may already carry companions - with zero of them
+     * (companionlessly, on one axis only, which may now newly bring it to
+     * an exact match on both), or with real, solve-validated companions
+     * of its own (see 'FullBinItem::companions_by_copy', which captures
+     * and carries them along instead of orphaning them - unlike an even
+     * earlier version of this function, which excluded already-enlarged
+     * item types entirely to sidestep that; see the git history for why
+     * that exclusion turned out to be the wrong fix).
+     *
+     * Sound for the same reason a 'PerfectPair' is: such an item can
+     * never share a bin with anything else in any solution (it already
+     * fills the entire bin by itself, taking into account permanently
+     * unusable margin, and taking into account its own real companions -
+     * if any - which are captured and travel with it), so setting it
+     * aside in its own dedicated bin never requires more bins than that
+     * solution already used. Respects the same bin type copies cap as
+     * 'reduce_perfect_pairs' (shared via 'number_of_dedicated_bins'), for
+     * the same reason.
+     */
+    bool reduce_full_bin_items(
+            std::vector<ReductionItemType>& reduction_item_types,
+            Length bin_w,
+            Length bin_h);
+
+    /**
+     * A "perfect pair": two item types that, together (each in some
+     * allowed orientation), exactly tile the bin via a single guillotine
+     * split - side by side, both spanning the bin's full height, widths
+     * summing to its full width; or stacked, both spanning its full
+     * width, heights summing to its full height. Unlike the
+     * wide/tall/both cases (which enlarge a surviving item type and
+     * remove its companions), *both* item types of a perfect pair are
+     * removed from the instance entirely: nothing else could ever share
+     * a bin with either of them (see 'reduce_perfect_pairs'), so the
+     * pair is set aside as 'copies' fixed, dedicated bins instead of
+     * being handed to the underlying solver at all. Reinstated as extra
+     * bins in 'unreduce_solution', and folded into the reduced
+     * instance's bin type copies in 'reduction_to_instance'.
+     */
+    struct PerfectPair
+    {
+        /**
+         * First item type id (original instance's id space); placed at a
+         * dedicated bin's bottom-left corner, never rotated. Both item
+         * types of a pair are required to be 'oriented' (see
+         * 'reduce_perfect_pairs''s own doc comment for why), so there is
+         * no rotated form to ever record for either one.
+         */
+        ItemTypeId item_type_id_1;
+
+        /** Second item type id (original instance's id space); never rotated either. */
+        ItemTypeId item_type_id_2;
+
+        /** Position of the second item's bottom-left corner. */
+        Point offset_2;
+
+        /** Number of dedicated bins (one per copy of the pair; both item types have this many copies). */
+        BinPos copies;
+
+        /**
+         * Companions of 'item_type_id_1', captured the same way as
+         * 'FullBinItem::companions_by_copy' (see there) - empty entries
+         * if it was never enlarged. One entry per copy consumed here.
+         */
+        std::vector<std::vector<CompanionItem>> item_1_companions_by_copy;
+
+        /** Companions of 'item_type_id_2', same as 'item_1_companions_by_copy' but for the second item type. */
+        std::vector<std::vector<CompanionItem>> item_2_companions_by_copy;
+    };
+
+    /**
+     * "Perfect pair" reduction: for every pair of distinct, not yet
+     * removed item types - either side may already carry companions, with
+     * zero of them (companionlessly) or with real, solve-validated
+     * companions of its own, which are captured into
+     * 'PerfectPair::item_1_companions_by_copy'/'item_2_companions_by_copy'
+     * rather than orphaned (see 'reduce_full_bin_items''s own doc comment
+     * for the same point spelled out for a single item) - consumes
+     * 'min(copies_1, copies_2)' copies from each side and records the
+     * pair in 'perfect_pairs_' if their *current* dimensions form a
+     * 'PerfectPair' against 'bin_w'x'bin_h'.
+     *
+     * 'bin_w'/'bin_h' are the *shrunk* bin dimensions, exactly as for
+     * 'reduce_full_bin_items' - see that function's own doc comment for
+     * why a single "current dimensions" check against the (uniformly
+     * shrunk, throughout the class) bin dimensions now suffices here too,
+     * where an earlier version of this function tried two independent
+     * regimes (current dimensions against the true bin, or original
+     * dimensions against the shrunk bin) separately.
+     *
+     * Returns 'true' iff at least one pair was reduced.
+     *
+     * Sound by a "slide together" exchange argument distinct from the
+     * wide/tall/both cases' own: since one item of the pair spans
+     * 'bin_w'/'bin_h' by construction, it is forced to do so in *every*
+     * bin it could ever be placed in (its own height already equals the
+     * bin's, taking into account the same permanently-unusable margin
+     * argument as 'reduce_full_bin_items''s own), so whatever shares a
+     * bin with it is confined to one or two same-height strips together
+     * summing to exactly the other item's own width - which can always be
+     * reassembled, by simple translation, into a single bin alongside
+     * whatever shared the *other* item's own bin. So setting them aside
+     * together in one dedicated bin, wherever they individually end up in
+     * any solution, never requires more bins than that solution already
+     * used.
+     *
+     * Both item types of a pair are required to be 'oriented' - unlike
+     * 'reduce_full_bin_items', this cannot soundly be relaxed for a
+     * non-oriented item. That function's own rotation handling is safe
+     * because matching *both* bin dimensions at once forces a non-square
+     * bin's declared (non-rotated) form to be geometrically infeasible in
+     * that same bin - the item is *effectively* oriented there regardless
+     * of the flag. A perfect pair only matches *one* bin dimension, which
+     * leaves the item's other dimension unconstrained: its declared form
+     * typically remains perfectly valid too, so nothing forces it into
+     * the "spans this dimension" role the "slide together" argument above
+     * depends on - a true optimal solution could legitimately place it
+     * the other way, sharing its bin with something this reduction never
+     * considered. Committing such an item to a dedicated bin here could
+     * then overstate the bins truly required, corrupting not just the
+     * primal solution but 'bin_packing_bound' itself (this reduction's
+     * dedicated-bin count is added directly onto it - see
+     * 'optimize()' - so it must never be an overcount).
+     *
+     * Pairs 'min(copies_1, copies_2)' copies (rather than requiring equal
+     * copies) by consuming that many from 'ReductionItemType::copies' on
+     * *both* sides: whichever side reaches zero is marked 'removed', but a
+     * side with more copies than its partner keeps its leftover copies
+     * and stays present in the reduced instance as an ordinary
+     * (non-removed) item type - e.g. a pair with 2 and 4 copies fixes 2
+     * dedicated bins and removes the 2-copy item type entirely, leaving
+     * the other with 2 copies still to be packed normally. Never reserves
+     * more dedicated bins than the bin type actually has copies for
+     * (skipping a pair that would otherwise overrun it, leaving both item
+     * types for the underlying solver instead) - this keeps the
+     * subtraction in 'reduction_to_instance' from ever going negative, so
+     * no separate infeasibility bookkeeping is needed here.
+     */
+    bool reduce_perfect_pairs(
+            std::vector<ReductionItemType>& reduction_item_types,
+            Length bin_w,
+            Length bin_h);
+
+    /** Build the final reduced 'Instance' from the working representation. */
+    Instance reduction_to_instance(
+            const std::vector<ReductionItemType>& reduction_item_types);
+
+    struct ShrunkBinSizes
+    {
+        /** Shrunk bin width (W*, equation (7)). */
+        Length bin_width;
+
+        /** Shrunk bin height (equation (7)'s height variant). */
+        Length bin_height;
+    };
+
+    /**
+     * "Shrinking the bins" (Côté, Haouari & Iori, 2019/2021, Section 4.1,
+     * equation (7)), following Alvarez-Valdes et al. (2009): the bin's own
+     * width can be shrunk down to the largest achievable combination of
+     * item widths that does not exceed it - no combination of items can
+     * ever use more of the bin's width than that regardless, so treating
+     * the bin as this narrower "shrunk" width changes nothing about which
+     * combinations of items can validly share a row, while tightening any
+     * test compared against the bin's width (e.g. "wide" item
+     * thresholds). Symmetric for height. Only meaningful for instances
+     * with a single bin type and finite item copies (an infinite-copies
+     * item type can already saturate any capacity on its own, and can't be
+     * flattened into individual units below); returns the instance's own
+     * (unchanged) bin dimensions for every other case.
+     *
+     * Computed via 'multiplechoicesubsetsumsolver' (as in
+     * 'boxstacks::TreeSearch''s own "lift length" computation): one group
+     * per item copy, containing one candidate value per orientation the
+     * item type is allowed to present on this axis (its declared
+     * dimension, plus its rotated one too if not 'oriented') - the solver
+     * picks *at most* one candidate per group (a group can contribute
+     * nothing at all, i.e. that copy sits out of this particular
+     * combination), maximizing the total not exceeding the bin's true
+     * dimension on that axis. This is what lets a non-oriented item
+     * participate soundly, unlike a plain (single-choice) subset sum:
+     * each axis's computation independently picks whichever orientation
+     * of a given copy contributes more, without needing that choice to
+     * also be consistent with what the *other* axis's own (separately
+     * computed) combination picked for the same copy - the two
+     * computations never claim their respective maxima are
+     * simultaneously achievable by one real arrangement, only that
+     * neither individually is ever exceeded by anything real, which is
+     * all equation (7) needs.
+     */
+    static ShrunkBinSizes compute_shrunk_bin_sizes(const Instance& instance);
+
+    /*
+     * Private attributes
+     */
+
+    /** Original instance. */
+    const Instance* original_instance_ = nullptr;
+
+    /** Reduced instance. */
+    Instance instance_;
+
+    /** See 'proven_infeasible()'. */
+    bool proven_infeasible_ = false;
+
+    /**
+     * "Full bin item" reservations found while building 'instance_' (see
+     * 'reduce_full_bin_items'/'FullBinItem'). Indexed by discovery order,
+     * not by item type id.
+     */
+    std::vector<FullBinItem> full_bin_items_;
+
+    /**
+     * "Perfect pair" reservations found while building 'instance_' (see
+     * 'reduce_perfect_pairs'/'PerfectPair'). Indexed by discovery order,
+     * not by item type id.
+     */
+    std::vector<PerfectPair> perfect_pairs_;
+
+    /**
+     * "Both" group reservations found while building 'instance_' (see
+     * 'reduce_both_groups'/'BothGroup'). Indexed by discovery order, not
+     * by item type id; each entry is already its own single dedicated
+     * bin (unlike 'full_bin_items_'/'perfect_pairs_', there is no
+     * separate 'copies' multiplier to expand).
+     */
+    std::vector<BothGroup> both_groups_;
+
+    /**
+     * The reduction's final bookkeeping for *every* original item type
+     * ('companions_by_copy' is empty for item types that were left
+     * untouched), survivor in the reduced instance or not - unlike a
+     * removed/consumed item type, which never appears in the reduced
+     * instance at all, this still needs to be reachable so
+     * 'unreduce_solution' can recursively resolve a companion (of a
+     * 'FullBinItem', a 'PerfectPair', or another companion) that turns
+     * out to have had real companions of its own.
+     *
+     * Indexed by the *original* instance's own item type ids (a direct
+     * copy of the working representation's own indexing - see
+     * 'ReductionItemType''s own doc comment): populated once, when the
+     * working representation is finalized into the reduced instance (see
+     * 'reduction_to_instance').
+     */
+    std::vector<ReductionItemType> final_item_types_;
+
+    /**
+     * For each item type of the reduced instance, the corresponding item
+     * type id in the original instance (removing items shifts ids, so this
+     * is never the identity mapping in general). Indexed by the reduced
+     * instance's own item type ids: populated once, alongside
+     * 'final_item_types_' (see 'reduction_to_instance').
+     */
+    std::vector<ItemTypeId> reduced_to_original_item_type_ids_;
+
+    /**
+     * Places 'item_type_id' (original instance's id space) at 'bl_corner'
+     * (with 'rotate') into bin 'bin_pos' of 'solution_builder', then
+     * recursively places each of 'companions' at its own recorded offset
+     * relative to 'bl_corner', and, for any companion whose own
+     * 'CompanionItem::nested_companions' is non-empty (an already-enlarged
+     * item type absorbed as someone else's companion - see
+     * 'CompanionItem''s own doc comment for why this is legitimate and
+     * not merely a defensive possibility), that companion's own nested
+     * companions too, and so on to arbitrary depth. Each 'CompanionItem'
+     * carries everything needed for its own subtree directly - no lookup
+     * into 'final_item_types_' needed here (that is only for the
+     * *top-level* item being placed, whose own companions come from
+     * 'final_item_types_' at the call site instead - see
+     * 'unreduce_solution').
+     */
+    void place_item_and_companions(
+            SolutionBuilder& solution_builder,
+            BinPos bin_pos,
+            ItemTypeId item_type_id,
+            Point bl_corner,
+            bool rotate,
+            const std::vector<CompanionItem>& companions) const;
+
+};
+
+}
+}

--- a/src/rectangle/CMakeLists.txt
+++ b/src/rectangle/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(PackingSolver_rectangle PRIVATE
     benders_decomposition.cpp
     dual_feasible_functions.cpp
     conservative_scales.cpp
+    reduction.cpp
     block.cpp
     tree_search_maximal_spaces.cpp)
 target_include_directories(PackingSolver_rectangle PUBLIC
@@ -25,6 +26,7 @@ target_link_libraries(PackingSolver_rectangle PUBLIC
     TreeSearchSolver::treesearchsolver
     Shape::shape
     MathOptSolversCMake::mathopt
+    MultipleChoiceSubsetSumSolver::dynamic_programming_bellman
     Threads::Threads)
 # Resource limits: the portable RSS reader in
 # include/packingsolver/algorithms/thread_pool.hpp uses GetProcessMemoryInfo on

--- a/src/rectangle/dual_feasible_functions.cpp
+++ b/src/rectangle/dual_feasible_functions.cpp
@@ -270,8 +270,12 @@ DualFeasibleFunctionsTables compute_dual_feasible_functions_tables(
     // e.g. an item that is "big" in both orientations, on both axes, needs
     // this breakpoint to be recognized as such if no item dimension is
     // exactly at half the bin's capacity).
-    tables.widths.push_back(bin_type.rect.x / 2);
-    tables.heights.push_back(bin_type.rect.y / 2);
+    // A breakpoint of 0 is never valid (f_ccm_0/f_ccm_1/f_ccm_2 all divide
+    // by k), which capacity / 2 degenerates to when capacity is 1.
+    if (bin_type.rect.x / 2 > 0)
+        tables.widths.push_back(bin_type.rect.x / 2);
+    if (bin_type.rect.y / 2 > 0)
+        tables.heights.push_back(bin_type.rect.y / 2);
     sort(tables.widths.begin(), tables.widths.end());
     sort(tables.heights.begin(), tables.heights.end());
     tables.widths.erase(unique(tables.widths.begin(), tables.widths.end()), tables.widths.end());

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -577,6 +577,93 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
     algorithm_formatter.start();
     algorithm_formatter.print_header();
 
+    // "Packing and removing some items" reduction (see 'Reduction'):
+    // applied once, upfront, wrapping the whole dispatch logic below
+    // uniformly for every algorithm (mirroring how e.g. setcoveringsolver's
+    // 'Reduction' wraps its own algorithms generically). Gated on
+    // 'Reduction::applies' directly, rather than constructing a
+    // 'Reduction' unconditionally and letting its constructor no-op: when
+    // it would not apply anyway (wrong objective, multiple bin types,
+    // 'parameters.reduction_parameters.reduce' itself 'false', ...), this
+    // skips it entirely instead of paying for (and discarding) a full
+    // pass building its working representation - see 'applies''s own doc
+    // comment. 'reduced_parameters.reduction_parameters.reduce' is set to
+    // 'false' below to avoid re-running the reduction recursively on the
+    // already-reduced instance: 'applies' only checks instance-level
+    // characteristics (objective, single bin type, ...), which the
+    // reduced instance still satisfies just as well as the original one,
+    // so without this it would gate 'true' again there too - a pass that
+    // can only ever find nothing new (the reduction already ran to a
+    // fixpoint), just at the cost of a wasted full pass to confirm it.
+    if (Reduction::applies(instance, parameters.reduction_parameters)) {
+        ReductionParameters reduction_parameters = parameters.reduction_parameters;
+        reduction_parameters.timer = parameters.timer;
+        Reduction reduction(instance, reduction_parameters);
+
+        if (reduction.proven_infeasible()) {
+            // The reduction alone already proves the instance infeasible
+            // (a bin type's dedicated bins exhausted its copies while real
+            // items were still left over - see 'Reduction::instance()''s
+            // doc): 'reduction.instance()' is not meaningful to solve at
+            // all, so skip straight to reporting the answer.
+            algorithm_formatter.update_is_proven_infeasible();
+            algorithm_formatter.end();
+            return output;
+        }
+        // Forwards a solution/bound found for the reduced instance to the
+        // original 'algorithm_formatter', in original-instance coordinates.
+        // Most bounds need no reduction-specific translation at all:
+        // removing items via this reduction never changes them (cost,
+        // feasibility, ...), so 'reduced_output's bounds already are the
+        // original instance's bounds, in exactly 'Output's own field
+        // layout. The one exception is the dedicated bins set aside
+        // outside the reduced instance (see
+        // 'Reduction::number_of_dedicated_bins'): entirely absent from the
+        // reduced instance, so no solve on it can ever count them - add
+        // them back onto the bin-count bounds, in a local copy, before
+        // letting 'update_bounds' read off the one relevant to the current
+        // objective.
+        auto report_reduced_output = [&reduction, &instance, &algorithm_formatter](
+                const rectangle::Output& reduced_output)
+            {
+                algorithm_formatter.update_solution(
+                        reduction.unreduce_solution(reduced_output.solution_pool.best()),
+                        reduced_output.solution_pool.best_label());
+                rectangle::Output translated_output(reduced_output);
+                BinPos number_of_dedicated_bins = reduction.number_of_dedicated_bins();
+                if (number_of_dedicated_bins > 0) {
+                    translated_output.bin_packing_bound += number_of_dedicated_bins;
+                    translated_output.variable_sized_bin_packing_bound
+                        += number_of_dedicated_bins * instance.bin_type(0).cost;
+                }
+                algorithm_formatter.update_bounds(translated_output);
+            };
+
+        OptimizeParameters reduced_parameters = parameters;
+        reduced_parameters.verbosity_level = 0;
+        reduced_parameters.reduction_parameters.reduce = false;
+        // Forward every solution/bound the recursive solve finds to the
+        // original 'algorithm_formatter' as soon as it is found, rather
+        // than only once at the very end: this is what lets an anytime
+        // run on the reduced instance report live progress (in original-
+        // instance coordinates) the same way a direct, unreduced run
+        // would.
+        reduced_parameters.new_solution_callback = report_reduced_output;
+        Output reduced_output = optimize(reduction.instance(), reduced_parameters);
+        // Also report the final result explicitly: some sub-solves (e.g. a
+        // reduced instance left with zero items, fully captured into
+        // dedicated bins) never call 'new_solution_callback' at all, since
+        // there is nothing to search for or improve on - this guarantees
+        // the answer is still reported once regardless. Harmless to call
+        // again even when the callback already reported this exact result,
+        // since 'update_solution'/'update_bounds' are themselves no-ops
+        // for anything that doesn't improve on what is already recorded.
+        report_reduced_output(reduced_output);
+
+        algorithm_formatter.end();
+        return output;
+    }
+
     optimize_trivial_bound(instance, algorithm_formatter);
 
     if (instance.objective() == Objective::BinPacking

--- a/src/rectangle/reduction.cpp
+++ b/src/rectangle/reduction.cpp
@@ -1,0 +1,1507 @@
+#include "packingsolver/rectangle/reduction.hpp"
+
+#include "packingsolver/rectangle/instance_builder.hpp"
+#include "packingsolver/rectangle/optimize.hpp"
+#include "rectangle/solution_builder.hpp"
+
+#include "multiplechoicesubsetsumsolver/instance_builder.hpp"
+#include "multiplechoicesubsetsumsolver/algorithms/dynamic_programming_bellman.hpp"
+
+#include <algorithm>
+
+using namespace packingsolver;
+using namespace packingsolver::rectangle;
+
+namespace
+{
+
+/** Parameters for a companion-bin (or companion-strip) feasibility check. */
+OptimizeParameters build_check_parameters(
+        const ReductionParameters& parameters,
+        Solution* fixed_items)
+{
+    OptimizeParameters check_parameters;
+    check_parameters.verbosity_level = 0;
+    check_parameters.timer = parameters.timer;
+    check_parameters.optimization_mode = OptimizationMode::NotAnytimeDeterministic;
+    check_parameters.use_tree_search = true;
+    check_parameters.not_anytime_tree_search_queue_size = parameters.subproblem_queue_size;
+    check_parameters.fixed_items = fixed_items;
+    // Never reduce the check sub-instance itself: 'fixed_items' (when set)
+    // references its item type ids directly, which a nested reduction
+    // could renumber, and there is nothing to gain from reducing an
+    // already-tiny companion-bin check anyway.
+    check_parameters.reduction_parameters.reduce = false;
+    return check_parameters;
+}
+
+}
+
+bool Reduction::has_validated_companions(
+        const std::vector<std::vector<CompanionItem>>& companions_by_copy)
+{
+    for (const std::vector<CompanionItem>& companions: companions_by_copy) {
+        if (!companions.empty())
+            return true;
+    }
+    return false;
+}
+
+std::vector<std::vector<Reduction::CompanionItem>> Reduction::extract_companions(
+        ReductionItemType& item,
+        ItemPos copies_to_consume)
+{
+    // Callers always index the result as '[0, copies_to_consume)', so a
+    // never-enlarged item (empty 'companions_by_copy') still needs
+    // 'copies_to_consume' (empty) placeholder entries here, not a
+    // genuinely empty vector.
+    if (item.companions_by_copy.empty())
+        return std::vector<std::vector<CompanionItem>>(copies_to_consume);
+    std::vector<std::vector<CompanionItem>> extracted(
+            item.companions_by_copy.begin(),
+            item.companions_by_copy.begin() + copies_to_consume);
+    item.companions_by_copy.erase(
+            item.companions_by_copy.begin(),
+            item.companions_by_copy.begin() + copies_to_consume);
+    return extracted;
+}
+
+bool Reduction::try_reduce_group(
+        std::vector<ReductionItemType>& reduction_item_types,
+        const ReductionParameters& parameters,
+        EnlargementCase enlargement_case,
+        Length bin_w,
+        Length bin_h,
+        const std::vector<ItemTypeId>& candidate_big_item_ids)
+{
+    // Big items whose companion bin has zero (or negative) usable size
+    // already have their target dimension - no action needed at all, and
+    // no feasibility check either. Only the remaining ("checked") big
+    // items - genuine, positive-area companion bins - are eligible for
+    // enlargement below, whether via a real companion or (if nothing at
+    // all fits) the "empty group" case.
+    std::vector<ItemTypeId> checked_big_item_ids;
+    for (ItemTypeId big_item_type_id: candidate_big_item_ids) {
+        Rectangle bin_dims = companion_bin_dimensions(enlargement_case, reduction_item_types[big_item_type_id], bin_w, bin_h);
+        if (bin_dims.x > 0 && bin_dims.y > 0)
+            checked_big_item_ids.push_back(big_item_type_id);
+    }
+
+    // Candidate companion items (R): not removed, not one of the
+    // candidate big items themselves, and worth offering to at least one
+    // checked big item (a necessary, not sufficient, pre-filter; see
+    // 'could_fit'). An already-enlarged item type is *not* excluded: it
+    // is a perfectly legitimate companion, geometrically - excluding it
+    // would mean concluding "nothing could fit here" using a narrower
+    // candidate pool than the original problem actually offers, which is
+    // unsound (an item that only happens to already be spoken for
+    // elsewhere in *this* reduction's own bookkeeping could still have
+    // been the thing a true optimal solution shares this space with). If
+    // absorbed here, its own real companions (if any) are captured
+    // directly into
+    // 'CompanionItem::nested_companions' in the "apply" step below,
+    // rather than orphaned - see that field's own doc comment for why
+    // this must happen at the moment of absorption, not via a later
+    // lookup.
+    std::vector<ItemTypeId> candidate_r_ids;
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < (ItemTypeId)reduction_item_types.size();
+            ++item_type_id) {
+        const ReductionItemType& item = reduction_item_types[item_type_id];
+        if (item.removed)
+            continue;
+        if (std::find(
+                    candidate_big_item_ids.begin(),
+                    candidate_big_item_ids.end(),
+                    item_type_id) != candidate_big_item_ids.end()) {
+            continue;
+        }
+        bool fits_any = false;
+        for (ItemTypeId big_item_type_id: checked_big_item_ids) {
+            if (could_fit(enlargement_case, reduction_item_types[big_item_type_id], item_type_id, item, bin_w, bin_h)) {
+                fits_any = true;
+                break;
+            }
+        }
+        if (fits_any)
+            candidate_r_ids.push_back(item_type_id);
+    }
+
+    if (checked_big_item_ids.empty())
+        return false;
+
+    // For each checked big item, the resulting (per-copy) companion
+    // assignments, filled in below either trivially (empty) or from the
+    // sub-solve.
+    std::vector<std::vector<std::vector<CompanionItem>>> companions_by_big_item(
+            checked_big_item_ids.size());
+
+    // 'true' iff every checked big item here was proven, via the
+    // candidate scan above (not an actual solve), to have *nothing at
+    // all* that could ever share its companion bin - the "empty group"
+    // case of equation (8) ("enlarging the items"), Côté, Haouari & Iori
+    // 2019/2021 Section 4.1. Every checked big item is then safe to
+    // enlarge with zero companions unconditionally below, bypassing
+    // 'has_validated_companions' (which otherwise exists precisely to
+    // tell a genuine "nothing at all fits" apart from "this specific big
+    // item just wasn't assigned anything in *this* group's particular
+    // solve", the latter of which is a weaker claim - some other
+    // candidate in this same group absorbed the shared R-items instead,
+    // which says nothing about this big item's own strip in isolation,
+    // so it must still be left untouched, not enlarged).
+    bool trivially_feasible = false;
+
+    if (!candidate_r_ids.empty()) {
+        // Build the check sub-instance: one bin type (companion bin) per
+        // checked big item, 'copies' instances each; items = candidate R
+        // items.
+        InstanceBuilder check_instance_builder;
+        check_instance_builder.set_objective(Objective::Feasibility);
+        check_instance_builder.set_parameters(original_instance_->parameters());
+
+        std::vector<BinTypeId> check_bin_type_ids;
+        for (ItemTypeId big_item_type_id: checked_big_item_ids) {
+            const ReductionItemType& big_item = reduction_item_types[big_item_type_id];
+            ItemPos big_item_copies = big_item.copies;
+            Rectangle bin_dims = companion_bin_dimensions(enlargement_case, big_item, bin_w, bin_h);
+            BinTypeId check_bin_type_id = check_instance_builder.add_bin_type(bin_dims.x, bin_dims.y);
+            check_instance_builder.set_bin_type_copies(check_bin_type_id, big_item_copies);
+            check_instance_builder.set_bin_type_copies_min(check_bin_type_id, 0);
+            check_bin_type_ids.push_back(check_bin_type_id);
+        }
+
+        std::vector<ItemTypeId> check_r_item_type_ids;
+        for (ItemTypeId r_item_type_id: candidate_r_ids) {
+            const ReductionItemType& item = reduction_item_types[r_item_type_id];
+            const ItemType& original_item_type = original_instance_->item_type(r_item_type_id);
+            ItemTypeId check_item_type_id = check_instance_builder.add_item_type(
+                    item.rect.x, item.rect.y, original_item_type.oriented);
+            check_instance_builder.set_item_type_copies(check_item_type_id, item.copies);
+            check_r_item_type_ids.push_back(check_item_type_id);
+        }
+
+        Instance check_instance = check_instance_builder.build();
+
+        OptimizeParameters check_parameters = build_check_parameters(parameters, nullptr);
+        Output check_output = optimize(check_instance, check_parameters);
+        const Solution& check_solution = check_output.solution_pool.best();
+        if (!check_solution.full())
+            return false;
+
+        // Interpret the check solution: for each distinct companion-bin
+        // content pattern found, replicate it 'copies' times (identical
+        // bin instances of the same type are merged into one 'SolutionBin'
+        // with a 'copies' multiplier) into that big item's per-copy
+        // companion list.
+        for (BinPos bin_pos = 0;
+                bin_pos < check_solution.number_of_different_bins();
+                ++bin_pos) {
+            const SolutionBin& solution_bin = check_solution.bin(bin_pos);
+            auto it = std::find(
+                    check_bin_type_ids.begin(),
+                    check_bin_type_ids.end(),
+                    solution_bin.bin_type_id);
+            size_t big_item_pos = it - check_bin_type_ids.begin();
+            const ReductionItemType& big_item = reduction_item_types[checked_big_item_ids[big_item_pos]];
+
+            std::vector<CompanionItem> companions;
+            for (const SolutionItem& solution_item: solution_bin.items) {
+                auto r_it = std::find(
+                        check_r_item_type_ids.begin(),
+                        check_r_item_type_ids.end(),
+                        solution_item.item_type_id);
+                size_t r_pos = r_it - check_r_item_type_ids.begin();
+                CompanionItem companion;
+                companion.item_type_id = candidate_r_ids[r_pos];
+                companion.offset = compute_offset(enlargement_case, big_item, solution_item.bl_corner);
+                companion.rotate = solution_item.rotate;
+                companions.push_back(companion);
+            }
+            for (BinPos copy = 0; copy < solution_bin.copies; ++copy)
+                companions_by_big_item[big_item_pos].push_back(companions);
+        }
+    } else {
+        // No candidate companions at all for any checked big item: the
+        // "empty group" case - see 'trivially_feasible''s own doc comment
+        // just above.
+        trivially_feasible = true;
+        for (size_t i = 0; i < checked_big_item_ids.size(); ++i)
+            companions_by_big_item[i].assign(
+                    reduction_item_types[checked_big_item_ids[i]].copies,
+                    std::vector<CompanionItem>{});
+    }
+
+    // Apply the reduction: enlarge every candidate big item that actually
+    // absorbed at least one companion, plus - if 'trivially_feasible' -
+    // every checked big item outright (all of them equally proven
+    // companionless by the same candidate scan). A candidate that ends up
+    // with nothing to absorb *without* 'trivially_feasible' - some other
+    // candidate in this same group's real solve claimed the shared
+    // R-items instead - is left completely untouched, so it stays fully
+    // eligible for a different sub-case (or a later round) to find real
+    // companions for it; recording a no-op "enlargement" would otherwise
+    // permanently (and pointlessly) exclude it from reconsideration under
+    // this same axis (see 'gather_sorted_big_items').
+    //
+    // A candidate may already carry companions from an earlier axis (see
+    // 'gather_sorted_big_items''s own doc comment): 'companions_by_copy' is
+    // appended to, never overwritten, so those stay intact. Both vectors
+    // always have exactly 'big_item.copies' entries (one per copy), so
+    // appending index-for-index is well-defined regardless of which axis
+    // contributed first.
+    auto enlarge = [&](ItemTypeId big_item_type_id, std::vector<std::vector<CompanionItem>> companions) {
+        ReductionItemType& big_item = reduction_item_types[big_item_type_id];
+        switch (enlargement_case) {
+        case EnlargementCase::Wide:
+            big_item.rect.x = bin_w;
+            break;
+        case EnlargementCase::Tall:
+            big_item.rect.y = bin_h;
+            break;
+        }
+        if (big_item.companions_by_copy.empty()) {
+            big_item.companions_by_copy = std::move(companions);
+        } else {
+            for (ItemPos copy = 0; copy < (ItemPos)big_item.companions_by_copy.size(); ++copy) {
+                big_item.companions_by_copy[copy].insert(
+                        big_item.companions_by_copy[copy].end(),
+                        companions[copy].begin(), companions[copy].end());
+            }
+        }
+    };
+
+    // Capture each newly absorbed companion's own real companions (if any -
+    // see 'CompanionItem::nested_companions') and mark it removed, before
+    // 'companions_by_big_item[i]' is moved from below. A companion item
+    // type can appear more than once here (several of its copies used,
+    // possibly across several different big items in this same group
+    // search), so its own prior companions are extracted once - all of
+    // its copies at once, via 'extract_companions' - the first time it is
+    // encountered, then handed out one entry per occurrence in the order
+    // encountered (any consistent order works, since copies of the same
+    // item type are interchangeable - see 'unreduce_solution''s own
+    // comment on this); 'check_solution.full()' having verified every
+    // offered candidate_r_id is fully placed guarantees every one of its
+    // copies is accounted for by the time this finishes.
+    std::vector<std::vector<std::vector<CompanionItem>>> companion_prior_companions(
+            reduction_item_types.size());
+    std::vector<ItemPos> companion_next_copy_index(reduction_item_types.size(), 0);
+
+    bool any_enlarged = false;
+    for (size_t i = 0; i < checked_big_item_ids.size(); ++i) {
+        if (!trivially_feasible && !has_validated_companions(companions_by_big_item[i]))
+            continue;
+        for (std::vector<CompanionItem>& companions: companions_by_big_item[i]) {
+            for (CompanionItem& companion: companions) {
+                ReductionItemType& companion_item = reduction_item_types[companion.item_type_id];
+                if (!companion_item.removed) {
+                    companion_prior_companions[companion.item_type_id] =
+                        extract_companions(companion_item, companion_item.copies);
+                    companion_item.copies = 0;
+                    companion_item.removed = true;
+                }
+                ItemPos copy_index = companion_next_copy_index[companion.item_type_id]++;
+                companion.nested_companions =
+                    companion_prior_companions[companion.item_type_id][copy_index];
+            }
+        }
+        enlarge(checked_big_item_ids[i], std::move(companions_by_big_item[i]));
+        any_enlarged = true;
+    }
+
+    return any_enlarged;
+}
+
+bool Reduction::is_big(
+        EnlargementCase enlargement_case,
+        ItemTypeId item_type_id,
+        const ReductionItemType& item,
+        Length bin_w,
+        Length bin_h) const
+{
+    if (!original_instance_->item_type(item_type_id).oriented)
+        return false;
+    switch (enlargement_case) {
+    case EnlargementCase::Wide:
+        return 2 * item.rect.x > bin_w;
+    case EnlargementCase::Tall:
+        return 2 * item.rect.y > bin_h;
+    }
+    return false;
+}
+
+bool Reduction::size_greater(
+        EnlargementCase enlargement_case,
+        const ReductionItemType& item_1,
+        const ReductionItemType& item_2) const
+{
+    switch (enlargement_case) {
+    case EnlargementCase::Wide:
+        if (item_1.rect.x != item_2.rect.x)
+            return item_1.rect.x > item_2.rect.x;
+        return item_1.rect.y > item_2.rect.y;
+    case EnlargementCase::Tall:
+        if (item_1.rect.y != item_2.rect.y)
+            return item_1.rect.y > item_2.rect.y;
+        return item_1.rect.x > item_2.rect.x;
+    }
+    return false;
+}
+
+bool Reduction::could_fit(
+        EnlargementCase enlargement_case,
+        const ReductionItemType& big_item,
+        ItemTypeId item_type_id,
+        const ReductionItemType& item,
+        Length bin_w,
+        Length bin_h) const
+{
+    // Width (or height) only, matching the paper's R = {j : wj <= w*}
+    // exactly (not a full bounding-box check against the strip's other
+    // dimension too): any item narrow enough to conceivably need a share
+    // of this strip must end up in R, even if it turns out too tall for
+    // this specific strip - otherwise it could be silently left out of
+    // the packing check while the strip still gets declared fully
+    // claimed, permanently hiding a combination that uses that leftover
+    // space differently and making the reduction unsound (found by
+    // testing against an exact-fit fixture: a narrow-but-tall item that
+    // doesn't fit any available strip must make the check - and so the
+    // whole reduction attempt - fail, not be silently ignored).
+    bool oriented = original_instance_->item_type(item_type_id).oriented;
+    switch (enlargement_case) {
+    case EnlargementCase::Wide: {
+        Length strip_w = bin_w - big_item.rect.x;
+        return item.rect.x <= strip_w || (!oriented && item.rect.y <= strip_w);
+    }
+    case EnlargementCase::Tall: {
+        Length strip_h = bin_h - big_item.rect.y;
+        return item.rect.y <= strip_h || (!oriented && item.rect.x <= strip_h);
+    }
+    }
+    return false;
+}
+
+bool Reduction::could_fit_both(
+        ItemTypeId big_item_type_id,
+        const ReductionItemType& big_item,
+        ItemTypeId item_type_id,
+        const ReductionItemType& item,
+        Length bin_w,
+        Length bin_h) const
+{
+    // The pairwise-sum condition alone isn't enough: satisfying it via
+    // one axis (say the height sum) says nothing about whether the
+    // item's *other* dimension (its width, in that example) even fits
+    // inside the bin at all - it could independently exceed the bin's
+    // own width (this does happen in practice: an item already enlarged
+    // by a different sub-case can have one dimension equal to the full
+    // bin size). Offering such an item to the companion-bin check would
+    // hand it an item larger than the bin itself, which every downstream
+    // consumer assumes never happens. So first require the item to fit
+    // the bin on its own (in some allowed orientation), then apply the
+    // paper's pairwise-sum test on top.
+    bool oriented = original_instance_->item_type(item_type_id).oriented;
+    bool fits_bin_oriented = item.rect.x <= bin_w && item.rect.y <= bin_h;
+    bool fits_bin_rotated = !oriented && item.rect.y <= bin_w && item.rect.x <= bin_h;
+    if (!fits_bin_oriented && !fits_bin_rotated)
+        return false;
+
+    // The big item may itself be non-oriented (see
+    // 'gather_sorted_both_big_items''s own doc comment), which may end up
+    // placed in either of its own valid orientations - not necessarily
+    // its declared one (the real-solve
+    // path in 'try_reduce_both_group' lets the actual solve pick; its
+    // own 'trivially_feasible' path picks whichever one fits). This must
+    // check the pairwise-sum condition against *every* orientation the
+    // big item could actually use, not just its declared form: see this
+    // function's own doc comment for why under-checking here would be
+    // unsound, not merely less effective.
+    bool big_item_oriented = original_instance_->item_type(big_item_type_id).oriented;
+    for (int big_item_rotate = 0; big_item_rotate < (big_item_oriented? 1: 2); ++big_item_rotate) {
+        Length big_item_w = (big_item_rotate == 0)? big_item.rect.x: big_item.rect.y;
+        Length big_item_h = (big_item_rotate == 0)? big_item.rect.y: big_item.rect.x;
+        if (big_item_w > bin_w || big_item_h > bin_h)
+            continue;
+        if (fits_bin_oriented
+                && (item.rect.x + big_item_w <= bin_w || item.rect.y + big_item_h <= bin_h)) {
+            return true;
+        }
+        if (fits_bin_rotated
+                && (item.rect.y + big_item_w <= bin_w || item.rect.x + big_item_h <= bin_h)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+Rectangle Reduction::companion_bin_dimensions(
+        EnlargementCase enlargement_case,
+        const ReductionItemType& big_item,
+        Length bin_w,
+        Length bin_h) const
+{
+    switch (enlargement_case) {
+    case EnlargementCase::Wide:
+        return Rectangle{bin_w - big_item.rect.x, big_item.rect.y};
+    case EnlargementCase::Tall:
+        return Rectangle{big_item.rect.x, bin_h - big_item.rect.y};
+    }
+    return Rectangle{0, 0};
+}
+
+Point Reduction::compute_offset(
+        EnlargementCase enlargement_case,
+        const ReductionItemType& big_item,
+        Point bl_corner_in_check) const
+{
+    switch (enlargement_case) {
+    case EnlargementCase::Wide:
+        return Point{big_item.rect.x + bl_corner_in_check.x, bl_corner_in_check.y};
+    case EnlargementCase::Tall:
+        return Point{bl_corner_in_check.x, big_item.rect.y + bl_corner_in_check.y};
+    }
+    return bl_corner_in_check;
+}
+
+std::vector<ItemTypeId> Reduction::gather_sorted_big_items(
+        const std::vector<ReductionItemType>& reduction_item_types,
+        EnlargementCase enlargement_case,
+        Length bin_w,
+        Length bin_h)
+{
+    std::vector<ItemTypeId> candidates;
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < (ItemTypeId)reduction_item_types.size();
+            ++item_type_id) {
+        const ReductionItemType& item = reduction_item_types[item_type_id];
+        if (item.removed)
+            continue;
+        if (is_big(enlargement_case, item_type_id, item, bin_w, bin_h))
+            candidates.push_back(item_type_id);
+    }
+    std::sort(
+            candidates.begin(),
+            candidates.end(),
+            [&](ItemTypeId item_type_id_1, ItemTypeId item_type_id_2)
+            {
+                return size_greater(
+                        enlargement_case,
+                        reduction_item_types[item_type_id_1],
+                        reduction_item_types[item_type_id_2]);
+            });
+    return candidates;
+}
+
+std::vector<ItemTypeId> Reduction::gather_sorted_both_big_items(
+        const std::vector<ReductionItemType>& reduction_item_types,
+        Length bin_w,
+        Length bin_h)
+{
+    std::vector<ItemTypeId> candidates;
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < (ItemTypeId)reduction_item_types.size();
+            ++item_type_id) {
+        const ReductionItemType& item = reduction_item_types[item_type_id];
+        if (item.removed)
+            continue;
+        // A non-oriented item is safe to admit here, unlike 'is_big''s
+        // own 'Wide'/'Tall' cases: 'try_reduce_both_group' never
+        // pre-places or enlarges the big item in place - it captures and
+        // replays whatever position/rotation the companion-bin check
+        // itself found (see 'BothGroup'), so there is no shared,
+        // per-type state that would need a single orientation to stay
+        // consistent across every copy.
+        bool oriented = original_instance_->item_type(item_type_id).oriented;
+        bool both_big = (2 * item.rect.x > bin_w && 2 * item.rect.y > bin_h)
+            || (!oriented && 2 * item.rect.y > bin_w && 2 * item.rect.x > bin_h);
+        if (both_big)
+            candidates.push_back(item_type_id);
+    }
+    std::sort(
+            candidates.begin(),
+            candidates.end(),
+            [&](ItemTypeId item_type_id_1, ItemTypeId item_type_id_2)
+            {
+                return reduction_item_types[item_type_id_1].rect.area()
+                    > reduction_item_types[item_type_id_2].rect.area();
+            });
+    return candidates;
+}
+
+bool Reduction::reduce_group(
+        std::vector<ReductionItemType>& reduction_item_types,
+        const ReductionParameters& parameters,
+        EnlargementCase enlargement_case,
+        Length bin_w,
+        Length bin_h)
+{
+    bool found_any = false;
+
+    // Loop A: singletons.
+    for (ItemTypeId big_item_type_id: gather_sorted_big_items(reduction_item_types, enlargement_case, bin_w, bin_h)) {
+        if (reduction_item_types[big_item_type_id].removed) {
+            // May have been consumed as a companion of an earlier singleton
+            // reduction in this same pass.
+            continue;
+        }
+        if (parameters.timer.needs_to_end())
+            return found_any;
+        if (try_reduce_group(reduction_item_types, parameters, enlargement_case, bin_w, bin_h, {big_item_type_id}))
+            found_any = true;
+    }
+
+    // Loop B: growing groups, following the paper's search - starting from
+    // the two largest remaining candidates, growing by one (the next
+    // largest) on failure, restarting from the (new) two largest remaining
+    // candidates after every success.
+    for (;;) {
+        std::vector<ItemTypeId> candidates = gather_sorted_big_items(reduction_item_types, enlargement_case, bin_w, bin_h);
+        if (candidates.size() < 2)
+            break;
+        bool applied = false;
+        for (size_t group_size = 2; group_size <= candidates.size(); ++group_size) {
+            if (parameters.timer.needs_to_end())
+                return found_any;
+            std::vector<ItemTypeId> group(candidates.begin(), candidates.begin() + group_size);
+            if (try_reduce_group(reduction_item_types, parameters, enlargement_case, bin_w, bin_h, group)) {
+                found_any = true;
+                applied = true;
+                break;
+            }
+        }
+        if (!applied)
+            break;
+    }
+
+    return found_any;
+}
+
+bool Reduction::try_reduce_both_group(
+        std::vector<ReductionItemType>& reduction_item_types,
+        const ReductionParameters& parameters,
+        Length bin_w,
+        Length bin_h,
+        const std::vector<ItemTypeId>& candidate_big_item_ids)
+{
+    // Unlike 'try_reduce_group''s wide/tall strips, "both"'s companion bin
+    // is always the full 'bin_w'x'bin_h' bin (see
+    // 'companion_bin_dimensions') - never degenerate, so every candidate
+    // here is genuinely checked; there is no trivial/zero-area shortcut.
+
+    // Candidate companion items (R): same as 'try_reduce_group' - see
+    // there for why an already-enlarged item type is *not* excluded (its
+    // own real companions, if absorbed here, are captured directly below
+    // via 'extract_companions', same as for the big item itself).
+    std::vector<ItemTypeId> candidate_r_ids;
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < (ItemTypeId)reduction_item_types.size();
+            ++item_type_id) {
+        const ReductionItemType& item = reduction_item_types[item_type_id];
+        if (item.removed)
+            continue;
+        if (std::find(
+                    candidate_big_item_ids.begin(),
+                    candidate_big_item_ids.end(),
+                    item_type_id) != candidate_big_item_ids.end()) {
+            continue;
+        }
+        bool fits_any = false;
+        for (ItemTypeId big_item_type_id: candidate_big_item_ids) {
+            if (could_fit_both(big_item_type_id, reduction_item_types[big_item_type_id], item_type_id, item, bin_w, bin_h)) {
+                fits_any = true;
+                break;
+            }
+        }
+        if (fits_any)
+            candidate_r_ids.push_back(item_type_id);
+    }
+    if (candidate_r_ids.empty()) {
+        // The "empty group" case of equation (8) ("enlarging the items"):
+        // genuinely nothing (from the same unified, 'removed'-only-
+        // excluded candidate pool 'could_fit' was just scanned over)
+        // could ever share any of these big items' companion bins - no
+        // real solve needed to know this, unlike the non-empty case
+        // below. Every candidate here is independently, unconditionally
+        // eligible for a direct single-item capture (no group solve ever
+        // combines several big items into one dedicated bin anyway - see
+        // 'BothGroup''s own doc comment), subject to the same bin type
+        // copies cap as the non-empty case, and to determining which
+        // orientation actually fits (a non-oriented item's declared form
+        // need not be the one that does - see 'is_big''s own doc comment
+        // for why 'Both' admits that in the first place).
+        const BinType& bin_type = original_instance_->bin_type(0);
+        bool any_captured = false;
+        for (ItemTypeId big_item_type_id: candidate_big_item_ids) {
+            ReductionItemType& big_item = reduction_item_types[big_item_type_id];
+            bool oriented = original_instance_->item_type(big_item_type_id).oriented;
+            bool rotate;
+            if (big_item.rect.x <= bin_w && big_item.rect.y <= bin_h) {
+                rotate = false;
+            } else if (!oriented && big_item.rect.y <= bin_w && big_item.rect.x <= bin_h) {
+                rotate = true;
+            } else {
+                // Neither orientation actually fits the companion bin at
+                // all: 'is_big''s own 'Both' condition does not by itself
+                // guarantee this (see its own doc comment), so skip
+                // defensively rather than ever building a geometrically
+                // invalid dedicated bin.
+                continue;
+            }
+            if (bin_type.copies >= 0
+                    && number_of_dedicated_bins() + big_item.copies > bin_type.copies) {
+                // Not enough bin copies left to reserve dedicated bins
+                // for this item type: leave it for the underlying solver
+                // instead (sound, just less effective - see
+                // 'reduce_perfect_pairs''s identical guard for why).
+                continue;
+            }
+            std::vector<std::vector<CompanionItem>> prior_companions =
+                extract_companions(big_item, big_item.copies);
+            ItemPos copies = big_item.copies;
+            big_item.copies = 0;
+            big_item.removed = true;
+            for (ItemPos copy = 0; copy < copies; ++copy) {
+                both_groups_.push_back(BothGroup{
+                        {BothGroup::PlacedItem{big_item_type_id, Point{0, 0}, rotate, prior_companions[copy]}}});
+            }
+            any_captured = true;
+        }
+        return any_captured;
+    }
+
+    // Build the check sub-instance: a single, shared companion bin type
+    // ('bin_w'x'bin_h', 'copies' = the sum of every candidate's own) -
+    // items = the big items themselves - each offered as an ordinary
+    // item, with its own true 'oriented' flag, free to be placed (and
+    // rotated, if non-oriented) however the check likes, since its own
+    // position and rotation are captured and replayed directly below,
+    // with no shared, per-type state (unlike 'ReductionItemType::rect')
+    // that would need to stay consistent across different copies - plus
+    // the candidate R items.
+    //
+    // No eligibility restriction is needed to keep different candidates'
+    // big items apart, unlike an earlier version of this function: two
+    // "both"-big items (each spanning more than half the companion bin on
+    // *both* axes, by definition - see 'gather_sorted_both_big_items')
+    // can never fit in the same 'bin_w'x'bin_h' bin together, regardless
+    // of where either is placed - any valid non-overlapping placement of
+    // two rectangles
+    // needs their widths to sum to at most 'bin_w' *or* their heights to
+    // sum to at most 'bin_h', and both are already individually violated.
+    // So a bin instance can hold at most one candidate's big item by
+    // geometry alone, and since every big item is itself mandatory (all
+    // 'copies' of it must be placed, exactly like the R-candidates), the
+    // interpretation loop below can just read off which big item (if any)
+    // a solved bin actually holds directly, rather than needing the check
+    // itself to keep candidates artificially apart.
+    InstanceBuilder check_instance_builder;
+    check_instance_builder.set_objective(Objective::Feasibility);
+    check_instance_builder.set_parameters(original_instance_->parameters());
+
+    ItemPos total_big_item_copies = 0;
+    for (ItemTypeId big_item_type_id: candidate_big_item_ids)
+        total_big_item_copies += reduction_item_types[big_item_type_id].copies;
+    BinTypeId check_bin_type_id = check_instance_builder.add_bin_type(bin_w, bin_h);
+    check_instance_builder.set_bin_type_copies(check_bin_type_id, total_big_item_copies);
+    check_instance_builder.set_bin_type_copies_min(check_bin_type_id, 0);
+
+    std::vector<ItemTypeId> check_big_item_type_ids;
+    for (ItemTypeId big_item_type_id: candidate_big_item_ids) {
+        const ReductionItemType& big_item = reduction_item_types[big_item_type_id];
+        ItemTypeId check_big_item_type_id = check_instance_builder.add_item_type(
+                big_item.rect.x, big_item.rect.y,
+                original_instance_->item_type(big_item_type_id).oriented);
+        check_instance_builder.set_item_type_copies(check_big_item_type_id, big_item.copies);
+        check_big_item_type_ids.push_back(check_big_item_type_id);
+    }
+
+    std::vector<ItemTypeId> check_r_item_type_ids;
+    for (ItemTypeId r_item_type_id: candidate_r_ids) {
+        const ReductionItemType& item = reduction_item_types[r_item_type_id];
+        const ItemType& original_item_type = original_instance_->item_type(r_item_type_id);
+        ItemTypeId check_item_type_id = check_instance_builder.add_item_type(
+                item.rect.x, item.rect.y, original_item_type.oriented);
+        check_instance_builder.set_item_type_copies(check_item_type_id, item.copies);
+        check_r_item_type_ids.push_back(check_item_type_id);
+    }
+
+    Instance check_instance = check_instance_builder.build();
+    OptimizeParameters check_parameters = build_check_parameters(parameters, nullptr);
+    Output check_output = optimize(check_instance, check_parameters);
+    const Solution& check_solution = check_output.solution_pool.best();
+    if (!check_solution.full())
+        return false;
+
+    // Interpret the check's own solution directly: every solved companion
+    // bin (one distinct pattern per 'SolutionBin', replicated 'copies'
+    // times) becomes its own dedicated bin, holding whichever big item
+    // and R-candidates the check placed into it, each at its own
+    // check-found position and rotation - no relative-offset computation
+    // needed, since the companion bin's dimensions ('bin_w'x'bin_h') are
+    // exactly the dedicated bin's own.
+    //
+    // Grouped by which candidate's big item type is actually found in
+    // each solved bin (there is at most one - see the check
+    // sub-instance's own doc comment above for why). A bin with no big
+    // item at all is not expected to happen (every big item is
+    // mandatory, and there are exactly as many bin instances offered as
+    // there are big item copies in total, so by pigeonhole every bin
+    // instance actually used must hold exactly one once the check
+    // succeeds), but is skipped defensively rather than assumed
+    // impossible; an item type id belonging to neither a candidate big
+    // item nor an R-candidate is treated the same way, declining the
+    // whole check rather than risk mis-indexing 'candidate_r_ids' (sound,
+    // just less effective - nothing has been mutated in
+    // 'reduction_item_types' yet at this point).
+    std::vector<std::vector<std::vector<BothGroup::PlacedItem>>> groups_by_big_item(
+            candidate_big_item_ids.size());
+    for (BinPos bin_pos = 0;
+            bin_pos < check_solution.number_of_different_bins();
+            ++bin_pos) {
+        const SolutionBin& solution_bin = check_solution.bin(bin_pos);
+
+        size_t big_item_pos = candidate_big_item_ids.size();
+        for (const SolutionItem& solution_item: solution_bin.items) {
+            auto it = std::find(
+                    check_big_item_type_ids.begin(),
+                    check_big_item_type_ids.end(),
+                    solution_item.item_type_id);
+            if (it != check_big_item_type_ids.end()) {
+                big_item_pos = it - check_big_item_type_ids.begin();
+                break;
+            }
+        }
+        if (big_item_pos == candidate_big_item_ids.size())
+            continue;
+
+        std::vector<BothGroup::PlacedItem> placed_items;
+        for (const SolutionItem& solution_item: solution_bin.items) {
+            ItemTypeId original_item_type_id;
+            if (solution_item.item_type_id == check_big_item_type_ids[big_item_pos]) {
+                original_item_type_id = candidate_big_item_ids[big_item_pos];
+            } else {
+                auto r_it = std::find(
+                        check_r_item_type_ids.begin(),
+                        check_r_item_type_ids.end(),
+                        solution_item.item_type_id);
+                if (r_it == check_r_item_type_ids.end())
+                    return false;
+                size_t r_pos = r_it - check_r_item_type_ids.begin();
+                original_item_type_id = candidate_r_ids[r_pos];
+            }
+            placed_items.push_back(BothGroup::PlacedItem{
+                    original_item_type_id, solution_item.bl_corner, solution_item.rotate, {}});
+        }
+        for (BinPos copy = 0; copy < solution_bin.copies; ++copy)
+            groups_by_big_item[big_item_pos].push_back(placed_items);
+    }
+
+    // All-or-nothing bin type copies cap check (see this function's own
+    // doc comment for why a partial commit isn't straightforward here,
+    // unlike 'reduce_full_bin_items'/'reduce_perfect_pairs''s own
+    // per-item skip).
+    const BinType& bin_type = original_instance_->bin_type(0);
+    BinPos total_copies_used = 0;
+    for (const auto& groups: groups_by_big_item)
+        total_copies_used += (BinPos)groups.size();
+    if (total_copies_used == 0)
+        return false;
+    if (bin_type.copies >= 0
+            && number_of_dedicated_bins() + total_copies_used > bin_type.copies) {
+        // Not enough bin copies left to reserve dedicated bins for this
+        // batch: leave every item type here untouched instead (sound,
+        // just less effective - see 'reduce_perfect_pairs''s identical
+        // guard for why).
+        return false;
+    }
+
+    // Apply: every R-candidate offered above is mandatory in the check
+    // (unlike the big items' own bin copies, which have 'copies_min' 0),
+    // so 'check_solution.full()' already guarantees every one of them was
+    // placed somewhere across the groups being applied here - captured
+    // and marked removed up front, then distributed one copy at a time,
+    // in encounter order, as each of its placements is found below (any
+    // consistent order works, since copies of the same item type are
+    // interchangeable - see 'unreduce_solution''s own comment on this).
+    std::vector<std::vector<std::vector<CompanionItem>>> r_prior_companions(reduction_item_types.size());
+    std::vector<ItemPos> r_next_copy_index(reduction_item_types.size(), 0);
+    for (ItemTypeId r_item_type_id: candidate_r_ids) {
+        ReductionItemType& r_item = reduction_item_types[r_item_type_id];
+        r_prior_companions[r_item_type_id] = extract_companions(r_item, r_item.copies);
+        r_item.copies = 0;
+        r_item.removed = true;
+    }
+
+    for (size_t candidate_pos = 0; candidate_pos < candidate_big_item_ids.size(); ++candidate_pos) {
+        if (groups_by_big_item[candidate_pos].empty())
+            continue;
+        ItemTypeId big_item_type_id = candidate_big_item_ids[candidate_pos];
+        ReductionItemType& big_item = reduction_item_types[big_item_type_id];
+        ItemPos copies_used = (ItemPos)groups_by_big_item[candidate_pos].size();
+
+        std::vector<std::vector<CompanionItem>> big_item_prior_companions =
+            extract_companions(big_item, copies_used);
+        big_item.copies -= copies_used;
+        if (big_item.copies == 0)
+            big_item.removed = true;
+
+        for (ItemPos copy = 0; copy < copies_used; ++copy) {
+            for (BothGroup::PlacedItem& placed_item: groups_by_big_item[candidate_pos][copy]) {
+                if (placed_item.item_type_id == big_item_type_id) {
+                    placed_item.companions = big_item_prior_companions[copy];
+                } else {
+                    ItemPos r_copy_index = r_next_copy_index[placed_item.item_type_id]++;
+                    placed_item.companions = r_prior_companions[placed_item.item_type_id][r_copy_index];
+                }
+            }
+            both_groups_.push_back(BothGroup{std::move(groups_by_big_item[candidate_pos][copy])});
+        }
+    }
+
+    return true;
+}
+
+bool Reduction::reduce_both_groups(
+        std::vector<ReductionItemType>& reduction_item_types,
+        const ReductionParameters& parameters,
+        Length bin_w,
+        Length bin_h)
+{
+    bool found_any = false;
+
+    // Loop A: singletons.
+    for (ItemTypeId big_item_type_id: gather_sorted_both_big_items(reduction_item_types, bin_w, bin_h)) {
+        if (reduction_item_types[big_item_type_id].removed) {
+            // May have been consumed as a companion of an earlier singleton
+            // reduction in this same pass.
+            continue;
+        }
+        if (parameters.timer.needs_to_end())
+            return found_any;
+        if (try_reduce_both_group(reduction_item_types, parameters, bin_w, bin_h, {big_item_type_id}))
+            found_any = true;
+    }
+
+    // Loop B: growing groups (same search strategy as 'reduce_group').
+    for (;;) {
+        std::vector<ItemTypeId> candidates = gather_sorted_both_big_items(reduction_item_types, bin_w, bin_h);
+        if (candidates.size() < 2)
+            break;
+        bool applied = false;
+        for (size_t group_size = 2; group_size <= candidates.size(); ++group_size) {
+            if (parameters.timer.needs_to_end())
+                return found_any;
+            std::vector<ItemTypeId> group(candidates.begin(), candidates.begin() + group_size);
+            if (try_reduce_both_group(reduction_item_types, parameters, bin_w, bin_h, group)) {
+                found_any = true;
+                applied = true;
+                break;
+            }
+        }
+        if (!applied)
+            break;
+    }
+
+    return found_any;
+}
+
+bool Reduction::reduce_full_bin_items(
+        std::vector<ReductionItemType>& reduction_item_types,
+        Length bin_w,
+        Length bin_h)
+{
+    const BinType& bin_type = original_instance_->bin_type(0);
+
+    bool any_reduced = false;
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < (ItemTypeId)reduction_item_types.size();
+            ++item_type_id) {
+        ReductionItemType& item = reduction_item_types[item_type_id];
+        if (item.removed)
+            continue;
+
+        // Exact match against 'bin_w'x'bin_h' (the *shrunk* bin - see
+        // this function's own doc comment), using the item's *current*
+        // dimensions (may already be enlarged, companionlessly or with
+        // real companions of its own).
+        bool oriented = original_instance_->item_type(item_type_id).oriented;
+        bool rotate = false;
+        bool matches = false;
+        if (item.rect.x == bin_w && item.rect.y == bin_h) {
+            matches = true;
+            rotate = false;
+        } else if (!oriented && item.rect.y == bin_w && item.rect.x == bin_h) {
+            matches = true;
+            rotate = true;
+        }
+        if (!matches)
+            continue;
+
+        ItemPos copies = item.copies;
+        if (bin_type.copies >= 0
+                && number_of_dedicated_bins() + copies > bin_type.copies) {
+            // Not enough bin copies left to reserve dedicated bins for
+            // this item type: leave it for the underlying solver instead
+            // (sound, just less effective - see 'reduce_perfect_pairs''s
+            // identical guard for why).
+            continue;
+        }
+
+        // Captures this item type's own companions (if 'enlarged' with
+        // any - see this function's own doc comment for why they are no
+        // longer excluded), instead of leaving them behind to be
+        // silently dropped once 'item' is marked 'removed' below.
+        std::vector<std::vector<CompanionItem>> companions_by_copy =
+            extract_companions(item, copies);
+        item.removed = true;
+        full_bin_items_.push_back(FullBinItem{
+                item_type_id, rotate, copies, std::move(companions_by_copy)});
+        any_reduced = true;
+    }
+
+    return any_reduced;
+}
+
+bool Reduction::reduce_perfect_pairs(
+        std::vector<ReductionItemType>& reduction_item_types,
+        Length bin_w,
+        Length bin_h)
+{
+    const BinType& bin_type = original_instance_->bin_type(0);
+
+    bool any_reduced = false;
+    for (ItemTypeId item_type_id_1 = 0;
+            item_type_id_1 < (ItemTypeId)reduction_item_types.size();
+            ++item_type_id_1) {
+        ReductionItemType& item_1 = reduction_item_types[item_type_id_1];
+        if (item_1.removed)
+            continue;
+        // Both sides of a pair must be 'oriented' - see this function's
+        // own doc comment for why rotation is unsound here specifically,
+        // unlike 'reduce_full_bin_items': matching only *one* bin
+        // dimension (not both simultaneously) never forces a non-oriented
+        // item's *other* orientation to become geometrically infeasible,
+        // so nothing guarantees it couldn't have been placed differently
+        // in a true optimal solution - the "slide together" argument
+        // below needs that guarantee unconditionally.
+        if (!original_instance_->item_type(item_type_id_1).oriented)
+            continue;
+        const Rectangle& footprint_1 = item_1.rect;
+
+        for (ItemTypeId item_type_id_2 = 0;
+                item_type_id_2 < (ItemTypeId)reduction_item_types.size();
+                ++item_type_id_2) {
+            if (item_type_id_2 == item_type_id_1)
+                continue;
+            ReductionItemType& item_2 = reduction_item_types[item_type_id_2];
+            if (item_2.removed)
+                continue;
+            if (!original_instance_->item_type(item_type_id_2).oriented)
+                continue;
+            ItemPos copies = std::min(item_1.copies, item_2.copies);
+            if (bin_type.copies >= 0
+                    && number_of_dedicated_bins() + copies > bin_type.copies) {
+                // Not enough bin copies left to reserve dedicated bins
+                // for this pair: leave both item types for the
+                // underlying solver instead (sound, just less
+                // effective - this keeps the subtraction in
+                // 'reduction_to_instance' from ever going negative).
+                continue;
+            }
+
+            const Rectangle& footprint_2 = item_2.rect;
+            bool vertical_split = footprint_1.y == bin_h && footprint_2.y == bin_h
+                    && footprint_1.x + footprint_2.x == bin_w;
+            bool horizontal_split = !vertical_split
+                    && footprint_1.x == bin_w && footprint_2.x == bin_w
+                    && footprint_1.y + footprint_2.y == bin_h;
+            if (!vertical_split && !horizontal_split)
+                continue;
+
+            // Consume 'copies' (the smaller of the two) from each side:
+            // fully depleted item types are removed entirely, but a type
+            // with more copies than its partner keeps its leftover
+            // copies as an ordinary item type in the reduced instance
+            // (see this function's own doc comment for the "j1: 2
+            // copies, j2: 4 copies" example this generalizes from the
+            // old equal-copies-only rule). Either side may already be
+            // 'enlarged' with real companions of its own (see this
+            // function's own doc comment for why that is no longer
+            // excluded) - captured here instead of being silently
+            // dropped once 'copies' worth of it is consumed.
+            std::vector<std::vector<CompanionItem>> item_1_companions_by_copy =
+                extract_companions(item_1, copies);
+            item_1.copies -= copies;
+            if (item_1.copies == 0)
+                item_1.removed = true;
+            std::vector<std::vector<CompanionItem>> item_2_companions_by_copy =
+                extract_companions(item_2, copies);
+            item_2.copies -= copies;
+            if (item_2.copies == 0)
+                item_2.removed = true;
+
+            Point offset_2 = (vertical_split)?
+                Point{footprint_1.x, 0}:
+                Point{0, footprint_1.y};
+            perfect_pairs_.push_back(PerfectPair{
+                    item_type_id_1, item_type_id_2, offset_2, copies,
+                    std::move(item_1_companions_by_copy),
+                    std::move(item_2_companions_by_copy)});
+            any_reduced = true;
+            break;
+        }
+    }
+
+    return any_reduced;
+}
+
+BinPos Reduction::number_of_dedicated_bins() const
+{
+    BinPos total = 0;
+    for (const FullBinItem& full_bin_item: full_bin_items_)
+        total += full_bin_item.copies;
+    for (const PerfectPair& pair: perfect_pairs_)
+        total += pair.copies;
+    total += (BinPos)both_groups_.size();
+    return total;
+}
+
+Instance Reduction::reduction_to_instance(
+        const std::vector<ReductionItemType>& reduction_item_types)
+{
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(original_instance_->objective());
+    instance_builder.set_parameters(original_instance_->parameters());
+    instance_builder.set_feasibility_callback(original_instance_->feasibility_callback());
+
+    BinPos number_of_dedicated_bins = this->number_of_dedicated_bins();
+    ItemPos remaining_items = 0;
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < (ItemTypeId)reduction_item_types.size();
+            ++item_type_id) {
+        if (!reduction_item_types[item_type_id].removed)
+            remaining_items += original_instance_->item_type(item_type_id).copies;
+    }
+
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < original_instance_->number_of_bin_types();
+            ++bin_type_id) {
+        BinTypeId new_bin_type_id = instance_builder.add_bin_type(*original_instance_, bin_type_id);
+        if (number_of_dedicated_bins > 0) {
+            // Fold the dedicated bins' capacity out of the reduced
+            // instance's own bin type copies: they are entirely absent
+            // from this instance (see 'FullBinItem'/'PerfectPair'), so
+            // nothing here should ever be allowed to use their reserved
+            // capacity. 'reduce_full_bin_items'/'reduce_perfect_pairs'
+            // never reserve more than 'bin_type.copies' itself, so this
+            // subtraction never goes negative - but it can reach exactly
+            // 0, which 'InstanceBuilder' rejects outright ('copies' must
+            // be > 0 or -1), so that case needs its own handling below.
+            const BinType& original_bin_type = original_instance_->bin_type(bin_type_id);
+            if (original_bin_type.copies >= 0) {
+                BinPos new_copies = original_bin_type.copies - number_of_dedicated_bins;
+                if (new_copies > 0) {
+                    instance_builder.set_bin_type_copies(new_bin_type_id, new_copies);
+                } else if (remaining_items == 0) {
+                    // Zero bin capacity left, but also nothing left that
+                    // could ever need it (every item type was itself
+                    // consumed by a dedicated-bin reservation): leave the
+                    // bin type's copies at its original (nonzero) value -
+                    // harmless, since a solve over zero items never
+                    // touches bin capacity at all.
+                } else {
+                    // Zero bin capacity left, with real items still
+                    // needing to be packed: the original instance needs
+                    // strictly more bins than this bin type has copies
+                    // for, so it is infeasible outright (only possible for
+                    // 'Feasibility', whose bin copies are genuinely finite
+                    // - the cap in 'reduce_full_bin_items'/
+                    // 'reduce_perfect_pairs' only prevents *exceeding*
+                    // available copies, not *exhausting* them). Record it
+                    // and leave a harmless nonzero placeholder so the
+                    // instance still builds; the recursive solve on it is
+                    // never actually reached (see 'optimize()', which
+                    // checks 'proven_infeasible()' first).
+                    proven_infeasible_ = true;
+                }
+            }
+            if (original_bin_type.copies_min > 0) {
+                instance_builder.set_bin_type_copies_min(
+                        new_bin_type_id,
+                        std::max<BinPos>(0, original_bin_type.copies_min - number_of_dedicated_bins));
+            }
+        }
+    }
+
+    // A direct copy of the whole working representation, indexed by the
+    // *original* instance's item type ids - see 'final_item_types_''s own
+    // doc comment for why every item type needs to stay reachable here,
+    // survivor or not.
+    final_item_types_ = reduction_item_types;
+
+    reduced_to_original_item_type_ids_.clear();
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < (ItemTypeId)reduction_item_types.size();
+            ++item_type_id) {
+        const ReductionItemType& item = reduction_item_types[item_type_id];
+        if (item.removed)
+            continue;
+        const ItemType& original_item_type = original_instance_->item_type(item_type_id);
+        ItemTypeId new_item_type_id = instance_builder.add_item_type(
+                item.rect.x, item.rect.y, original_item_type.oriented);
+        instance_builder.set_item_type_profit(new_item_type_id, original_item_type.profit);
+        instance_builder.set_item_type_copies(new_item_type_id, item.copies);
+        instance_builder.set_item_type_group(new_item_type_id, original_item_type.group_id);
+        instance_builder.set_item_type_weight(new_item_type_id, original_item_type.weight);
+        instance_builder.set_item_type_eligibility(new_item_type_id, original_item_type.eligibility_id);
+        reduced_to_original_item_type_ids_.push_back(item_type_id);
+    }
+
+    return instance_builder.build();
+}
+
+namespace
+{
+
+/**
+ * Maximum achievable combination of item widths (or heights) not
+ * exceeding 'capacity' - the inner multiple-choice subset-sum
+ * maximization of equation (7) - via 'multiplechoicesubsetsumsolver': one
+ * group per item copy, containing one candidate value per orientation
+ * that copy is allowed to present on this axis (see
+ * 'Reduction::compute_shrunk_bin_sizes''s own doc comment for why this is
+ * sound for non-oriented items too).
+ */
+Length max_achievable_dimension_sum(
+        const Instance& instance,
+        Length capacity,
+        bool width_axis)
+{
+    multiplechoicesubsetsumsolver::InstanceBuilder mcss_instance_builder;
+    mcss_instance_builder.set_capacity(capacity);
+    multiplechoicesubsetsumsolver::GroupId mcss_group_id = 0;
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance.number_of_item_types();
+            ++item_type_id) {
+        const ItemType& item_type = instance.item_type(item_type_id);
+        Length value = (width_axis)? item_type.rect.x: item_type.rect.y;
+        Length rotated_value = (width_axis)? item_type.rect.y: item_type.rect.x;
+        for (ItemPos copy = 0; copy < item_type.copies; ++copy) {
+            mcss_instance_builder.add_item(mcss_group_id, value);
+            if (!item_type.oriented && rotated_value != value)
+                mcss_instance_builder.add_item(mcss_group_id, rotated_value);
+            ++mcss_group_id;
+        }
+    }
+    multiplechoicesubsetsumsolver::Instance mcss_instance = mcss_instance_builder.build();
+    multiplechoicesubsetsumsolver::Parameters mcss_parameters;
+    mcss_parameters.verbosity_level = 0;
+    auto mcss_output = multiplechoicesubsetsumsolver::dynamic_programming_bellman_array(
+            mcss_instance,
+            mcss_parameters);
+    return mcss_output.bound;
+}
+
+}
+
+Reduction::ShrunkBinSizes Reduction::compute_shrunk_bin_sizes(
+        const Instance& instance)
+{
+    ShrunkBinSizes result;
+
+    if (instance.number_of_bin_types() != 1) {
+        result.bin_width = 0;
+        result.bin_height = 0;
+        return result;
+    }
+    const BinType& bin_type = instance.bin_type(0);
+    result.bin_width = bin_type.rect.x;
+    result.bin_height = bin_type.rect.y;
+
+    // Infinite item copies can't be flattened into individual groups; the
+    // technique isn't meaningful there anyway (an infinite-copies item
+    // type can already saturate any capacity on its own), so skip it and
+    // return the bin's own, unshrunk dimensions.
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance.number_of_item_types();
+            ++item_type_id) {
+        if (instance.item_type(item_type_id).copies < 0)
+            return result;
+    }
+
+    // Equation (7): shrink the bin width/height to the largest achievable
+    // combination of item widths/heights.
+    result.bin_width = max_achievable_dimension_sum(instance, bin_type.rect.x, /* width_axis */ true);
+    result.bin_height = max_achievable_dimension_sum(instance, bin_type.rect.y, /* width_axis */ false);
+
+    return result;
+}
+
+bool Reduction::applies(
+        const Instance& instance,
+        const ReductionParameters& parameters)
+{
+    // Every check this class performs (the wide/tall/both companion-bin
+    // feasibility solves in 'try_reduce_group', and the direct
+    // dimension-only matches in 'reduce_full_bin_items'/
+    // 'reduce_perfect_pairs') reasons purely about geometry: whether a set
+    // of item footprints fits together inside an empty rectangle. Three
+    // instance features break that:
+    //
+    // - Defects: the companion-bin sub-instances built in
+    //   'try_reduce_group' are always plain, defect-free rectangles (see
+    //   'bin_dims' there) - a defect sitting where a companion or the big
+    //   item itself would need to go is entirely invisible to the check,
+    //   and 'reduce_full_bin_items'/'reduce_perfect_pairs' do not even run
+    //   a solve to catch it.
+    // - A finite bin weight capacity together with non-trivial item
+    //   weights: unlike the wide/tall/both geometric argument, total bin
+    //   weight is a *whole-bin* aggregate over every item that ends up
+    //   sharing it. A validated-enlarged item's real companions are
+    //   removed from the reduced instance and only reinserted by
+    //   'unreduce_solution' after the downstream solve has already
+    //   finished - that solve never sees them, so it can never verify the
+    //   combined weight of whatever *it* additionally places in that same
+    //   bin. (The reduced instance's own bookkeeping compounds this:
+    //   'reduction_to_instance' carries over an enlarged item's own
+    //   original weight only, silently dropping its companions'.)
+    // - A non-'None' unloading constraint: the same whole-bin argument as
+    //   weight - an unloading order that holds for the big item and its
+    //   companions checked in isolation says nothing about whether it
+    //   still holds once other items, chosen later and never part of that
+    //   check, join the same bin.
+    bool weight_matters = instance.number_of_bin_types() == 1
+            && instance.bin_type(0).maximum_weight != std::numeric_limits<Weight>::infinity();
+    if (weight_matters) {
+        weight_matters = false;
+        for (ItemTypeId item_type_id = 0;
+                item_type_id < instance.number_of_item_types();
+                ++item_type_id) {
+            if (instance.item_type(item_type_id).weight != 0) {
+                weight_matters = true;
+                break;
+            }
+        }
+    }
+    return (instance.objective() == Objective::BinPacking
+                || instance.objective() == Objective::VariableSizedBinPacking
+                || instance.objective() == Objective::Feasibility)
+            && instance.number_of_bin_types() == 1
+            && instance.number_of_defects() == 0
+            && instance.unloading_constraint() == UnloadingConstraint::None
+            && !weight_matters
+            && parameters.reduce;
+}
+
+Reduction::Reduction(
+        const Instance& instance,
+        const ReductionParameters& parameters):
+    original_instance_(&instance),
+    instance_(instance)
+{
+    // Working representation: a stable 1:1 copy of the original instance's
+    // item types (see 'ReductionItemType'). Always built and compacted
+    // back via 'reduction_to_instance' at the end (even when the
+    // reduction doesn't apply below, in which case it is an identity
+    // rebuild): this keeps 'final_item_types_'/
+    // 'reduced_to_original_item_type_ids_' always populated, so
+    // 'unreduce_solution' never needs a separate no-op code path. Callers
+    // that already know 'applies()' is 'false' are better off not
+    // constructing a 'Reduction' at all (see 'applies''s own doc comment)
+    // - but the constructor still handles that case correctly, both for
+    // simplicity (one code path regardless of caller diligence) and
+    // because 'applies()' and the constructor could otherwise silently
+    // drift out of sync.
+    std::vector<ReductionItemType> reduction_item_types(instance.number_of_item_types());
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance.number_of_item_types();
+            ++item_type_id) {
+        reduction_item_types[item_type_id].rect = instance.item_type(item_type_id).rect;
+        reduction_item_types[item_type_id].copies = instance.item_type(item_type_id).copies;
+    }
+
+    if (!applies(instance, parameters)) {
+        instance_ = reduction_to_instance(reduction_item_types);
+        return;
+    }
+
+    // Shrunk bin dimensions (equation (7), "shrinking the bins": see
+    // 'compute_shrunk_bin_sizes'), computed once from the *original*,
+    // never-reduced instance's full item set - not per round. This stays
+    // sound throughout every round despite items later being removed: the
+    // bound proves "no item in the original full set is small enough to
+    // extend this achieved sum", and every item ever considered in a later
+    // round is a subset of that same original full set, so the bound only
+    // ever remains valid (if anything, recomputing it from a shrinking
+    // remaining set could tighten it further, but that is a possible
+    // future improvement, not a soundness requirement).
+    //
+    // Used as the effective bin dimensions throughout this whole class
+    // ('is_big', 'could_fit', 'companion_bin_dimensions', enlargement
+    // targets, 'reduce_full_bin_items', 'reduce_perfect_pairs'): any
+    // multi-item combination that fits within the *true* bin capacity is,
+    // by definition of 'shrunk_bin_w'/'shrunk_bin_h' as the maximum
+    // achievable subset-sum from the full original item set, already
+    // bounded by it - so substituting it for the true dimensions never
+    // discards a genuinely achievable candidate, and the true bin's
+    // remaining margin beyond it is provably unusable by any combination
+    // of the actual items.
+    ShrunkBinSizes shrunk_bin_sizes = compute_shrunk_bin_sizes(instance);
+    Length bin_w = shrunk_bin_sizes.bin_width;
+    Length bin_h = shrunk_bin_sizes.bin_height;
+
+    // Outer fixpoint loop: repeat {wide, tall, both, full-bin items,
+    // perfect pairs} until a full pass finds nothing new (a later case's
+    // success can free up items that make an earlier case worth
+    // retrying).
+    for (Counter round_number = 0;
+            round_number < parameters.maximum_number_of_rounds;
+            ++round_number) {
+        if (parameters.timer.needs_to_end())
+            break;
+        bool found = false;
+        found |= reduce_group(reduction_item_types, parameters, EnlargementCase::Wide, bin_w, bin_h);
+        if (parameters.timer.needs_to_end())
+            break;
+        found |= reduce_group(reduction_item_types, parameters, EnlargementCase::Tall, bin_w, bin_h);
+        if (parameters.timer.needs_to_end())
+            break;
+        found |= reduce_both_groups(reduction_item_types, parameters, bin_w, bin_h);
+        if (parameters.timer.needs_to_end())
+            break;
+        found |= reduce_full_bin_items(
+                reduction_item_types, bin_w, bin_h);
+        if (parameters.timer.needs_to_end())
+            break;
+        found |= reduce_perfect_pairs(
+                reduction_item_types, bin_w, bin_h);
+        if (!found)
+            break;
+    }
+
+    instance_ = reduction_to_instance(reduction_item_types);
+}
+
+void Reduction::place_item_and_companions(
+        SolutionBuilder& solution_builder,
+        BinPos bin_pos,
+        ItemTypeId item_type_id,
+        Point bl_corner,
+        bool rotate,
+        const std::vector<CompanionItem>& companions) const
+{
+    solution_builder.add_item(bin_pos, item_type_id, bl_corner, rotate);
+    for (const CompanionItem& companion: companions) {
+        Point companion_bl_corner{
+            bl_corner.x + companion.offset.x,
+            bl_corner.y + companion.offset.y};
+        place_item_and_companions(
+                solution_builder,
+                bin_pos,
+                companion.item_type_id,
+                companion_bl_corner,
+                companion.rotate,
+                companion.nested_companions);
+    }
+}
+
+Solution Reduction::unreduce_solution(
+        const Solution& solution) const
+{
+    SolutionBuilder solution_builder(*original_instance_);
+
+    // For each reduced item type, how many of its placements have been
+    // encountered so far while scanning 'solution' (used to pick the right
+    // entry of 'companions_by_copy' - any consistent order works, since
+    // companion-bin instances of the same type are interchangeable).
+    std::vector<ItemPos> next_copy_index(instance_.number_of_item_types(), 0);
+
+    for (BinPos bin_pos = 0;
+            bin_pos < solution.number_of_different_bins();
+            ++bin_pos) {
+        const SolutionBin& solution_bin = solution.bin(bin_pos);
+        for (BinPos copy = 0; copy < solution_bin.copies; ++copy) {
+            BinPos new_bin_pos = solution_builder.add_bin(solution_bin.bin_type_id, 1);
+            for (const SolutionItem& solution_item: solution_bin.items) {
+                ItemTypeId original_item_type_id =
+                    reduced_to_original_item_type_ids_[solution_item.item_type_id];
+                const ReductionItemType& item_type = final_item_types_[original_item_type_id];
+
+                std::vector<CompanionItem> no_companions;
+                const std::vector<CompanionItem>* companions = &no_companions;
+                if (!item_type.companions_by_copy.empty()) {
+                    ItemPos copy_index = next_copy_index[solution_item.item_type_id]++;
+                    companions = &item_type.companions_by_copy[copy_index];
+                }
+                place_item_and_companions(
+                        solution_builder,
+                        new_bin_pos,
+                        original_item_type_id,
+                        solution_item.bl_corner,
+                        solution_item.rotate,
+                        *companions);
+            }
+        }
+    }
+
+    // Reinstate each "full bin item"/"perfect pair"/"both group"
+    // reservation as its own dedicated bin(s) (see
+    // 'FullBinItem'/'PerfectPair'/'BothGroup'): entirely absent from
+    // 'instance_', so nothing above ever encounters them while scanning
+    // 'solution'. Only ever populated when 'original_instance_' has a
+    // single bin type (see 'reduce_full_bin_items'/'reduce_perfect_pairs'/
+    // 'reduce_both_groups'/'try_reduce_both_group'), so bin type id 0
+    // always refers to it.
+    for (const FullBinItem& full_bin_item: full_bin_items_) {
+        for (BinPos copy = 0; copy < full_bin_item.copies; ++copy) {
+            BinPos new_bin_pos = solution_builder.add_bin(0, 1);
+            place_item_and_companions(
+                    solution_builder,
+                    new_bin_pos,
+                    full_bin_item.item_type_id,
+                    Point{0, 0},
+                    full_bin_item.rotate,
+                    full_bin_item.companions_by_copy[copy]);
+        }
+    }
+    for (const PerfectPair& pair: perfect_pairs_) {
+        for (BinPos copy = 0; copy < pair.copies; ++copy) {
+            BinPos new_bin_pos = solution_builder.add_bin(0, 1);
+            place_item_and_companions(
+                    solution_builder,
+                    new_bin_pos,
+                    pair.item_type_id_1,
+                    Point{0, 0},
+                    false,
+                    pair.item_1_companions_by_copy[copy]);
+            place_item_and_companions(
+                    solution_builder,
+                    new_bin_pos,
+                    pair.item_type_id_2,
+                    pair.offset_2,
+                    false,
+                    pair.item_2_companions_by_copy[copy]);
+        }
+    }
+    // Unlike 'full_bin_items_'/'perfect_pairs_', each 'BothGroup' entry is
+    // already exactly one dedicated bin (see its own doc comment for why
+    // there is no shared 'copies' count to expand), and every item in it
+    // already carries its own absolute position and rotation directly
+    // from the companion-bin check's own solution - no relative-offset
+    // translation needed, since that check's own bin was already
+    // 'bin_w'x'bin_h', the same as this dedicated bin.
+    for (const BothGroup& group: both_groups_) {
+        BinPos new_bin_pos = solution_builder.add_bin(0, 1);
+        for (const BothGroup::PlacedItem& placed_item: group.items) {
+            place_item_and_companions(
+                    solution_builder,
+                    new_bin_pos,
+                    placed_item.item_type_id,
+                    placed_item.bl_corner,
+                    placed_item.rotate,
+                    placed_item.companions);
+        }
+    }
+
+    return solution_builder.build();
+}

--- a/test/rectangle/CMakeLists.txt
+++ b/test/rectangle/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(PackingSolver_rectangle_test PRIVATE
     benders_decomposition_test.cpp
     conservative_scales_test.cpp
     dual_feasible_functions_test.cpp
+    reduction_test.cpp
     sequential_value_correction_test.cpp
     tree_search/test.cpp
     tree_search/defects_test.cpp

--- a/test/rectangle/reduction_test.cpp
+++ b/test/rectangle/reduction_test.cpp
@@ -1,0 +1,1084 @@
+#include "packingsolver/rectangle/instance_builder.hpp"
+#include "packingsolver/rectangle/optimize.hpp"
+#include "packingsolver/rectangle/reduction.hpp"
+#include "rectangle/solution_builder.hpp"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <sstream>
+
+using namespace packingsolver;
+using namespace packingsolver::rectangle;
+
+namespace
+{
+
+/** Rectangle (accounting for rotation) an item occupies. */
+Rectangle item_footprint(const ItemType& item_type, bool rotate)
+{
+    return rotate? Rectangle{item_type.rect.y, item_type.rect.x}: item_type.rect;
+}
+
+/** Check that a solution has no two overlapping items and everything lies within its bin. */
+void expect_geometrically_valid(const Solution& solution)
+{
+    for (BinPos bin_pos = 0;
+            bin_pos < solution.number_of_different_bins();
+            ++bin_pos) {
+        const SolutionBin& solution_bin = solution.bin(bin_pos);
+        const BinType& bin_type = solution.instance().bin_type(solution_bin.bin_type_id);
+        for (size_t item_pos_1 = 0; item_pos_1 < solution_bin.items.size(); ++item_pos_1) {
+            const SolutionItem& item_1 = solution_bin.items[item_pos_1];
+            const ItemType& item_type_1 = solution.instance().item_type(item_1.item_type_id);
+            Rectangle footprint_1 = item_footprint(item_type_1, item_1.rotate);
+            EXPECT_LE(item_1.bl_corner.x + footprint_1.x, bin_type.rect.x);
+            EXPECT_LE(item_1.bl_corner.y + footprint_1.y, bin_type.rect.y);
+            for (size_t item_pos_2 = item_pos_1 + 1; item_pos_2 < solution_bin.items.size(); ++item_pos_2) {
+                const SolutionItem& item_2 = solution_bin.items[item_pos_2];
+                const ItemType& item_type_2 = solution.instance().item_type(item_2.item_type_id);
+                Rectangle footprint_2 = item_footprint(item_type_2, item_2.rotate);
+                EXPECT_FALSE(rect_intersection(
+                        item_1.bl_corner, footprint_1,
+                        item_2.bl_corner, footprint_2))
+                    << "Items " << item_1.item_type_id << " and " << item_2.item_type_id << " overlap.";
+            }
+        }
+    }
+}
+
+}
+
+TEST(RectangleReduction, WideItemWithNarrowCompanionsExactFit)
+{
+    // Bin 10x10. Item 0 (8x10) is wide (8 > 10/2): its companion strip is
+    // (2, 10). Items 1 (2x4) and 2 (2x6) exactly tile that strip stacked
+    // vertically (4 + 6 = 10), so item 0 gets validated-wide-enlarged to
+    // (10x10) with items 1/2 as its real companions - and since its
+    // height (10) already equalled the bin's, that enlarged size exactly
+    // matches the *true* bin too: 'reduce_full_bin_items' then claims it
+    // as its own dedicated bin, capturing items 1/2 along with it (see
+    // 'FullBinItem::companions_by_copy') rather than leaving item 0
+    // present in the reduced instance.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(8, 10, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(2, 4, true);
+    instance_builder.set_item_type_copies(1, 1);
+    instance_builder.add_item_type(2, 6, true);
+    instance_builder.set_item_type_copies(2, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    Solution reduced_solution = reduced_solution_builder.build();
+
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    EXPECT_EQ(solution.number_of_bins(), 1);
+    ASSERT_EQ(solution.bin(0).items.size(), 3);
+    expect_geometrically_valid(solution);
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_EQ(output.solution_pool.best().number_of_bins(), 1);
+    EXPECT_TRUE(output.solution_pool.best().full());
+}
+
+TEST(RectangleReduction, TallItemWithNarrowCompanionsExactFit)
+{
+    // Bin 10x10. Item 0 (4x8) is tall (8 > 10/2) but not wide (4 <= 5):
+    // its companion strip is (4, 2). Items 1 (1x2) and 2 (3x2) - neither
+    // wide nor tall themselves - exactly tile that strip side by side
+    // (1 + 3 = 4).
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(4, 8, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(1, 2, true);
+    instance_builder.set_item_type_copies(1, 1);
+    instance_builder.add_item_type(3, 2, true);
+    instance_builder.set_item_type_copies(2, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 1);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.x, 4);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.y, 10);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    BinPos bin_pos = reduced_solution_builder.add_bin(0, 1);
+    reduced_solution_builder.add_item(bin_pos, 0, Point{0, 0}, false);
+    Solution reduced_solution = reduced_solution_builder.build();
+
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    EXPECT_EQ(solution.number_of_bins(), 1);
+    ASSERT_EQ(solution.bin(0).items.size(), 3);
+    expect_geometrically_valid(solution);
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_EQ(output.solution_pool.best().number_of_bins(), 1);
+    EXPECT_TRUE(output.solution_pool.best().full());
+}
+
+TEST(RectangleReduction, WideAndTallItemWithFullBinCompanionsExactFit)
+{
+    // Bin 10x10. Item 0 (6x6) is both wide and tall: its companion "bin" is
+    // the full (10, 10) bin, with item 0 fixed at the bottom-left corner.
+    // Items 1 and 2 (4x5 each) together need the *entire* right-hand
+    // column (4 wide, the full 10 tall) - more than item 0's own row (6
+    // tall), so neither fits in the wide sub-case's smaller (4, 6) strip
+    // check (which would need to hold both, 40 > 24 = strip area) or the
+    // tall sub-case's (6, 4) strip check (both are 5 tall, taller than
+    // that strip); only the "both" case's full-bin check has room for
+    // them. This deliberately leaves the top-left (6, 4) corner
+    // unpacked - the point is to exercise the full-bin/fixed-item
+    // mechanism in isolation, not to reach a zero-waste packing. Item 0's
+    // validated-both-enlargement sets both dimensions to the bin's own
+    // (10x10), which then also exactly matches the *true* bin:
+    // 'reduce_full_bin_items' claims it as its own dedicated bin,
+    // capturing items 1/2 along with it (see
+    // 'FullBinItem::companions_by_copy') rather than leaving item 0
+    // present in the reduced instance.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(6, 6, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(4, 5, true);
+    instance_builder.set_item_type_copies(1, 1);
+    instance_builder.add_item_type(4, 5, true);
+    instance_builder.set_item_type_copies(2, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    Solution reduced_solution = reduced_solution_builder.build();
+
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    EXPECT_EQ(solution.number_of_bins(), 1);
+    ASSERT_EQ(solution.bin(0).items.size(), 3);
+    expect_geometrically_valid(solution);
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_EQ(output.solution_pool.best().number_of_bins(), 1);
+    EXPECT_TRUE(output.solution_pool.best().full());
+}
+
+TEST(RectangleReduction, NarrowButTallItemPreventsWideReduction)
+{
+    // Bin 10x10. Item 0 (7x4) is wide (7 > 5): its companion strip is
+    // (3, 4). Item 1 (2x8) is narrow enough to fall into that strip by
+    // width alone (2 <= 3), but far too tall for it (8 > 4) - and does not
+    // fit anywhere else in the instance either. A reduction that only
+    // checked whether item 1 fits *this one* strip's height too (instead
+    // of including every width-eligible item in the packing check
+    // regardless of height, matching the width-only definition of the
+    // candidate set) could wrongly conclude no companion applies and
+    // enlarge item 0 anyway; item 0 must be left untouched.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(7, 4, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(2, 8, true);
+    instance_builder.set_item_type_copies(1, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    EXPECT_EQ(reduction.instance().number_of_item_types(), 2);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.x, 7);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.y, 4);
+}
+
+TEST(RectangleReduction, PerfectPairSideBySideExactFit)
+{
+    // Bin 10x10. Items 0 and 1 (5x10 each) both span the bin's full height
+    // and their widths sum exactly to the bin's full width (5 + 5 = 10),
+    // but neither is "wide" under the wide/tall/both cases (2*5 = 10 is not
+    // > 10): this is exactly the exact-boundary case those cases miss and
+    // the perfect-pair rule catches. Both item types are removed entirely
+    // (not enlarged): nothing else could ever share their dedicated bin.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(5, 10, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(5, 10, true);
+    instance_builder.set_item_type_copies(1, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    EXPECT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    Solution reduced_solution = reduced_solution_builder.build();
+
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    EXPECT_EQ(solution.number_of_bins(), 1);
+    ASSERT_EQ(solution.bin(0).items.size(), 2);
+    expect_geometrically_valid(solution);
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_EQ(output.solution_pool.best().number_of_bins(), 1);
+    EXPECT_TRUE(output.solution_pool.best().full());
+    EXPECT_EQ(output.bin_packing_bound, 1);
+}
+
+TEST(RectangleReduction, PerfectPairStackedExactFit)
+{
+    // Bin 10x8. Item 0 (10x3) and item 1 (10x5), both oriented, span the
+    // bin's full width and their heights sum exactly to its full height
+    // (3 + 5 = 8): the "horizontal split" case (unlike
+    // 'PerfectPairSideBySideExactFit''s "vertical split").
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 8);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(10, 3, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(10, 5, true);
+    instance_builder.set_item_type_copies(1, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    EXPECT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    Solution reduced_solution = reduced_solution_builder.build();
+
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    EXPECT_EQ(solution.number_of_bins(), 1);
+    ASSERT_EQ(solution.bin(0).items.size(), 2);
+    expect_geometrically_valid(solution);
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_EQ(output.solution_pool.best().number_of_bins(), 1);
+    EXPECT_TRUE(output.solution_pool.best().full());
+    EXPECT_EQ(output.bin_packing_bound, 1);
+}
+
+TEST(RectangleReduction, BothGroupCatchesNonOrientedPairPerfectPairCannot)
+{
+    // Bin 10x8. Item 0 (10x3, oriented) spans the bin's full width. Item 1
+    // (5x10, non-oriented) does not match stacked as declared (5 != 10),
+    // and only its *rotated* footprint (10x5) would complete the pair
+    // (3 + 5 = 8) - but 'reduce_perfect_pairs' requires both sides to be
+    // 'oriented' (see its own doc comment for why: unlike
+    // 'reduce_full_bin_items', matching only one bin dimension never
+    // forces a non-oriented item's other orientation to become
+    // infeasible, so nothing guarantees a true optimal solution couldn't
+    // place it the other way), so 'reduce_perfect_pairs' itself never
+    // finds this pair.
+    //
+    // 'reduce_both_groups' does, though: item 1 (2*10 > 10 and 2*5 > 8 when
+    // rotated) is "both"-big via its rotated presentation alone (see
+    // 'is_big''s own doc comment for why a non-oriented item is safe to
+    // admit there, unlike for 'reduce_perfect_pairs'), and the actual
+    // companion-bin feasibility check it runs - unlike
+    // 'reduce_perfect_pairs''s own pure dimension match - directly proves
+    // item 0 fits alongside item 1's rotated form, so the two are captured
+    // together as a single dedicated "both" group instead.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 8);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(10, 3, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(5, 10, false);
+    instance_builder.set_item_type_copies(1, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    EXPECT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    Solution reduced_solution = reduced_solution_builder.build();
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    EXPECT_EQ(solution.number_of_bins(), 1);
+    expect_geometrically_valid(solution);
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_EQ(output.solution_pool.best().number_of_bins(), 1);
+    EXPECT_TRUE(output.solution_pool.best().full());
+    EXPECT_EQ(output.bin_packing_bound, 1);
+}
+
+TEST(RectangleReduction, PerfectPairUnequalCopiesPartiallyReduces)
+{
+    // Bin 10x10. Items 0 and 1 (5x10 each) tile the bin exactly like in
+    // 'PerfectPairSideBySideExactFit', but item 0 has 2 copies against
+    // item 1's 4: only 'min(2,4)=2' copies can be paired into 2 dedicated
+    // bins, fully consuming item 0 (removed entirely), while item 1 keeps
+    // its leftover 2 copies as an ordinary item type in the reduced
+    // instance ('reduce_perfect_pairs' never pairs an item type with
+    // itself, so those 2 copies are left for the underlying solver -
+    // which still finds, on its own, that they tile one more bin together
+    // (5+5=10): 3 bins total, confirming the reduction stays sound
+    // (optimal) even though it only handles part of the instance itself).
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(5, 10, true);
+    instance_builder.set_item_type_copies(0, 2);
+    instance_builder.add_item_type(5, 10, true);
+    instance_builder.set_item_type_copies(1, 4);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 1);
+    EXPECT_EQ(reduction.instance().item_type(0).copies, 2);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 2);
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_EQ(output.solution_pool.best().number_of_bins(), 3);
+    EXPECT_TRUE(output.solution_pool.best().full());
+    EXPECT_EQ(output.bin_packing_bound, 3);
+}
+
+TEST(RectangleReduction, PerfectPairLimitedByFiniteBinCopies)
+{
+    // Bin 10x10 with only 1 copy available (Feasibility objective). Items 0
+    // and 1 (5x10 each, 2 copies each) would tile the bin exactly, twice
+    // over (needing 2 dedicated bins), but only 1 bin copy exists in total:
+    // the reduction must not reserve more dedicated bins than the bin type
+    // actually has copies for, leaving both item types for the underlying
+    // solver instead (which, with only 1 bin available for 2 copies of
+    // each item, correctly proves the instance infeasible).
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::Feasibility);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, 1);
+    instance_builder.add_item_type(5, 10, true);
+    instance_builder.set_item_type_copies(0, 2);
+    instance_builder.add_item_type(5, 10, true);
+    instance_builder.set_item_type_copies(1, 2);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 0);
+    EXPECT_EQ(reduction.instance().number_of_item_types(), 2);
+    EXPECT_EQ(reduction.instance().bin_type(0).copies, 1);
+}
+
+TEST(RectangleReduction, FullBinItemExactFit)
+{
+    // Bin 10x10. Item 0 (10x10, 2 copies) already exactly matches the
+    // bin's own dimensions: nothing could ever share a bin with it, so it
+    // is removed entirely and set aside as its own dedicated bin, one per
+    // copy - even though it also satisfies the "both" case's 'is_big'
+    // test (2*10 > 10 on both axes), 'try_reduce_group' would otherwise
+    // leave it untouched (zero room for any companion to absorb).
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(10, 10, true);
+    instance_builder.set_item_type_copies(0, 2);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    EXPECT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 2);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    Solution reduced_solution = reduced_solution_builder.build();
+
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    EXPECT_EQ(solution.number_of_bins(), 2);
+    expect_geometrically_valid(solution);
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_EQ(output.solution_pool.best().number_of_bins(), 2);
+    EXPECT_TRUE(output.solution_pool.best().full());
+    EXPECT_EQ(output.bin_packing_bound, 2);
+}
+
+TEST(RectangleReduction, FullBinItemWithRotationExactFit)
+{
+    // Bin 10x8. Item 0 (8x10, non-oriented, 1 copy) does not match the
+    // bin's dimensions as declared, but its rotated footprint (10x8)
+    // does.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 8);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(8, 10, false);
+    instance_builder.set_item_type_copies(0, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    EXPECT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    Solution reduced_solution = reduced_solution_builder.build();
+
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    EXPECT_EQ(solution.number_of_bins(), 1);
+    ASSERT_EQ(solution.bin(0).items.size(), 1);
+    EXPECT_TRUE(solution.bin(0).items[0].rotate);
+    expect_geometrically_valid(solution);
+}
+
+TEST(RectangleReduction, FullBinItemExhaustsCapacityProvesInfeasible)
+{
+    // Bin 10x10 with only 1 copy available (Feasibility objective). Item 0
+    // (10x10, 1 copy) exactly matches the bin and claims the sole bin copy
+    // as its own dedicated bin; item 1 (2x2, 1 copy) is a real, unrelated
+    // item still left over with nowhere to go - the reduction alone
+    // already proves the instance infeasible, without needing to run any
+    // solve on the (otherwise still-buildable) reduced instance.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::Feasibility);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, 1);
+    instance_builder.add_item_type(10, 10, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(2, 2, true);
+    instance_builder.set_item_type_copies(1, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    EXPECT_TRUE(reduction.proven_infeasible());
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_TRUE(output.is_proven_infeasible);
+}
+
+TEST(RectangleReduction, CompanionlessEnlargementUpgradedToFullBinItem)
+{
+    // Bin 10x10. Item 0 (10x9, 1 copy) already spans the bin's full width
+    // (a degenerate "wide" strip) and is "tall" (2*9 > 10) with a
+    // genuinely checked, non-degenerate but empty companion strip (10
+    // wide, 1 tall - there is no other item type in the instance to ever
+    // fill it): the companionless step enlarges it to 10x10 with zero
+    // companions. Once enlarged, it exactly matches the bin on both axes -
+    // a strictly better reduction (full removal, as its own dedicated
+    // bin) that 'reduce_full_bin_items' must be allowed to pick up in a
+    // later round, even though the item is already 'enlarged'.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(10, 9, true);
+    instance_builder.set_item_type_copies(0, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    EXPECT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_EQ(output.solution_pool.best().number_of_bins(), 1);
+    EXPECT_TRUE(output.solution_pool.best().full());
+    EXPECT_EQ(output.bin_packing_bound, 1);
+}
+
+TEST(RectangleReduction, BothCompanionlessCaptureUsesCorrectRotation)
+{
+    // Bin 10x8. Item 0 (7x9, non-oriented, 1 copy) is the only item type
+    // in the instance. Its *declared* form (7x9) does not fit the bin at
+    // all (9 > 8), only its *rotated* form (9x7) does - 'is_big''s own
+    // 'Both' check does not itself distinguish this (it is a pure
+    // threshold comparison, not a fit check: 2*7 > 10 and 2*9 > 8 already
+    // hold for the declared form alone), so it is
+    // 'reduce_companionless_items''s own responsibility to work out which
+    // orientation the item can actually be captured at, exactly as
+    // 'reduce_full_bin_items' already does - not simply assume the
+    // declared one, which would silently build a geometrically invalid
+    // dedicated bin (found via a regression: an earlier version of this
+    // code always captured a companionless "both" item at its declared
+    // orientation unconditionally).
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 8);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(7, 9, false);
+    instance_builder.set_item_type_copies(0, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    EXPECT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    Solution reduced_solution = reduced_solution_builder.build();
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    ASSERT_EQ(solution.number_of_bins(), 1);
+    ASSERT_EQ(solution.bin(0).items.size(), 1);
+    EXPECT_TRUE(solution.bin(0).items[0].rotate);
+    expect_geometrically_valid(solution);
+}
+
+TEST(RectangleReduction, FullBinItemViaShrunkBin)
+{
+    // Bin 10x10. Item 0 (9x9, oriented, 1 copy) is the only item type in
+    // the instance: equation (7) ("shrinking the bins": see
+    // 'compute_shrunk_bin_sizes') proves the bin's true achievable
+    // width/height, given only this item, is exactly 9x9 - matching item
+    // 0's own dimensions exactly - so nothing could ever share its bin
+    // (the remaining (1,10)+(9,1) L-shaped margin is guaranteed
+    // permanently unusable), even though item 0 does not physically fill
+    // the true 10x10 bin.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(9, 9, true);
+    instance_builder.set_item_type_copies(0, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    EXPECT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_EQ(output.solution_pool.best().number_of_bins(), 1);
+    EXPECT_TRUE(output.solution_pool.best().full());
+    EXPECT_EQ(output.bin_packing_bound, 1);
+}
+
+TEST(RectangleReduction, PerfectPairViaShrunkBin)
+{
+    // Bin 10x10. Items 0 and 1 (4x9 each, oriented, 1 copy each) do not
+    // tile the true bin exactly (4+4=8 < 10, 9 < 10), but equation (7)
+    // ("shrinking the bins": see 'compute_shrunk_bin_sizes') proves the
+    // bin's true achievable width/height, given only these two items, is
+    // exactly 8x9 - so the pair does exactly tile the *shrunk* bin, with
+    // the remaining (10-8=2, 10-9=1) L-shaped margin guaranteed
+    // permanently unusable by anything else (nothing else in the instance
+    // is small enough to ever occupy it).
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(4, 9, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(4, 9, true);
+    instance_builder.set_item_type_copies(1, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    EXPECT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    Solution reduced_solution = reduced_solution_builder.build();
+
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    EXPECT_EQ(solution.number_of_bins(), 1);
+    ASSERT_EQ(solution.bin(0).items.size(), 2);
+    expect_geometrically_valid(solution);
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_EQ(output.solution_pool.best().number_of_bins(), 1);
+    EXPECT_TRUE(output.solution_pool.best().full());
+    EXPECT_EQ(output.bin_packing_bound, 1);
+}
+
+TEST(RectangleReduction, PerfectPairCompanionHasItsOwnCompanions)
+{
+    // Bin 10x10. Item 1 (6x6, oriented) is "tall" (2*6 > 10): its
+    // companion strip (6, 4) is exactly filled by item 2 (6x4), so item 1
+    // gets validated-tall-enlarged to 6x10 with item 2 as its real
+    // companion. Item 0 (4x10, oriented) already spans the bin's full
+    // height and, together with item 1's *now*-enlarged width (6),
+    // exactly tiles the bin (4+6=10): a 'PerfectPair' with item 0 as
+    // survivor and item 1 as its companion - except item 1 itself already
+    // carries a real companion (item 2) from its own earlier enlargement,
+    // exercising the two-level nesting 'place_item_and_companions'
+    // recurses through (item 0 -> item 1 -> item 2).
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(4, 10, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(6, 6, true);
+    instance_builder.set_item_type_copies(1, 1);
+    instance_builder.add_item_type(6, 4, true);
+    instance_builder.set_item_type_copies(2, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    Solution reduced_solution = reduced_solution_builder.build();
+
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    EXPECT_EQ(solution.number_of_bins(), 1);
+    ASSERT_EQ(solution.bin(0).items.size(), 3);
+    expect_geometrically_valid(solution);
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_EQ(output.solution_pool.best().number_of_bins(), 1);
+    EXPECT_TRUE(output.solution_pool.best().full());
+    EXPECT_EQ(output.bin_packing_bound, 1);
+}
+
+TEST(RectangleReduction, BothGroupCompanionHasItsOwnCompanions)
+{
+    // Bin 10x10. Item 1 (3x7, oriented) is "tall" (2*7 > 10): its
+    // companion strip (3, 3) is exactly filled by item 2 (3x3), so item 1
+    // gets validated-tall-enlarged to 3x10 with item 2 as its real
+    // companion - all within 'reduce_group(Tall)', which runs before
+    // 'reduce_both_groups' in the same round.
+    //
+    // Item 0 (6x6, oriented) is "both"-big (2*6 > 10 on both axes). Its
+    // companion-bin check offers every not-yet-removed item type as a
+    // candidate - including item 1, even though item 1 is *already*
+    // enlarged (an already-enlarged item type must not be excluded from
+    // this candidate scan: excluding it would mean concluding "nothing
+    // could fit here" using a narrower pool than the original problem
+    // actually offers - see 'try_reduce_both_group''s own R-candidate
+    // scan). Item 1's *current* dimensions (3x10) do fit alongside item 0
+    // in the full 10x10 companion bin (6+3=9 <= 10), so the check
+    // succeeds and item 0 absorbs item 1 as a real "both" companion -
+    // exercising the two-level nesting 'place_item_and_companions'
+    // recurses through (item 0 -> item 1 -> item 2), the same as
+    // 'PerfectPairCompanionHasItsOwnCompanions' but reached via
+    // 'reduce_both_groups' instead of 'reduce_perfect_pairs'.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(6, 6, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(3, 7, true);
+    instance_builder.set_item_type_copies(1, 1);
+    instance_builder.add_item_type(3, 3, true);
+    instance_builder.set_item_type_copies(2, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    Solution reduced_solution = reduced_solution_builder.build();
+
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    EXPECT_EQ(solution.number_of_bins(), 1);
+    ASSERT_EQ(solution.bin(0).items.size(), 3);
+    expect_geometrically_valid(solution);
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_EQ(output.solution_pool.best().number_of_bins(), 1);
+    EXPECT_TRUE(output.solution_pool.best().full());
+    EXPECT_EQ(output.bin_packing_bound, 1);
+}
+
+TEST(RectangleReduction, TallCompanionlessEnlargementIndependentOfBlockedWideStrip)
+{
+    // Bin 10x10, all items oriented. Item 0 (6x9) is "big" under wide
+    // (2*6 > 10), tall (2*9 > 10) AND both simultaneously. Its wide strip
+    // (4x9, beside it) is blocked from companionless enlargement: item 2
+    // (4x2) is narrow enough (width 4) to pass the necessary 'could_fit'
+    // pre-filter for that strip, even though it (and nothing else here)
+    // can actually exactly tile all 36 units of it - so wide's own
+    // validated-companion search also fails to enlarge item 0, leaving it
+    // genuinely undecided on that axis. Item 0's *tall* strip (6x1, above
+    // it) is a completely different region: no item has height <= 1, so
+    // it is provably, permanently empty regardless of the wide strip's
+    // status. This is a regression test for a bug where companionless
+    // enlargement's blocking check was wrongly shared across all three
+    // axes via one flag threaded through wide/tall/both, so the wide
+    // strip's real (if inconclusive) candidate silently vetoed the tall
+    // strip's own, otherwise-conclusive, empty-margin proof - item 0 must
+    // still get tall-companionless-enlarged to (6x10) independently of
+    // the wide strip's outcome, at which point it exactly matches item 1
+    // (4x10) as a 'PerfectPair' (6+4=10), leaving item 2 untouched in the
+    // reduced instance.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(6, 9, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(4, 10, true);
+    instance_builder.set_item_type_copies(1, 1);
+    instance_builder.add_item_type(4, 2, true);
+    instance_builder.set_item_type_copies(2, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 1);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.x, 4);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.y, 2);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    BinPos bin_pos = reduced_solution_builder.add_bin(0, 1);
+    reduced_solution_builder.add_item(bin_pos, 0, Point{0, 0}, false);
+    Solution reduced_solution = reduced_solution_builder.build();
+
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    ASSERT_EQ(solution.number_of_bins(), 2);
+    expect_geometrically_valid(solution);
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_EQ(output.solution_pool.best().number_of_bins(), 2);
+    EXPECT_TRUE(output.solution_pool.best().full());
+    EXPECT_EQ(output.bin_packing_bound, 2);
+}
+
+TEST(RectangleReduction, WideThenTallRealCompanionsComposeIntoFullBinItem)
+{
+    // Bin 10x10, all items oriented. Item 0 (6x9) is "wide" (2*6 > 10):
+    // its wide strip (4x9) is exactly tiled by item 1 (4x9), so
+    // 'try_reduce_group' validated-wide-enlarges it to (10x9) with item 1
+    // as a real companion - it does not yet span the bin's full height.
+    // Item 0's *current* dimensions (10x9, already full width) are then
+    // reconsidered for "tall": its now-full-width top strip (10x1) is
+    // exactly tiled by item 2 (10x1), a real companion nothing else could
+    // have offered before item 0's width grew. This requires
+    // 'gather_sorted_big_items' to not exclude an already-enlarged item 0
+    // from tall's own search, and 'try_reduce_group''s 'enlarge()' to
+    // append item 2 onto item 0's 'companions_by_copy' alongside item 1
+    // (rather than overwriting it), composing item 0 up to (10x10) - a
+    // full bin, captured whole by 'reduce_full_bin_items' with both item 1
+    // and item 2 as its direct (sibling, not nested) companions.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(6, 9, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(4, 9, true);
+    instance_builder.set_item_type_copies(1, 1);
+    instance_builder.add_item_type(10, 1, true);
+    instance_builder.set_item_type_copies(2, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    Solution reduced_solution = reduced_solution_builder.build();
+
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    ASSERT_EQ(solution.number_of_bins(), 1);
+    ASSERT_EQ(solution.bin(0).items.size(), 3);
+    expect_geometrically_valid(solution);
+
+    OptimizeParameters optimize_parameters;
+    rectangle::Output output = optimize(instance, optimize_parameters);
+    EXPECT_EQ(output.solution_pool.best().number_of_bins(), 1);
+    EXPECT_TRUE(output.solution_pool.best().full());
+    EXPECT_EQ(output.bin_packing_bound, 1);
+}
+
+
+// Reports the percentage of items removed by 'Reduction' across the full
+// berkey1987/martello1998 benchmark (500 instances, classes 1-10, n in
+// {20,40,60,80,100}, 10 instances each - the same benchmark and grouping as
+// Côté, Haouari & Iori 2019/2021 Tables 4/5), for comparison against the
+// paper's own '%rmv' column (average percentage of items removed by its
+// Section 4.2 preprocessing). 'DISABLED_' since it prints a report rather
+// than asserting anything and would otherwise slow down every routine
+// 'ctest' run for no benefit - run explicitly with:
+//   PackingSolver_rectangle_test --gtest_filter='*ReportBenchmarkRmv' --gtest_also_run_disabled_tests
+// (from the repository root, so the 'data/rectangle/...' relative paths
+// resolve).
+TEST(RectangleReduction, DISABLED_ReportBenchmarkRmv)
+{
+    struct ClassInfo { std::string dir; int class_id; };
+    std::vector<ClassInfo> classes = {
+        {"berkey1987", 1}, {"berkey1987", 2}, {"berkey1987", 3},
+        {"berkey1987", 4}, {"berkey1987", 5}, {"berkey1987", 6},
+        {"martello1998", 7}, {"martello1998", 8}, {"martello1998", 9}, {"martello1998", 10},
+    };
+    std::vector<int> sizes = {20, 40, 60, 80, 100};
+
+    std::map<int, std::vector<double>> by_class;
+    std::map<int, std::vector<double>> by_size;
+    std::vector<double> all;
+
+    for (const ClassInfo& class_info: classes) {
+        for (int size: sizes) {
+            for (int instance_num = 1; instance_num <= 10; ++instance_num) {
+                char class_str[8];
+                snprintf(class_str, sizeof(class_str), "%02d", class_info.class_id);
+                std::ostringstream base;
+                base << "data/rectangle/" << class_info.dir << "/Class_" << class_str
+                     << ".2bp_" << size << "_" << instance_num;
+                InstanceBuilder instance_builder;
+                instance_builder.set_objective(Objective::BinPacking);
+                instance_builder.read_item_types(base.str() + "_items.csv");
+                instance_builder.read_bin_types(base.str() + "_bins.csv");
+                instance_builder.set_bin_type_copies(0, -1);
+                instance_builder.set_item_types_oriented();
+                Instance instance = instance_builder.build();
+
+                ItemPos total_items = instance.number_of_items();
+                Reduction reduction(instance);
+                ItemPos remaining_items = reduction.instance().number_of_items();
+                double pct = 100.0 * (total_items - remaining_items) / total_items;
+
+                by_class[class_info.class_id].push_back(pct);
+                by_size[size].push_back(pct);
+                all.push_back(pct);
+            }
+        }
+    }
+
+    auto avg = [](const std::vector<double>& values)
+        {
+            double sum = 0.0;
+            for (double value: values)
+                sum += value;
+            return sum / values.size();
+        };
+
+    std::cout << "Per class:" << std::endl;
+    for (const ClassInfo& class_info: classes)
+        std::cout << "  class " << class_info.class_id << ": "
+            << avg(by_class[class_info.class_id]) << "%" << std::endl;
+
+    std::cout << "Per size:" << std::endl;
+    for (int size: sizes)
+        std::cout << "  n=" << size << ": " << avg(by_size[size]) << "%" << std::endl;
+
+    std::cout << "Overall: " << avg(all) << "%" << std::endl;
+}
+
+TEST(RectangleReduction, ShrunkBinViaMultipleCopiesOfSameItem)
+{
+    // Bin 20x10 (asymmetric so only the height axis is ever "big",
+    // keeping this isolated to a single case). Item 0 (5x6, oriented, 1
+    // copy) is tall (2*6=12 > 10): its own companion strip is (5,
+    // 10-target_bin_h). Item 1 (5x1, oriented, 3 copies) exactly tiles a
+    // (5,3) strip stacked three high (1+1+1=3), which is exactly what
+    // equation (7) ("shrinking the bins") computes as the tallest
+    // achievable combination not exceeding the bin's true height: item
+    // 0's own height (6) plus all three separate copies of item 1's
+    // height (1 each) sum to exactly 9 (<= 10; a fourth unit would
+    // overshoot). This specifically requires each of the 3 copies to be
+    // counted as its own individual candidate in the underlying subset-sum
+    // (not e.g. item 1's type counted only once regardless of its copies)
+    // - the target height (9) is unreachable from any smaller number of
+    // copies. Item 0 gets validated-tall-enlarged to 5x9 with all three
+    // copies of item 1 as its real companions, rather than to the bin's
+    // true height (10).
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(20, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(5, 6, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(5, 1, true);
+    instance_builder.set_item_type_copies(1, 3);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 1);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.x, 5);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.y, 9);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 0);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    BinPos bin_pos = reduced_solution_builder.add_bin(0, 1);
+    reduced_solution_builder.add_item(bin_pos, 0, Point{0, 0}, false);
+    Solution reduced_solution = reduced_solution_builder.build();
+
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    ASSERT_EQ(solution.bin(0).items.size(), 4);
+    expect_geometrically_valid(solution);
+}
+
+TEST(RectangleReduction, ShrunkBinViaNonOrientedItemRotation)
+{
+    // Bin 10x10. Item 1 (5x9, non-oriented, 1 copy) contributes to
+    // equation (7)'s width computation via *either* of its orientations:
+    // declared width 5, or rotated width 9 - and only the rotated value
+    // (9 <= 10) is what the computed shrunk width of 9 actually comes
+    // from (item 0's own width (6) alone, or item 1's declared width (5)
+    // alone, never reach it; item 0 + item 1's declared width (6+5=11)
+    // exceeds the true bin width (10) so isn't achievable at all),
+    // proving the multiple-choice subset-sum genuinely considers rotation
+    // (unlike a plain per-item subset sum, which would need to commit to
+    // one fixed value per item upfront and could never reach 9 here). The
+    // same reasoning shrinks the height to 9 too (item 1's *declared*
+    // height, 9, dominates there instead - item 0's own height (3) is too
+    // small to ever combine with it under the true bin height of 10).
+    //
+    // With 'is_big''s 'Both' case now admitting a non-oriented item (see
+    // its own doc comment), item 1's rotated presentation (2*9 > 9 and
+    // 2*5 > 9, against the *shrunk* 9x9 companion bin) makes it eligible
+    // there, and the companion-bin check - run against that same shrunk
+    // 9x9 bin, not the true 10x10 one - finds item 0 fits alongside it
+    // (stacked: item 0's height 3 plus item 1's rotated height 5 sums to
+    // exactly 9). Both items end up captured together as a single
+    // dedicated "both" group - a stronger result than the plain
+    // wide-companionless enlargement this test originally demonstrated,
+    // but one that still only succeeds because of the same rotation-aware
+    // shrunk bin computation: at the *true* 10x10 bin size this pairing
+    // would prove nothing distinctive, since almost anything fits there.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(6, 3, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(5, 9, false);
+    instance_builder.set_item_type_copies(1, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    EXPECT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    Solution reduced_solution = reduced_solution_builder.build();
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    EXPECT_EQ(solution.number_of_bins(), 1);
+    expect_geometrically_valid(solution);
+}
+
+TEST(RectangleReduction, NoReductionWhenBinHasDefects)
+{
+    // Bin 10x10 with a defect: item 0 (10x10, 2 copies) would otherwise be
+    // captured as two dedicated bins (see 'FullBinItemExactFit'), but the
+    // companion-bin checks this class performs are always plain,
+    // defect-free rectangles - a defect could sit exactly where a
+    // companion (or the big item itself) needs to go, invisibly to those
+    // checks - so the whole reduction is skipped: 'instance()' stays an
+    // unchanged copy of the original instance.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_defect(bin_type_id, 0, 0, 1, 1);
+    instance_builder.add_item_type(10, 10, true);
+    instance_builder.set_item_type_copies(0, 2);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 1);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.x, 10);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.y, 10);
+    EXPECT_EQ(reduction.instance().item_type(0).copies, 2);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 0);
+}
+
+TEST(RectangleReduction, NoReductionWhenUnloadingConstraintSet)
+{
+    // Same instance as 'FullBinItemExactFit', but with a non-'None'
+    // unloading constraint set: an unloading order that holds for the big
+    // item and its companions checked in isolation says nothing about
+    // whether it still holds once other items - chosen later by the
+    // downstream solve, never part of that isolated check - join the same
+    // bin, so the whole reduction is skipped.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    instance_builder.set_unloading_constraint(UnloadingConstraint::OnlyXMovements);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(10, 10, true);
+    instance_builder.set_item_type_copies(0, 2);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 1);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.x, 10);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.y, 10);
+    EXPECT_EQ(reduction.instance().item_type(0).copies, 2);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 0);
+}
+
+TEST(RectangleReduction, NoReductionWhenBinWeightConstrained)
+{
+    // Same instance as 'FullBinItemExactFit', but with a finite bin
+    // weight capacity and a non-zero item weight: total bin weight is a
+    // whole-bin aggregate over every item sharing it, the same
+    // whole-bin argument as the unloading constraint case, so the whole
+    // reduction is skipped.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.set_bin_type_maximum_weight(bin_type_id, 100);
+    ItemTypeId item_type_id = instance_builder.add_item_type(10, 10, true);
+    instance_builder.set_item_type_copies(item_type_id, 2);
+    instance_builder.set_item_type_weight(item_type_id, 5);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 1);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.x, 10);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.y, 10);
+    EXPECT_EQ(reduction.instance().item_type(0).copies, 2);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 0);
+}
+
+TEST(RectangleReduction, ReductionStillAppliesWithFiniteWeightButZeroItemWeights)
+{
+    // Same instance as 'NoReductionWhenBinWeightConstrained', but every
+    // item weight is left at its default (0): a finite bin weight
+    // capacity alone can never be exceeded by items that all weigh
+    // nothing, so this is not the risky case the previous test guards
+    // against, and the reduction must still apply normally.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.set_bin_type_maximum_weight(bin_type_id, 100);
+    instance_builder.add_item_type(10, 10, true);
+    instance_builder.set_item_type_copies(0, 2);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    EXPECT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 2);
+}


### PR DESCRIPTION
## Summary
- Wraps `rectangle::optimize()` with a `Reduction` step that identifies items wider/taller than half the bin (or both), proves via an `Objective::Feasibility` solve that narrower "companion" items are guaranteed to fit alongside them, and removes those companions while enlarging the big item, shrinking the instance before any tree search/Benders/SVC algorithm runs.
- Applies only to `BinPacking`, `VariableSizedBinPacking` and `Feasibility`, single-bin-type instances with no defects, no finite weight capacity with non-trivial item weights, and no unloading constraint (exposed as a static `Reduction::applies()` so `optimize()` can skip constructing one entirely when it would not apply).
- The wide/tall and "both" enlargement sub-cases are handled by separate functions instead of a shared switch, since "both" needs genuinely different control flow: it captures and replays a companion-bin check's own solution directly into a dedicated bin (`BothGroup`) rather than pre-placing the big item and enlarging it in place, using one shared companion bin type per group (no per-candidate eligibility) since two "both"-big items can never fit in the same bin by geometry alone.
- Reduction results stream into the original `AlgorithmFormatter` live via a `new_solution_callback` as the recursive solve on the reduced instance finds them.

See the commit message for full design rationale, including a `tree_search` bug found and sidestepped during development (traced via gdb to an eligibility-restriction edge case) and `#rmv` benchmark results (berkey1987 + martello1998, sizes 20-100).

## Test plan
- [x] `PackingSolver_rectangle_test` with `--gtest_filter="*Reduction*"`: 26/26 passed (1 disabled benchmark test)
- [x] Full `ctest --parallel`: 481/481 passed (1 disabled)