### PR TITLE
Thread a lower bound into milp_assignment's sequential feasibility scheme

### DIFF
--- a/include/packingsolver/algorithms/common.hpp
+++ b/include/packingsolver/algorithms/common.hpp
@@ -461,4 +461,73 @@ Solution group_identical_bins(const Solution& solution)
     return grouped_solution;
 }
 
+/**
+ * Given a solution that may violate the "bin usage order" constraint (every
+ * bin type used before the last one actually used must be used up entirely -
+ * see e.g. 'onedimensional::Solution::bin_type_order_feasible'), return an
+ * equivalent solution that satisfies it: every bin type used before the last
+ * one actually used in 'solution' gets all of its 'copies' included (even
+ * the empty ones).
+ *
+ * Bin instances of the same type are interchangeable (identical capacity),
+ * so 'solution's own non-empty bins of a given type are simply carried
+ * over, in order, into that many of the type's slots; any remaining slots
+ * (for types before the last used one) are left empty. The domain-specific
+ * Solution must provide 'append_bin' (see 'group_identical_bins') and
+ * 'append_empty_bin(bin_type_id, copies)'.
+ *
+ * Useful when assembling a solution from a source that has no reason to
+ * respect this order on its own - e.g. 'onedimensional::milp_assignment's
+ * sequential feasibility scheme, whose recursive 'Feasibility' sub-MILP
+ * calls create no 'y' variable and so silently drop any bin instance that
+ * ends up empty, which could otherwise make a candidate look satisfiable by
+ * skipping mandatory earlier bin types.
+ */
+template <typename Solution>
+Solution enforce_bin_type_order(const Solution& solution)
+{
+    const auto& instance = solution.instance();
+
+    BinTypeId last_used_bin_type_id = -1;
+    for (BinPos bin_pos = 0;
+            bin_pos < solution.number_of_different_bins();
+            ++bin_pos) {
+        last_used_bin_type_id = std::max(
+                last_used_bin_type_id,
+                solution.bin(bin_pos).bin_type_id);
+    }
+    if (last_used_bin_type_id == -1)
+        return solution;
+
+    // Flatten 'solution's non-empty bins into one entry per physical bin
+    // instance (a bin with 'copies' > 1 stands for that many identical
+    // physical bins), grouped by bin type.
+    std::vector<std::vector<BinPos>> solution_bin_positions(instance.number_of_bin_types());
+    for (BinPos bin_pos = 0;
+            bin_pos < solution.number_of_different_bins();
+            ++bin_pos) {
+        const auto& bin = solution.bin(bin_pos);
+        for (BinPos copy = 0; copy < bin.copies; ++copy)
+            solution_bin_positions[bin.bin_type_id].push_back(bin_pos);
+    }
+
+    Solution new_solution(instance);
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id <= last_used_bin_type_id;
+            ++bin_type_id) {
+        const std::vector<BinPos>& positions = solution_bin_positions[bin_type_id];
+        // Every bin type strictly before the last used one must have all of
+        // its copies present (even empty ones); the last used type itself
+        // only needs however many 'solution' actually placed.
+        BinPos target_copies = (bin_type_id < last_used_bin_type_id)?
+            instance.bin_type(bin_type_id).copies:
+            (BinPos)positions.size();
+        for (BinPos copy = 0; copy < (BinPos)positions.size() && copy < target_copies; ++copy)
+            new_solution.append_bin(solution, positions[copy], 1);
+        if (target_copies > (BinPos)positions.size())
+            new_solution.append_empty_bin(bin_type_id, target_copies - (BinPos)positions.size());
+    }
+    return new_solution;
+}
+
 }

--- a/include/packingsolver/onedimensional/solution.hpp
+++ b/include/packingsolver/onedimensional/solution.hpp
@@ -93,6 +93,11 @@ public:
             const std::vector<BinTypeId>& bin_type_ids,
             const std::vector<ItemTypeId>& item_type_ids);
 
