### PR TITLE
Fix Solution::append overload ambiguity causing silently-dropped solutions

### DIFF
--- a/include/packingsolver/algorithms/common.hpp
+++ b/include/packingsolver/algorithms/common.hpp
@@ -457,7 +457,7 @@ Solution group_identical_bins(const Solution& solution)
 
     Solution grouped_solution(solution.instance());
     for (const BinGroup& group: groups)
-        grouped_solution.append(solution, group.original_bin_pos, group.total_copies);
+        grouped_solution.append_bin(solution, group.original_bin_pos, group.total_copies);
     return grouped_solution;
 }
 

--- a/include/packingsolver/box/solution.hpp
+++ b/include/packingsolver/box/solution.hpp
@@ -73,14 +73,16 @@ public:
     /** Destructor. */
     virtual ~Solution() { }
 
-    void append(
+    /** Append a single bin of 'solution' (at 'bin_pos') to this solution. */
+    void append_bin(
             const Solution& solution,
             BinPos bin_pos,
             BinPos copies,
             const std::vector<BinTypeId>& bin_type_ids = {},
             const std::vector<ItemTypeId>& item_type_ids = {});
 
-    void append(
+    /** Append every bin of 'solution' to this solution. */
+    void append_bins(
             const Solution& solution,
             const std::vector<BinTypeId>& bin_type_ids,
             const std::vector<ItemTypeId>& item_type_ids);

--- a/include/packingsolver/boxstacks/solution.hpp
+++ b/include/packingsolver/boxstacks/solution.hpp
@@ -119,14 +119,16 @@ public:
     /** Destructor. */
     virtual ~Solution() { }
 
-    void append(
+    /** Append a single bin of 'solution' (at 'bin_pos') to this solution. */
+    void append_bin(
             const Solution& solution,
             BinPos bin_pos,
             BinPos copies,
             const std::vector<BinTypeId>& bin_type_ids = {},
             const std::vector<ItemTypeId>& item_type_ids = {});
 
-    void append(
+    /** Append every bin of 'solution' to this solution. */
+    void append_bins(
             const Solution& solution,
             const std::vector<BinTypeId>& bin_type_ids,
             const std::vector<ItemTypeId>& item_type_ids);

--- a/include/packingsolver/irregular/solution.hpp
+++ b/include/packingsolver/irregular/solution.hpp
@@ -60,14 +60,16 @@ public:
         feasible_ = (number_of_infeasible_item_copies_min_ == 0);
     }
 
-    void append(
+    /** Append a single bin of 'solution' (at 'bin_pos') to this solution. */
+    void append_bin(
             const Solution& solution,
             BinPos bin_pos,
             BinPos copies,
             const std::vector<BinTypeId>& bin_type_ids = {},
             const std::vector<ItemTypeId>& item_type_ids = {});
 
-    void append(
+    /** Append every bin of 'solution' to this solution. */
+    void append_bins(
             const Solution& solution,
             const std::vector<BinTypeId>& bin_type_ids,
             const std::vector<ItemTypeId>& item_type_ids);

--- a/include/packingsolver/onedimensional/solution.hpp
+++ b/include/packingsolver/onedimensional/solution.hpp
@@ -79,14 +79,16 @@ public:
         feasible_ = (number_of_infeasible_item_copies_min_ == 0);
     }
 
-    void append(
+    /** Append a single bin of 'solution' (at 'bin_pos') to this solution. */
+    void append_bin(
             const Solution& solution,
             BinPos bin_pos,
             BinPos copies,
             const std::vector<BinTypeId>& bin_type_ids = {},
             const std::vector<ItemTypeId>& item_type_ids = {});
 
-    void append(
+    /** Append every bin of 'solution' to this solution. */
+    void append_bins(
             const Solution& solution,
             const std::vector<BinTypeId>& bin_type_ids,
             const std::vector<ItemTypeId>& item_type_ids);

--- a/include/packingsolver/rectangle/solution.hpp
+++ b/include/packingsolver/rectangle/solution.hpp
@@ -75,14 +75,16 @@ public:
         feasible_ = (number_of_infeasible_item_copies_min_ == 0);
     }
 
-    void append(
+    /** Append a single bin of 'solution' (at 'bin_pos') to this solution. */
+    void append_bin(
             const Solution& solution,
             BinPos bin_pos,
             BinPos copies,
             const std::vector<BinTypeId>& bin_type_ids = {},
             const std::vector<ItemTypeId>& item_type_ids = {});
 
-    void append(
+    /** Append every bin of 'solution' to this solution. */
+    void append_bins(
             const Solution& solution,
             const std::vector<BinTypeId>& bin_type_ids,
             const std::vector<ItemTypeId>& item_type_ids);

--- a/include/packingsolver/rectangleguillotine/solution.hpp
+++ b/include/packingsolver/rectangleguillotine/solution.hpp
@@ -99,14 +99,16 @@ public:
         feasible_ = (number_of_infeasible_item_copies_min_ == 0);
     }
 
-    void append(
+    /** Append a single bin of 'solution' (at 'bin_pos') to this solution. */
+    void append_bin(
             const Solution& solution,
             BinPos bin_pos,
             BinPos copies,
             const std::vector<BinTypeId>& bin_type_ids = {},
             const std::vector<ItemTypeId>& item_type_ids = {});
 
-    void append(
+    /** Append every bin of 'solution' to this solution. */
+    void append_bins(
             const Solution& solution,
             const std::vector<BinTypeId>& bin_type_ids,
             const std::vector<ItemTypeId>& item_type_ids);

--- a/src/algorithms/column_generation.hpp
+++ b/src/algorithms/column_generation.hpp
@@ -186,7 +186,7 @@ std::vector<std::shared_ptr<const Column>> solution_to_columns(
             ++bin_pos) {
         BinTypeId bin_type_id = solution.bin(bin_pos).bin_type_id;
         Solution extra_solution(instance);
-        extra_solution.append(solution, bin_pos, 1);
+        extra_solution.append_bin(solution, bin_pos, 1);
         Column column;
         if (instance.objective() == Objective::VariableSizedBinPacking
                 || instance.objective() == Objective::BinPacking) {
@@ -294,7 +294,7 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution,
             Column column;
 
             Solution extra_solution(instance_);
-            extra_solution.append(
+            extra_solution.append_bin(
                     kp_entry.solution,
                     0,
                     1,
@@ -399,7 +399,7 @@ Output column_generation(
                 BinPos value = std::round(pair.second);
                 if (value < 0.5)
                     continue;
-                solution.append(
+                solution.append_bin(
                         *std::static_pointer_cast<Solution>(column.extra),
                         0,
                         value);

--- a/src/algorithms/dichotomic_search.hpp
+++ b/src/algorithms/dichotomic_search.hpp
@@ -241,7 +241,7 @@ DichotomicSearchOutput<Instance, Solution, Output> dichotomic_search(
             // Save solution.
             Solution solution(instance);
             //std::cout << bpp_solution.number_of_items() << " " << bpp_solution.number_of_bins() << std::endl;
-            solution.append(bpp_solution, bin_types_bpp2ps, item_types_bpp2ps);
+            solution.append_bins(bpp_solution, bin_types_bpp2ps, item_types_bpp2ps);
             //std::cout << solution.number_of_items() << " " << solution.number_of_bins() << std::endl;
             //std::cout << &instance << std::endl;
             std::stringstream ss;

--- a/src/algorithms/sequential_value_correction.hpp
+++ b/src/algorithms/sequential_value_correction.hpp
@@ -338,13 +338,13 @@ SequentialValueCorrectionOutput<Instance, Solution, Output> sequential_value_cor
                     auto bppl_solution = bppl_solution_pool.best();
 
                     Solution kp_solution_tmp(bppl_instance);
-                    kp_solution_tmp.append(kp_solution, 0, 1);
+                    kp_solution_tmp.append_bin(kp_solution, 0, 1);
                     if (!(bppl_solution < kp_solution_tmp))
                         kp_solution = bppl_solution;
                 }
 
                 Solution kp_solution_orig(instance);
-                kp_solution_orig.append(kp_solution, 0, 1, {bin_type_id}, kp2orig);
+                kp_solution_orig.append_bin(kp_solution, 0, 1, {bin_type_id}, kp2orig);
                 solutions_cur[bin_type_id].first = kp_solution_orig;
                 solutions_cur[bin_type_id].second = kp_solution.profit();
                 output.all_patterns.push_back(kp_solution_orig);
@@ -359,7 +359,7 @@ SequentialValueCorrectionOutput<Instance, Solution, Output> sequential_value_cor
 
                     // Update current solution.
                     Solution solution_tmp = solution;
-                    solution_tmp.append(
+                    solution_tmp.append_bin(
                             kp_solution_orig,
                             0,
                             number_of_copies);
@@ -458,7 +458,7 @@ SequentialValueCorrectionOutput<Instance, Solution, Output> sequential_value_cor
             // Update partial_fixed_copies, then current solution.
             for (const auto& fixed_item: instance.bin_type(bin_type_id_best).fixed_items)
                 partial_fixed_copies[fixed_item.item_type_id] += number_of_copies;
-            solution.append(
+            solution.append_bin(
                     kp_solution_best,
                     0,
                     number_of_copies);

--- a/src/box/solution.cpp
+++ b/src/box/solution.cpp
@@ -80,7 +80,7 @@ void Solution::update_indicators(
         && (number_of_infeasible_item_copies_min_ == 0);
 }
 
-void Solution::append(
+void Solution::append_bin(
         const Solution& solution,
         BinPos bin_pos,
         BinPos copies,
@@ -104,14 +104,14 @@ void Solution::append(
     update_indicators(bins_.size() - 1);
 }
 
-void Solution::append(
+void Solution::append_bins(
         const Solution& solution,
         const std::vector<BinTypeId>& bin_type_ids,
         const std::vector<ItemTypeId>& item_type_ids)
 {
     for (BinPos i_pos = 0; i_pos < (BinPos)solution.bins_.size(); ++i_pos) {
         const SolutionBin& bin = solution.bins_[i_pos];
-        append(solution, i_pos, bin.copies, bin_type_ids, item_type_ids);
+        append_bin(solution, i_pos, bin.copies, bin_type_ids, item_type_ids);
     }
 }
 

--- a/src/boxstacks/solution.cpp
+++ b/src/boxstacks/solution.cpp
@@ -229,7 +229,7 @@ Weight Solution::compute_rear_axle_weight_constraints_violation() const
     return violation;
 }
 
-void Solution::append(
+void Solution::append_bin(
         const Solution& solution,
         BinPos bin_pos,
         BinPos copies,
@@ -261,14 +261,14 @@ void Solution::append(
     update_indicators(bins_.size() - 1);
 }
 
-void Solution::append(
+void Solution::append_bins(
         const Solution& solution,
         const std::vector<BinTypeId>& bin_type_ids,
         const std::vector<ItemTypeId>& item_type_ids)
 {
     for (BinPos i_pos = 0; i_pos < (BinPos)solution.bins_.size(); ++i_pos) {
         const SolutionBin& bin = solution.bins_[i_pos];
-        append(solution, i_pos, bin.copies, bin_type_ids, item_type_ids);
+        append_bin(solution, i_pos, bin.copies, bin_type_ids, item_type_ids);
     }
 }
 

--- a/src/irregular/large_item_first.cpp
+++ b/src/irregular/large_item_first.cpp
@@ -211,7 +211,7 @@ LargeItemFirstOutput packingsolver::irregular::large_item_first(
 
     // Reconstruct and report the solution in the original instance.
     Solution solution(instance);
-    solution.append(
+    solution.append_bins(
             phase2_output.solution_pool.best(),
             phase2_to_orig_bin_type_ids,
             {});

--- a/src/irregular/linear_programming.cpp
+++ b/src/irregular/linear_programming.cpp
@@ -639,7 +639,7 @@ LinearProgrammingAnchorOutput packingsolver::irregular::linear_programming_ancho
             ++bin_pos) {
         const SolutionBin& solution_bin = initial_solution.bin(bin_pos);
         Solution initial_solution_cur(instance);
-        initial_solution_cur.append(initial_solution, bin_pos, 1);
+        initial_solution_cur.append_bin(initial_solution, bin_pos, 1);
         Solution new_solution_cur = ::linear_programming_anchor(
                 instance,
                 initial_solution_cur,
@@ -647,7 +647,7 @@ LinearProgrammingAnchorOutput packingsolver::irregular::linear_programming_ancho
                 y_weight,
                 parameters,
                 icd);
-        solution.append(
+        solution.append_bin(
                 new_solution_cur,
                 0,
                 solution_bin.copies);

--- a/src/irregular/local_search.cpp
+++ b/src/irregular/local_search.cpp
@@ -191,7 +191,7 @@ bool pack_item(
     bin_data[bin_pos].lambda.push_back(0.0);
 
     Solution bin_solution(instance);
-    bin_solution.append(solution, bin_pos, 1);
+    bin_solution.append_bin(solution, bin_pos, 1);
 
     bool bin_feasible = false;
     while (!bin_feasible) {
@@ -225,9 +225,9 @@ bool pack_item(
     Solution new_solution(instance);
     for (BinPos bp = 0; bp < solution.number_of_bins(); ++bp) {
         if (bp == bin_pos) {
-            new_solution.append(bin_solution, 0, 1);
+            new_solution.append_bin(bin_solution, 0, 1);
         } else {
-            new_solution.append(solution, bp, 1);
+            new_solution.append_bin(solution, bp, 1);
         }
     }
     solution = std::move(new_solution);

--- a/src/irregular/optimize.cpp
+++ b/src/irregular/optimize.cpp
@@ -321,10 +321,10 @@ void optimize_tree_search(
                     bin_pos < solution_best.number_of_different_bins() - 2;
                     ++bin_pos) {
                 const SolutionBin& solution_bin = solution_best.bin(bin_pos);
-                solution.append(solution_best, bin_pos, solution_bin.copies);
+                solution.append_bin(solution_best, bin_pos, solution_bin.copies);
             }
             // Add last optimized bin.
-            solution.append(
+            solution.append_bin(
                     last_bin_output.solution_pool.best(),
                     0,
                     last_bin.copies,

--- a/src/irregular/post_process.cpp
+++ b/src/irregular/post_process.cpp
@@ -52,7 +52,7 @@ static Solution compute_shifted_solution(
 
         if (!shape::strictly_greater(dx, 0.0) && !shape::strictly_greater(dy, 0.0)) {
             //std::cout << "skip" << std::endl;
-            result.append(solution, bin_pos, solution_bin.copies);
+            result.append_bin(solution, bin_pos, solution_bin.copies);
             continue;
         }
 
@@ -82,9 +82,9 @@ static Solution compute_shifted_solution(
                 && overlapping.items_outside_bin.empty();
 
         if (feasible) {
-            result.append(shifted_bin, 0, solution_bin.copies);
+            result.append_bin(shifted_bin, 0, solution_bin.copies);
         } else {
-            result.append(solution, bin_pos, solution_bin.copies);
+            result.append_bin(solution, bin_pos, solution_bin.copies);
         }
     }
 

--- a/src/irregular/sequential_feasibility.cpp
+++ b/src/irregular/sequential_feasibility.cpp
@@ -182,12 +182,12 @@ SequentialFeasibilityOutput packingsolver::irregular::sequential_feasibility(
         Solution solution(instance);
         if (instance.objective() == Objective::BinPacking
                 || instance.objective() == Objective::BinPackingWithLeftovers) {
-            solution.append(
+            solution.append_bins(
                     sub_solution_pool.best(),
                     sub_to_orig_bin_type_ids,
                     {});
         } else {
-            solution.append(
+            solution.append_bin(
                     sub_solution_pool.best(),
                     0,  // bin_pos
                     1,  // copies

--- a/src/irregular/solution.cpp
+++ b/src/irregular/solution.cpp
@@ -125,7 +125,7 @@ void Solution::update_indicators(
         && (number_of_infeasible_item_copies_min_ == 0);
 }
 
-void Solution::append(
+void Solution::append_bin(
         const Solution& solution,
         BinPos bin_pos,
         BinPos copies,
@@ -157,14 +157,14 @@ void Solution::append(
     update_indicators(bins_.size() - 1);
 }
 
-void Solution::append(
+void Solution::append_bins(
         const Solution& solution,
         const std::vector<BinTypeId>& bin_type_ids,
         const std::vector<ItemTypeId>& item_type_ids)
 {
     for (BinPos i_pos = 0; i_pos < (BinPos)solution.bins_.size(); ++i_pos) {
         const SolutionBin& bin = solution.bins_[i_pos];
-        append(solution, i_pos, bin.copies, bin_type_ids, item_type_ids);
+        append_bin(solution, i_pos, bin.copies, bin_type_ids, item_type_ids);
     }
 }
 

--- a/src/onedimensional/milp_assignment.cpp
+++ b/src/onedimensional/milp_assignment.cpp
@@ -89,7 +89,7 @@ BinPos compute_bin_instance_upper_bound(
         // 'bin_type_id' in 'instance'; 'sub_item_type_ids' maps its item
         // type ids back likewise.
         Solution solution(instance);
-        solution.append(sub_output.solution_pool.best(), {bin_type_id}, sub_item_type_ids);
+        solution.append_bins(sub_output.solution_pool.best(), {bin_type_id}, sub_item_type_ids);
         algorithm_formatter.update_solution(solution, "single bin type");
         if (instance.objective() == Objective::BinPacking) {
             algorithm_formatter.update_bin_packing_bound(sub_output.bin_packing_bound);
@@ -1258,7 +1258,7 @@ MilpAssignmentOutput packingsolver::onedimensional::milp_assignment(
 
             if (sub_output.solution_pool.best().full()) {
                 Solution solution(instance);
-                solution.append(sub_output.solution_pool.best(), {}, {});
+                solution.append_bins(sub_output.solution_pool.best(), {}, {});
                 std::stringstream ss;
                 ss << "MILP-A SF " << (number_of_bins - lower_bound)
                     << " " << sub_output.solution_pool.best_label();

--- a/src/onedimensional/solution.cpp
+++ b/src/onedimensional/solution.cpp
@@ -162,7 +162,7 @@ void Solution::update_indicators(
         && (number_of_infeasible_item_copies_min_ == 0);
 }
 
-void Solution::append(
+void Solution::append_bin(
         const Solution& solution,
         BinPos bin_pos,
         BinPos copies,
@@ -196,14 +196,14 @@ void Solution::append(
     update_indicators(bins_.size() - 1);
 }
 
-void Solution::append(
+void Solution::append_bins(
         const Solution& solution,
         const std::vector<BinTypeId>& bin_type_ids,
         const std::vector<ItemTypeId>& item_type_ids)
 {
     for (BinPos i_pos = 0; i_pos < (BinPos)solution.bins_.size(); ++i_pos) {
         const SolutionBin& bin = solution.bins_[i_pos];
-        append(solution, i_pos, bin.copies, bin_type_ids, item_type_ids);
+        append_bin(solution, i_pos, bin.copies, bin_type_ids, item_type_ids);
     }
 }
 

--- a/src/rectangle/benders_decomposition.cpp
+++ b/src/rectangle/benders_decomposition.cpp
@@ -672,7 +672,7 @@ std::vector<BinPos> compute_bin_type_upper_bounds_variable_sized_bin_packing(
         if (instance.number_of_bin_types() == 1
                 && (ItemTypeId)sub_item_type_ids.size() == instance.number_of_item_types()) {
             Solution solution(instance);
-            solution.append(sub_output.solution_pool.best(), {bin_type_id}, sub_item_type_ids);
+            solution.append_bins(sub_output.solution_pool.best(), {bin_type_id}, sub_item_type_ids);
             algorithm_formatter.update_solution(solution, "single bin type upper bound");
         }
 
@@ -1186,7 +1186,7 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
             const Solution& sub_solution = sub_output.solution_pool.best();
 
             if (sub_solution.number_of_bins() > 0) {
-                solution.append(
+                solution.append_bin(
                         sub_solution,
                         0,  // bin_pos
                         1,  // copies

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -1147,10 +1147,10 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
                     bin_pos < solution_best.number_of_different_bins() - 2;
                     ++bin_pos) {
                 const SolutionBin& solution_bin = solution_best.bin(bin_pos);
-                solution.append(solution_best, bin_pos, solution_bin.copies);
+                solution.append_bin(solution_best, bin_pos, solution_bin.copies);
             }
             // Add last optimized bin.
-            solution.append(
+            solution.append_bin(
                     last_bin_output.solution_pool.best(),
                     0,
                     last_bin.copies,

--- a/src/rectangle/solution.cpp
+++ b/src/rectangle/solution.cpp
@@ -101,7 +101,7 @@ void Solution::update_indicators(
         && (number_of_infeasible_item_copies_min_ == 0);
 }
 
-void Solution::append(
+void Solution::append_bin(
         const Solution& solution,
         BinPos bin_pos,
         BinPos copies,
@@ -125,14 +125,14 @@ void Solution::append(
     update_indicators(bins_.size() - 1);
 }
 
-void Solution::append(
+void Solution::append_bins(
         const Solution& solution,
         const std::vector<BinTypeId>& bin_type_ids,
         const std::vector<ItemTypeId>& item_type_ids)
 {
     for (BinPos i_pos = 0; i_pos < (BinPos)solution.bins_.size(); ++i_pos) {
         const SolutionBin& bin = solution.bins_[i_pos];
-        append(solution, i_pos, bin.copies, bin_type_ids, item_type_ids);
+        append_bin(solution, i_pos, bin.copies, bin_type_ids, item_type_ids);
     }
 }
 

--- a/src/rectangleguillotine/post_process.cpp
+++ b/src/rectangleguillotine/post_process.cpp
@@ -262,9 +262,9 @@ Solution packingsolver::rectangleguillotine::minimize_number_of_stages(
                 instance, bin.bin_type_id, item_placements);
 
         if (bin_solution.number_of_different_bins() > 0) {
-            result.append(bin_solution, 0, bin.copies);
+            result.append_bin(bin_solution, 0, bin.copies);
         } else {
-            result.append(solution, bin_pos, bin.copies);
+            result.append_bin(solution, bin_pos, bin.copies);
         }
     }
 
@@ -581,7 +581,7 @@ Solution packingsolver::rectangleguillotine::sort_subplates(
                 bin.first_cut_orientation,
                 cut_thickness,
                 solution_builder);
-        result.append(solution_builder.build(), 0, bin.copies);
+        result.append_bin(solution_builder.build(), 0, bin.copies);
     }
 
     return result;

--- a/src/rectangleguillotine/sequential_feasibility.cpp
+++ b/src/rectangleguillotine/sequential_feasibility.cpp
@@ -139,12 +139,12 @@ SequentialFeasibilityOutput packingsolver::rectangleguillotine::sequential_feasi
         Solution solution(instance);
         if (instance.objective() == Objective::BinPacking
                 || instance.objective() == Objective::BinPackingWithLeftovers) {
-            solution.append(
+            solution.append_bins(
                     sub_solution_pool.best(),
                     sub_to_orig_bin_type_ids,
                     {});
         } else {
-            solution.append(
+            solution.append_bin(
                     sub_solution_pool.best(),
                     0,  // bin_pos
                     1,  // copies

--- a/src/rectangleguillotine/solution.cpp
+++ b/src/rectangleguillotine/solution.cpp
@@ -439,7 +439,7 @@ void Solution::update_indicators(
         && (number_of_infeasible_item_copies_min_ == 0);
 }
 
-void Solution::append(
+void Solution::append_bin(
         const Solution& solution,
         BinPos bin_pos,
         BinPos copies,
@@ -479,13 +479,13 @@ void Solution::append(
     update_indicators(bins_.size() - 1);
 }
 
-void Solution::append(
+void Solution::append_bins(
         const Solution& solution,
         const std::vector<BinTypeId>& bin_type_ids,
         const std::vector<ItemTypeId>& item_type_ids)
 {
     for (BinPos bin_pos = 0; bin_pos < solution.number_of_bins(); ++bin_pos)
-        append(solution, bin_pos, 1, bin_type_ids, item_type_ids);
+        append_bin(solution, bin_pos, 1, bin_type_ids, item_type_ids);
 }
 
 bool Solution::operator<(const Solution& solution) const


### PR DESCRIPTION
## Summary
- `Solution::append` had two overloads in every domain (onedimensional, rectangle, rectangleguillotine, box, boxstacks, irregular): a 5-parameter one (`bin_pos`, `copies`, with defaulted id-remapping vectors) and a 3-parameter one (id-remapping vectors only, appending every bin).
- Calling the latter as `append(solution, {}, {})` was ambiguous and silently resolved to the former, binding `bin_pos=0, copies=0` instead of the intended vectors — so instead of appending every bin, it appended nothing.
- This hit `onedimensional::milp_assignment`'s sequential-feasibility scheme: it found a genuine feasible solution, silently discarded it via this call, and returned an empty solution — which `rectangle::benders_decomposition` then mistook for a genuinely infeasible master problem, aborting with `"the master problem should not be infeasible"`.
- Confirmed the overload-resolution behavior in isolation with a standalone 15-line repro before touching the codebase.

## Fix
Renamed the two overloads to `append_bin` (single bin, explicit position/copies) and `append_bins` (every bin, id remapping) across all six domains — headers, `.cpp` definitions, and every call site, including the shared header-only algorithm templates (`sequential_value_correction.hpp`, `column_generation.hpp`, `dichotomic_search.hpp`, `common.hpp`) instantiated by every domain.

## Test plan
- [x] Full `cmake --build` across all domains and test binaries: clean, zero errors
- [x] `ctest --output-on-failure --parallel`: 507/507 tests pass
- [x] Reproduced the original crash (`packingsolver_rectangle --use-benders-decomposition 1` on `data/rectangle/martello1998/Class_10.2bp_60_1`) before the fix, confirmed it no longer occurs after