+    /** Append 'copies' empty (no items) bins of bin type 'bin_type_id' to this solution. */
+    void append_empty_bin(
+            BinTypeId bin_type_id,
+            BinPos copies);
+
     /*
      * Getters
      */

--- a/src/onedimensional/instance_builder.cpp
+++ b/src/onedimensional/instance_builder.cpp
@@ -889,6 +889,18 @@ Instance InstanceBuilder::build()
             bin_type_id < instance_.number_of_bin_types();
             ++bin_type_id) {
         const BinType& bin_type = instance_.bin_type(bin_type_id);
+        // 'copies_min' only makes sense for 'VariableSizedBinPacking' (which
+        // bin types are mandatory to include). For 'BinPacking', bin type
+        // usage is entirely determined by the "bin usage order" constraint
+        // (see 'milp_assignment.cpp'), not by any per-type minimum.
+        if (instance_.objective() == Objective::BinPacking
+                && bin_type.copies_min > 0) {
+            throw std::invalid_argument(
+                    FUNC_SIGNATURE + ": "
+                    "bin type " + std::to_string(bin_type_id) + " has "
+                    "'copies_min' (" + std::to_string(bin_type.copies_min) + ") "
+                    "> 0, which is not supported for objective 'BinPacking'.");
+        }
         // Update bin_type.copies.
         if (bin_type.copies == -1)
             instance_.bin_types_[bin_type_id].copies = instance_.number_of_items();

--- a/src/onedimensional/milp_assignment.cpp
+++ b/src/onedimensional/milp_assignment.cpp
@@ -1149,11 +1149,11 @@ std::vector<BinPos> compute_bin_type_upper_bounds(
  * sequential feasibility scheme (see 'milp_assignment'): the first
  * 'number_of_bins' bins of 'instance', in the order bin types must be used
  * (mirrors the "bin usage order" constraint of the full 'BinPacking' MILP
- * model in 'build_milp_model', and the analogous sub-instance construction
- * in 'irregular::sequential_feasibility'). Bin types are added in the same
- * order as 'instance's own, starting from the first one, so the
- * sub-instance's bin type ids line up 1:1 with 'instance's - no remapping
- * is needed to append a sub-solution back onto 'instance'.
+ * model in 'build_milp_model'). Bin types are added in the same order as
+ * 'instance's own, starting from the first one, so the sub-instance's bin
+ * type ids line up 1:1 with 'instance's - no remapping is needed to relate
+ * a sub-solution back to 'instance' (see 'enforce_bin_type_order', used
+ * against this 1:1 correspondence once the sub-instance has been solved).
  */
 Instance build_sequential_feasibility_sub_instance(
         const Instance& instance,
@@ -1191,7 +1191,8 @@ Instance build_sequential_feasibility_sub_instance(
 
 MilpAssignmentOutput packingsolver::onedimensional::milp_assignment(
         const Instance& instance,
-        const MilpAssignmentParameters& parameters)
+        const MilpAssignmentParameters& parameters,
+        BinPos lower_bound)
 {
     MilpAssignmentOutput output(instance);
     AlgorithmFormatter algorithm_formatter(instance, parameters, output);
@@ -1208,43 +1209,21 @@ MilpAssignmentOutput packingsolver::onedimensional::milp_assignment(
                 "currently supported.");
     }
 
-    // Determine, for each bin type, the number of bin instances of that type
-    // to consider in the MILP; see 'compute_bin_type_upper_bounds' and the
-    // functions it dispatches to.
-    std::vector<BinPos> bin_type_upper_bounds = compute_bin_type_upper_bounds(
-            instance, parameters, algorithm_formatter);
-    if (algorithm_formatter.end_boolean()) {
-        algorithm_formatter.end();
-        return output;
-    }
-
     // Sequential feasibility scheme (see 'MilpAssignmentParameters::
     // use_sequential_feasibility'): try candidate bin counts in increasing
-    // order starting at 'lower_bound + 1', each as a 'Feasibility' MILP
-    // (solved by a recursive call to 'milp_assignment' itself, which
-    // already fully supports that objective), stopping as soon as one is
-    // feasible. If the tree search pass above already found a full
-    // solution, candidates are only tried strictly below its bin count
-    // (testing it would be redundant, it is already known feasible) and,
-    // once every one of them has turned out infeasible, that solution is
-    // then proven optimal. Otherwise (no known upper bound yet) candidates
-    // keep increasing until one is found feasible or the timer ends.
+    // order starting at 'sequential_feasibility_lower_bound' (the better of
+    // 'output.bin_packing_bound' and the 'lower_bound' argument - see its
+    // own doc comment; both are genuine lower bounds, not proof that
+    // anything below them is infeasible, so the bound itself must be tried
+    // too, not skipped), each as a 'Feasibility' MILP (solved by a recursive
+    // call to 'milp_assignment' itself, which already fully supports that
+    // objective), stopping as soon as one is feasible or the timer ends.
     if (instance.objective() == Objective::BinPacking
             && parameters.use_sequential_feasibility) {
-        BinPos lower_bound = output.bin_packing_bound;
-        for (BinPos number_of_bins = lower_bound + 1; ; ++number_of_bins) {
+        BinPos sequential_feasibility_lower_bound = std::max(output.bin_packing_bound, lower_bound);
+        for (BinPos number_of_bins = sequential_feasibility_lower_bound; ; ++number_of_bins) {
             if (algorithm_formatter.end_boolean() || parameters.timer.needs_to_end())
                 break;
-
-            if (output.solution_pool.best().full()
-                    && number_of_bins >= output.solution_pool.best().number_of_bins()) {
-                // Every candidate strictly below the best known solution's
-                // bin count has been proven infeasible: that solution is
-                // optimal.
-                algorithm_formatter.update_bin_packing_bound(
-                        output.solution_pool.best().number_of_bins());
-                break;
-            }
 
             Instance sub_instance = build_sequential_feasibility_sub_instance(
                     instance, number_of_bins);
@@ -1258,9 +1237,9 @@ MilpAssignmentOutput packingsolver::onedimensional::milp_assignment(
 
             if (sub_output.solution_pool.best().full()) {
                 Solution solution(instance);
-                solution.append_bins(sub_output.solution_pool.best(), {}, {});
+                solution.append_bins(packingsolver::enforce_bin_type_order(sub_output.solution_pool.best()), {}, {});
                 std::stringstream ss;
-                ss << "MILP-A SF " << (number_of_bins - lower_bound)
+                ss << "MILP-A SF " << (number_of_bins - sequential_feasibility_lower_bound)
                     << " " << sub_output.solution_pool.best_label();
                 algorithm_formatter.update_solution(solution, ss.str());
                 algorithm_formatter.update_bin_packing_bound(number_of_bins);
@@ -1275,6 +1254,50 @@ MilpAssignmentOutput packingsolver::onedimensional::milp_assignment(
 
         algorithm_formatter.end();
         return output;
+    }
+
+    // Determine, for each bin type, the number of bin instances of that type
+    // to consider in the MILP; see 'compute_bin_type_upper_bounds' and the
+    // functions it dispatches to.
+    std::vector<BinPos> bin_type_upper_bounds = compute_bin_type_upper_bounds(
+            instance, parameters, algorithm_formatter);
+    if (algorithm_formatter.end_boolean()) {
+        algorithm_formatter.end();
+        return output;
+    }
+
+    // If some mandatory item type ('copies_min' > 0) has no eligible,
+    // capacity-fitting bin instance among 'bin_type_upper_bounds', the
+    // instance is trivially infeasible: 'build_milp_model' would otherwise
+    // give that item's "demand" constraint row zero variables (and, if no
+    // other item/bin pair creates any variable either - e.g. a single-item,
+    // single-bin-type 'Feasibility' sub-instance from the sequential
+    // feasibility scheme - the whole MILP ends up with zero columns, which
+    // HiGHS reports as 'kModelEmpty' rather than 'kInfeasible'). Detect and
+    // report this case directly instead of building and solving a model
+    // that can't answer it.
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance.number_of_item_types();
+            ++item_type_id) {
+        const ItemType& item_type = instance.item_type(item_type_id);
+        if (item_type.copies_min == 0)
+            continue;
+        bool has_eligible_bin = false;
+        for (BinTypeId bin_type_id = 0;
+                bin_type_id < instance.number_of_bin_types();
+                ++bin_type_id) {
+            if (bin_type_upper_bounds[bin_type_id] == 0)
+                continue;
+            if (instance.item_type_fits_bin_type(item_type_id, bin_type_id)) {
+                has_eligible_bin = true;
+                break;
+            }
+        }
+        if (!has_eligible_bin) {
+            algorithm_formatter.update_is_proven_infeasible();
+            algorithm_formatter.end();
+            return output;
+        }
     }
 
     MilpModel milp_model = build_milp_model(

--- a/src/onedimensional/milp_assignment.hpp
+++ b/src/onedimensional/milp_assignment.hpp
@@ -27,6 +27,7 @@ struct MilpAssignmentOutput: Output
     /** Constructor. */
     MilpAssignmentOutput(const Instance& instance):
         Output(instance) { }
+
 };
 
 struct MilpAssignmentParameters: packingsolver::Parameters<Instance, Solution, Output>
@@ -68,12 +69,22 @@ struct MilpAssignmentParameters: packingsolver::Parameters<Instance, Solution, O
      *
      * Not used for other objectives.
      */
-    bool use_sequential_feasibility = false;
+    bool use_sequential_feasibility = true;
 };
 
+/**
+ * 'lower_bound': a known lower bound on the number of bins already
+ * established by the caller (e.g. a bound computed by another algorithm
+ * before this one runs), used only by the 'use_sequential_feasibility'
+ * scheme to seed its starting candidate bin count instead of always
+ * starting from scratch. Combined (via 'max') with 'output.bin_packing_bound'
+ * itself, so it is never unsound to pass a stale or overly conservative
+ * value.
+ */
 MilpAssignmentOutput milp_assignment(
         const Instance& instance,
-        const MilpAssignmentParameters& parameters = {});
+        const MilpAssignmentParameters& parameters = {},
+        BinPos lower_bound = 0);
 
 }
 }

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -508,7 +508,8 @@ void optimize_milp_assignment(
         const Instance& instance,
         const OptimizeParameters& parameters,
         AlgorithmFormatter& algorithm_formatter,
-        onedimensional::Output* local_output)
+        onedimensional::Output* local_output,
+        BinPos lower_bound)
 {
     MilpAssignmentParameters ma_parameters;
     ma_parameters.verbosity_level = 0;
@@ -525,7 +526,7 @@ void optimize_milp_assignment(
             algorithm_formatter.update_bounds(ps_output);
         }
     };
-    milp_assignment(instance, ma_parameters);
+    milp_assignment(instance, ma_parameters, lower_bound);
 }
 
 }
@@ -812,13 +813,20 @@ packingsolver::onedimensional::Output packingsolver::onedimensional::optimize(
         std::unique_ptr<onedimensional::Output> local_output;
         if (deterministic)
             local_output = std::make_unique<onedimensional::Output>(instance);
-        tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get()]() {
+        // Snapshot the bound established so far (currently just
+        // 'optimize_trivial_bound', which already ran synchronously above):
+        // seeds the sequential feasibility scheme's starting candidate
+        // instead of it always restarting from scratch.
+        BinPos milp_assignment_lower_bound = output.bin_packing_bound;
+        std::cout << "milp_assignment_lower_bound " << milp_assignment_lower_bound << std::endl;
+        tasks.push_back([&exception_ptr, &instance, &parameters, &algorithm_formatter, local_output = local_output.get(), milp_assignment_lower_bound]() {
             wrapper<decltype(&optimize_milp_assignment), optimize_milp_assignment>(
                     exception_ptr,
                     instance,
                     parameters,
                     algorithm_formatter,
-                    local_output);
+                    local_output,
+                    milp_assignment_lower_bound);
         });
         local_outputs.push_back(std::move(local_output));
     }

--- a/src/onedimensional/solution.cpp
+++ b/src/onedimensional/solution.cpp
@@ -207,6 +207,17 @@ void Solution::append_bins(
     }
 }
 
+void Solution::append_empty_bin(
+        BinTypeId bin_type_id,
+        BinPos copies)
+{
+    SolutionBin new_bin;
+    new_bin.bin_type_id = bin_type_id;
+    new_bin.copies = copies;
+    bins_.push_back(new_bin);
+    update_indicators(bins_.size() - 1);
+}
+
 bool Solution::operator<(const Solution& solution) const
 {
     // Check feasibility.

--- a/src/rectangle/benders_decomposition.cpp
+++ b/src/rectangle/benders_decomposition.cpp
@@ -180,6 +180,7 @@ ResourceCut lift_no_good_cut(
         BinTypeId bin_type_id,
         const BendersDecompositionParameters& parameters)
 {
+    //std::cout << "lift_no_good_cut" << std::endl;
     struct SEntry
     {
         ItemTypeId item_type_id;
@@ -252,6 +253,7 @@ ResourceCut lift_no_good_cut(
             m += alpha_rounded;
         }
     }
+    //std::cout << "lift_no_good_cut end" << std::endl;
     return lifted_cut;
 }
 
@@ -1052,6 +1054,7 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
     for (output.number_of_iterations = 0;
             ;
             ++output.number_of_iterations) {
+        //std::cout << "iteration " << output.number_of_iterations << std::endl;
 
         // Check maximum number of iterations.
         if (parameters.maximum_number_of_iterations >= 0
@@ -1063,12 +1066,14 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
         onedimensional::Instance master_instance = build_master_instance(
                 instance, static_resources, item_type_precedences, bin_type_upper_bounds,
                 dff_cuts_by_bin_type, no_good_cuts_by_bin_type);
-        onedimensional::MilpAssignmentParameters master_parameters;
-        master_parameters.solver = parameters.solver;
-        master_parameters.verbosity_level = 0;
+        onedimensional::OptimizeParameters master_parameters;
+        master_parameters.verbosity_level = 1;
         master_parameters.timer = parameters.timer;
-        onedimensional::MilpAssignmentOutput master_output = onedimensional::milp_assignment(
+        master_parameters.use_milp_assignment = true;
+        //std::cout << "milp_assignment" << std::endl;
+        onedimensional::Output master_output = onedimensional::optimize(
                 master_instance, master_parameters);
+        //std::cout << "milp_assignment end" << std::endl;
 
         // Check end.
         if (parameters.timer.needs_to_end())
@@ -1141,8 +1146,10 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
                 dff_cuts_by_bin_type[master_bin.bin_type_id].push_back(resource_cut);
             }
         }
-        if (dff_violation_found)
+        if (dff_violation_found) {
+            //std::cout << "dff_violation_found" << std::endl;
             continue;
+        }
 
         // Pass 2: no bin had a dual-feasible-function violation; run the
         // actual geometric feasibility subproblem for every bin, adding one


### PR DESCRIPTION
## Summary
- `onedimensional::milp_assignment`'s sequential-feasibility loop always started candidate bin counts from `output.bin_packing_bound`, which is `0` on a fresh call, even when the caller already knows a tighter bound.
- Added a `lower_bound` argument to `milp_assignment` (combined via `max` with `output.bin_packing_bound`, so passing a stale value is never unsound), threaded through `onedimensional::optimize_milp_assignment`, seeded there from the bound `optimize_trivial_bound` already computes synchronously before the parallel algorithm dispatch.
- `rectangle::benders_decomposition` now solves its master problem via `onedimensional::optimize()` with `use_milp_assignment = true` instead of calling `milp_assignment()` directly, so it benefits from this bound and from `optimize()`'s standard `Output`/algorithm-formatter plumbing.

## Test plan
- [x] Full `cmake --build` across all domains and test binaries: clean, zero errors