### PR TITLE
Add soft resource penalties to onedimensional, with SR-cut-style MILP support

### DIFF
--- a/include/packingsolver/onedimensional/instance.hpp
+++ b/include/packingsolver/onedimensional/instance.hpp
@@ -121,6 +121,16 @@ struct ItemType
     /** Number of fixed copies of the item type (pre-placed in bin types). */
     ItemPos copies_fixed = 0;
 
+    /**
+     * For each bin type (indexed by bin_type_id - a resource's id is only
+     * ever local to one bin type, see 'BinType::resources'), the ids of
+     * that bin type's resources this item type has a non-zero consumption
+     * for. Lets algorithms that need every resource a given item type
+     * (in a given bin type) might affect skip the rest, instead of scanning
+     * every resource of the bin type for every item.
+     */
+    std::vector<std::vector<ResourceId>> resource_ids;
+
 };
 
 std::ostream& operator<<(
@@ -134,6 +144,81 @@ struct FixedItem
 
     /** Initial position of the item. */
     Length start;
+};
+
+/**
+ * A resource of a bin type: a capacity, together with each item type's
+ * consumption of it. Added via 'InstanceBuilder::add_bin_type_resource' /
+ * 'InstanceBuilder::add_resource_consumption'.
+ *
+ * By default ('penalize == false'), the capacity is a hard constraint: a bin
+ * whose consumption exceeds it is infeasible (see 'Solution::update_indicators').
+ * This is what lets combinatorial cuts (e.g. the rectangle Benders
+ * decomposition's no-good cuts and pairwise-incompatibility cuts) be
+ * expressed exactly as resources, via 'item_consumptions''s per-copy
+ * schedule - see its own doc comment.
+ *
+ * When 'penalize' is 'true' instead, exceeding the capacity does not make
+ * the bin infeasible: 'penalty' is subtracted from the solution's profit the
+ * first time (per bin) consumption crosses 'capacity', matching a
+ * subset-row-cut-style soft penalty (e.g. a triplet cut: packing at least
+ * two of three given item types together in the same bin costs 'penalty').
+ *
+ * 'onedimensional::tree_search' handles 'penalize' resources correctly (see
+ * 'BranchingScheme::child_tmp'): they never block an insertion, and the
+ * penalty is charged to the node's profit the first time consumption
+ * crosses the capacity, exactly like 'Solution::update_indicators'.
+ * 'milp_assignment''s MILP model does not yet: it still encodes every
+ * resource as a hard linear constraint, so it would need dedicated
+ * (non-hard-constraint, penalized-objective) handling before a 'penalize'
+ * resource could be used with it.
+ */
+struct Resource
+{
+    /** Capacity of the resource. */
+    double capacity = 0.0;
+
+    /**
+     * Resource consumption schedule of each item type, indexed by
+     * [item_type_id][copy]: the consumption charged for the 'copy'-th
+     * (0-indexed) unit of the item type packed in a bin with this resource.
+     * A 'copy' past the end of the schedule repeats its last entry (so a
+     * length-1 schedule means "the same consumption regardless of how many
+     * copies are already packed" - the common case); an 'item_type_id' past
+     * the end of this vector implicitly consumes 0 regardless of 'copy'.
+     *
+     * A non-uniform schedule lets a resource express "at least N copies of
+     * this item type" as a plain capacity/consumption row: an all-ones
+     * schedule of length N followed by a single trailing 0 makes the total
+     * consumption equal to 'min(count, N)', which only keeps growing while
+     * count < N.
+     */
+    std::vector<std::vector<double>> item_consumptions;
+
+    /**
+     * If 'true', exceeding 'capacity' does not make a bin infeasible;
+     * instead, 'penalty' is subtracted from the solution's profit. See this
+     * struct's own doc comment.
+     */
+    bool penalize = false;
+
+    /** Penalty subtracted from the solution's profit; only used when 'penalize' is 'true'. */
+    double penalty = 0.0;
+
+    /** Get the consumption of the 'copy'-th (0-indexed) unit of an item type. */
+    inline double item_consumption(
+            ItemTypeId item_type_id,
+            ItemPos copy) const
+    {
+        if (item_type_id >= (ItemTypeId)item_consumptions.size())
+            return 0.0;
+        const std::vector<double>& schedule = item_consumptions[item_type_id];
+        if (schedule.empty())
+            return 0.0;
+        return (copy < (ItemPos)schedule.size())?
+            schedule[copy]:
+            schedule.back();
+    }
 };
 
 /**
@@ -162,32 +247,8 @@ struct BinType
     /** Fixed items pre-placed in every bin of this type. */
     std::vector<FixedItem> fixed_items;
 
-    /**
-     * Resource capacities, indexed by resource_id (a resource_id is local to
-     * this bin type).
-     */
-    std::vector<double> resource_capacities;
-
-    /**
-     * Resource consumption schedule of each item type for each resource of
-     * this bin type, indexed by [resource_id][item_type_id][copy]: the
-     * consumption charged for the 'copy'-th (0-indexed) unit of the item
-     * type packed in a bin of this type. A 'copy' past the end of the
-     * schedule repeats its last entry (so a length-1 schedule means
-     * "the same consumption regardless of how many copies are already
-     * packed" - the common case); a resource_id or item_type_id past the
-     * end of these vectors implicitly consumes 0 regardless of 'copy'.
-     *
-     * A non-uniform schedule lets a resource express "at least N copies of
-     * this item type" as a plain capacity/consumption row: an all-ones
-     * schedule of length N followed by a single trailing 0 makes the total
-     * consumption equal to 'min(count, N)', which only keeps growing while
-     * count < N. Combined across item types in one resource, this is what
-     * lets combinatorial cuts (e.g. the rectangle Benders decomposition's
-     * no-good cuts and pairwise-incompatibility cuts) be expressed exactly
-     * as resources instead of needing a dedicated mechanism.
-     */
-    std::vector<std::vector<std::vector<double>>> item_resource_consumptions;
+    /** Resources of this bin type; a resource's id is its index in this vector. */
+    std::vector<Resource> resources;
 
     /*
      * Computed attributes.
@@ -199,29 +260,10 @@ struct BinType
     inline Volume space() const { return length; }
 
     /** Get the number of resources of this bin type. */
-    inline ResourceId number_of_resources() const { return resource_capacities.size(); }
+    inline ResourceId number_of_resources() const { return resources.size(); }
 
-    /**
-     * Get the consumption of the 'copy'-th (0-indexed) unit of an item type
-     * for a resource.
-     */
-    inline double item_resource_consumption(
-            ItemTypeId item_type_id,
-            ResourceId resource_id,
-            ItemPos copy) const
-    {
-        if (resource_id >= (ResourceId)item_resource_consumptions.size())
-            return 0.0;
-        const std::vector<std::vector<double>>& consumptions = item_resource_consumptions[resource_id];
-        if (item_type_id >= (ItemTypeId)consumptions.size())
-            return 0.0;
-        const std::vector<double>& schedule = consumptions[item_type_id];
-        if (schedule.empty())
-            return 0.0;
-        return (copy < (ItemPos)schedule.size())?
-            schedule[copy]:
-            schedule.back();
-    }
+    /** Get a resource of this bin type. */
+    inline const Resource& resource(ResourceId resource_id) const { return resources[resource_id]; }
 
 };
 

--- a/include/packingsolver/onedimensional/instance_builder.hpp
+++ b/include/packingsolver/onedimensional/instance_builder.hpp
@@ -73,15 +73,20 @@ public:
             BinTypeId bin_type_id,
             EligibilityId eligibility_id);
 
-    /** Add a resource to a bin type. Returns the resource's id (local to this bin type). */
+    /**
+     * Add a resource to a bin type. Returns the resource's id (local to this
+     * bin type). See 'Resource' for the meaning of 'penalize'/'penalty'.
+     */
     ResourceId add_bin_type_resource(
             BinTypeId bin_type_id,
-            double capacity);
+            double capacity,
+            bool penalize = false,
+            double penalty = 0.0);
 
     /**
      * Set an item type's consumption of a bin type's resource for the
      * 'item_copy'-th (0-indexed) copy of the item type; see
-     * 'BinType::item_resource_consumptions' for the exact semantics of a
+     * 'Resource::item_consumptions' for the exact semantics of a
      * copy past the last one explicitly set (it repeats the last one set).
      * Setting only 'item_copy == 0' gives the same, uniform consumption
      * regardless of how many copies are already packed - the common case.

--- a/src/onedimensional/instance.cpp
+++ b/src/onedimensional/instance.cpp
@@ -348,11 +348,16 @@ void Instance::write_json(
             for (ResourceId resource_id = 0;
                     resource_id < bin_type.number_of_resources();
                     ++resource_id) {
+                const Resource& resource = bin_type.resource(resource_id);
                 nlohmann::json json_resource;
-                json_resource["capacity"] = bin_type.resource_capacities[resource_id];
+                json_resource["capacity"] = resource.capacity;
+                if (resource.penalize) {
+                    json_resource["penalize"] = resource.penalize;
+                    json_resource["penalty"] = resource.penalty;
+                }
                 nlohmann::json json_consumptions = nlohmann::json::array();
                 const std::vector<std::vector<double>>& consumptions
-                    = bin_type.item_resource_consumptions[resource_id];
+                    = resource.item_consumptions;
                 for (ItemTypeId item_type_id = 0;
                         item_type_id < (ItemTypeId)consumptions.size();
                         ++item_type_id) {

--- a/src/onedimensional/instance_builder.cpp
+++ b/src/onedimensional/instance_builder.cpp
@@ -86,7 +86,9 @@ void InstanceBuilder::add_bin_type_eligibility(
 
 ResourceId InstanceBuilder::add_bin_type_resource(
         BinTypeId bin_type_id,
-        double capacity)
+        double capacity,
+        bool penalize,
+        double penalty)
 {
     if (bin_type_id < 0 || bin_type_id >= (BinTypeId)instance_.bin_types_.size()) {
         throw std::invalid_argument(
@@ -97,9 +99,12 @@ ResourceId InstanceBuilder::add_bin_type_resource(
     }
 
     BinType& bin_type = instance_.bin_types_[bin_type_id];
-    ResourceId resource_id = bin_type.resource_capacities.size();
-    bin_type.resource_capacities.push_back(capacity);
-    bin_type.item_resource_consumptions.push_back({});
+    ResourceId resource_id = bin_type.resources.size();
+    Resource resource;
+    resource.capacity = capacity;
+    resource.penalize = penalize;
+    resource.penalty = penalty;
+    bin_type.resources.push_back(resource);
     return resource_id;
 }
 
@@ -119,12 +124,12 @@ void InstanceBuilder::add_resource_consumption(
     }
 
     BinType& bin_type = instance_.bin_types_[bin_type_id];
-    if (resource_id < 0 || resource_id >= (ResourceId)bin_type.resource_capacities.size()) {
+    if (resource_id < 0 || resource_id >= (ResourceId)bin_type.resources.size()) {
         throw std::invalid_argument(
                 FUNC_SIGNATURE + ": "
                 "invalid 'resource_id'; "
                 "resource_id: " + std::to_string(resource_id) + "; "
-                "bin_type.resource_capacities.size(): " + std::to_string(bin_type.resource_capacities.size()) + ".");
+                "bin_type.resources.size(): " + std::to_string(bin_type.resources.size()) + ".");
     }
     if (item_copy < 0) {
         throw std::invalid_argument(
@@ -133,7 +138,7 @@ void InstanceBuilder::add_resource_consumption(
                 "item_copy: " + std::to_string(item_copy) + ".");
     }
 
-    std::vector<std::vector<double>>& item_consumptions = bin_type.item_resource_consumptions[resource_id];
+    std::vector<std::vector<double>>& item_consumptions = bin_type.resources[resource_id].item_consumptions;
     if (item_type_id >= (ItemTypeId)item_consumptions.size())
         item_consumptions.resize(item_type_id + 1);
     std::vector<double>& schedule = item_consumptions[item_type_id];
@@ -167,9 +172,12 @@ BinTypeId InstanceBuilder::add_bin_type(
     for (ResourceId resource_id = 0;
             resource_id < bin_type.number_of_resources();
             ++resource_id) {
+        const Resource& resource = bin_type.resource(resource_id);
         add_bin_type_resource(
                 bin_type_id,
-                bin_type.resource_capacities[resource_id]);
+                resource.capacity,
+                resource.penalize,
+                resource.penalty);
     }
     return bin_type_id;
 }
@@ -407,7 +415,7 @@ ItemTypeId InstanceBuilder::add_item_type(
                 resource_id < original_bin_type.number_of_resources();
                 ++resource_id) {
             const std::vector<std::vector<double>>& item_consumptions
-                = original_bin_type.item_resource_consumptions[resource_id];
+                = original_bin_type.resource(resource_id).item_consumptions;
             if (original_item_type_id >= (ItemTypeId)item_consumptions.size())
                 continue;
             const std::vector<double>& schedule = item_consumptions[original_item_type_id];
@@ -759,14 +767,16 @@ void InstanceBuilder::read(
         if (json_bin_type.contains("resources")) {
             for (const auto& json_resource: json_bin_type["resources"]) {
                 double capacity = json_resource["capacity"];
-                ResourceId resource_id = add_bin_type_resource(bin_type_id, capacity);
+                bool penalize = json_resource.value("penalize", false);
+                double penalty = json_resource.value("penalty", 0.0);
+                ResourceId resource_id = add_bin_type_resource(bin_type_id, capacity, penalize, penalty);
                 if (json_resource.contains("consumptions")) {
                     for (const auto& json_consumption: json_resource["consumptions"]) {
                         ItemTypeId item_type_id = json_consumption["item_type_id"];
                         if (json_consumption.contains("consumption_schedule")) {
                             // Per-copy consumption schedule (a copy past
                             // the end of the schedule repeats its last
-                            // entry); see 'BinType::item_resource_consumptions'.
+                            // entry); see 'Resource::item_consumptions'.
                             std::vector<double> schedule = json_consumption["consumption_schedule"];
                             for (ItemPos item_copy = 0;
                                     item_copy < (ItemPos)schedule.size();
@@ -921,6 +931,31 @@ Instance InstanceBuilder::build()
                 continue;
             }
             bin_type.item_type_ids.push_back(item_type_id);
+        }
+    }
+
+    // Compute item_type.resource_ids (see its own doc comment).
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance_.number_of_item_types();
+            ++item_type_id) {
+        instance_.item_types_[item_type_id].resource_ids.resize(instance_.number_of_bin_types());
+    }
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < instance_.number_of_bin_types();
+            ++bin_type_id) {
+        const BinType& bin_type = instance_.bin_types_[bin_type_id];
+        for (ResourceId resource_id = 0;
+                resource_id < bin_type.number_of_resources();
+                ++resource_id) {
+            const Resource& resource = bin_type.resource(resource_id);
+            for (ItemTypeId item_type_id = 0;
+                    item_type_id < (ItemTypeId)resource.item_consumptions.size();
+                    ++item_type_id) {
+                if (!resource.item_consumptions[item_type_id].empty()) {
+                    instance_.item_types_[item_type_id].resource_ids[bin_type_id]
+                        .push_back(resource_id);
+                }
+            }
         }
     }
 

--- a/src/onedimensional/milp_assignment.cpp
+++ b/src/onedimensional/milp_assignment.cpp
@@ -160,7 +160,7 @@ struct MilpModel
      * added by callers (e.g. the rectangle Benders decomposition's no-good
      * cuts and pairwise-incompatibility cuts) be expressed as plain
      * resources instead of needing their own mechanism - see
-     * 'BinType::item_resource_consumptions'.
+     * 'Resource::item_consumptions'.
      */
     std::vector<std::vector<std::vector<std::vector<int>>>> x;
 };
@@ -318,6 +318,148 @@ std::vector<double> build_initial_solution(
         }
     }
     return initial_solution;
+}
+
+/**
+ * Add the MILP encoding of a 'penalize' resource (see 'Resource::penalize')
+ * to 'milp_model', for every bin instance of 'bin_type_id' - one binary
+ * "excess" variable psi_k per bin instance k, subtracting the resource's
+ * penalty from the objective whenever it is 1, plus the constraints forcing
+ * it to 1 whenever the resource's threshold is reached.
+ *
+ * Only a Jepsen et al. (2008)-style "at least 2 of a set of item-type units
+ * are packed together" shape is supported: 'resource.capacity == 1'
+ * (threshold 2), and every item type it involves capped at a contribution of
+ * 1 per copy up to some bound N, via a 'threshold_schedule(N)' schedule (N
+ * ones followed by a single trailing 0 - see 'threshold_schedule' in the
+ * rectangle Benders decomposition, or 'Resource::item_consumptions' for the
+ * general semantics). Throws if the resource does not have this shape.
+ *
+ * Since every copy of an item type is already its own separate binary
+ * variable (see 'build_milp_model's own "Variables: x_{i,t,k,c}" section:
+ * 'x_{i,t,k,c} == 1' iff at least 'c + 1' copies of item type i are packed,
+ * so under the "dominated copies" ordering, 'x_{i,t,k,0} + ... + x_{i,t,k,N-1}'
+ * is exactly the number - from 0 to N - of type i's copies present), each of
+ * the resource's first N copies of each item type is already a plain 0/1
+ * "is this particular unit present" indicator, exactly like Wang et al.
+ * (2025)'s individual items. "At least two (of any mix of units, whether
+ * from the same item type or different ones) are packed together" is then
+ * exactly their G2KP formulation's pairwise/clique linearization (their
+ * constraint (5c)), applied to the flattened list of every (item type,
+ * copy) unit the resource involves: for every pair of units {u, v} in that
+ * list,
+ *     x_u + x_v - psi_k <= 1,
+ * which forces 'psi_k' to 1 exactly when both are packed together, with no
+ * slack/tolerance needed (unlike a general excess-vs-capacity row, which
+ * would need an upper bound on the resource's own maximum possible
+ * consumption to relax by) - this holds for any finite set of 0/1
+ * variables, regardless of whether some of them happen to be different
+ * copies of the same item type. A pair is skipped if either unit has no
+ * variable at all for this bin instance (excluded by eligibility or by the
+ * "pigeonhole" bound): such a pair can never be packed together there, so
+ * the row would be vacuous anyway.
+ */
+void add_penalize_resource_constraints(
+        const Instance& instance,
+        BinTypeId bin_type_id,
+        ResourceId resource_id,
+        const Resource& resource,
+        BinPos number_of_bin_instances,
+        double multiplier_profit,
+        MilpModel& milp_model)
+{
+    if (resource.capacity != 1.0) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "'penalize' resource " + std::to_string(resource_id) + " of bin type " +
+                std::to_string(bin_type_id) + " has capacity " + std::to_string(resource.capacity) +
+                " != 1; only 'at least 2 of a set of item-type units' penalize resources "
+                "(capacity == 1, every item type's consumption a 'threshold_schedule(N)' "
+                "for some N) are currently supported by the MILP model.");
+    }
+
+    // Every (item type, copy) unit the resource involves, flattened.
+    std::vector<std::pair<ItemTypeId, ItemPos>> resource_units;
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance.number_of_item_types();
+            ++item_type_id) {
+        if (resource.item_consumption(item_type_id, 0) == 0.0)
+            continue;
+        // Validate the 'threshold_schedule(N)' shape: N ones then a single
+        // trailing 0 - anything else (e.g. an uncapped uniform consumption,
+        // or a non-0/1 value) is not expressible as 0/1 "unit" presence.
+        // Bounded by the item type's own total copies: no valid schedule
+        // needs to cap beyond that, and an uncapped (all-1) schedule would
+        // otherwise make this scan run forever ('item_consumption' repeats
+        // a schedule's last entry for every copy past its end).
+        ItemPos copies_bound = instance.item_type(item_type_id).copies;
+        ItemPos threshold = 0;
+        while (threshold <= copies_bound
+                && resource.item_consumption(item_type_id, threshold) == 1.0) {
+            ++threshold;
+        }
+        if (resource.item_consumption(item_type_id, threshold) != 0.0) {
+            throw std::invalid_argument(
+                    FUNC_SIGNATURE + ": "
+                    "'penalize' resource " + std::to_string(resource_id) + " of bin type " +
+                    std::to_string(bin_type_id) + " does not use a 'threshold_schedule(N)' "
+                    "consumption for item type " + std::to_string(item_type_id) + "; only "
+                    "'at least 2 of a set of item-type units' penalize resources are "
+                    "currently supported by the MILP model.");
+        }
+        for (ItemPos copy = 0; copy < threshold; ++copy)
+            resource_units.push_back({item_type_id, copy});
+    }
+    if (resource_units.size() < 2)
+        return;
+
+    for (BinPos bin_instance_pos = 0;
+            bin_instance_pos < number_of_bin_instances;
+            ++bin_instance_pos) {
+        // Presence variable of every unit in the resource, for this bin
+        // instance, or -1 if that unit has no variable there at all.
+        std::vector<int> presence_variable_ids;
+        for (const auto& unit: resource_units) {
+            ItemTypeId item_type_id = unit.first;
+            ItemPos copy = unit.second;
+            const std::vector<std::vector<int>>& x_bin_type
+                = milp_model.x[item_type_id][bin_type_id];
+            int presence_variable_id = (!x_bin_type.empty()
+                    && copy < (ItemPos)x_bin_type[bin_instance_pos].size())?
+                x_bin_type[bin_instance_pos][copy]:
+                -1;
+            presence_variable_ids.push_back(presence_variable_id);
+        }
+
+        // psi_k variable.
+        int psi_variable_id = milp_model.model.variables_lower_bounds.size();
+        milp_model.model.variables_lower_bounds.push_back(0.0);
+        milp_model.model.variables_upper_bounds.push_back(1.0);
+        milp_model.model.variables_types.push_back(mathoptsolverscmake::VariableType::Binary);
+        milp_model.model.objective_coefficients.push_back(-resource.penalty / multiplier_profit);
+
+        // Pairwise constraints.
+        for (std::size_t a = 0; a < presence_variable_ids.size(); ++a) {
+            if (presence_variable_ids[a] == -1)
+                continue;
+            for (std::size_t b = a + 1; b < presence_variable_ids.size(); ++b) {
+                if (presence_variable_ids[b] == -1)
+                    continue;
+                // Initialize new row.
+                milp_model.model.constraints_starts.push_back(milp_model.model.elements_variables.size());
+                // Add row elements.
+                milp_model.model.elements_variables.push_back(presence_variable_ids[a]);
+                milp_model.model.elements_coefficients.push_back(1.0);
+                milp_model.model.elements_variables.push_back(presence_variable_ids[b]);
+                milp_model.model.elements_coefficients.push_back(1.0);
+                milp_model.model.elements_variables.push_back(psi_variable_id);
+                milp_model.model.elements_coefficients.push_back(-1.0);
+                // Add row bounds.
+                milp_model.model.constraints_lower_bounds.push_back(-std::numeric_limits<double>::infinity());
+                milp_model.model.constraints_upper_bounds.push_back(1.0);
+            }
+        }
+    }
 }
 
 /**
@@ -666,7 +808,7 @@ MilpModel build_milp_model(
     // Without a 'y' variable: sum_{i,c} consumption_{i,r,c} * x_{i,t,k,c} <= capacity_{t,r}
     //
     // The consumption of the 'c'-th copy of an item type can depend on 'c'
-    // (see 'BinType::item_resource_consumptions'): a schedule that is 1 for
+    // (see 'Resource::item_consumptions'): a schedule that is 1 for
     // the first 'a' copies and 0 after makes the row's contribution from
     // that item type equal to 'min(count, a)', which keeps growing only
     // while count < a. This is what lets combinatorial cuts (no-good cuts,
@@ -675,6 +817,12 @@ MilpModel build_milp_model(
     // "cost per unit" resource could only cap the *combined* total of the
     // item types involved, wrongly excluding unrelated combinations using
     // more of one item type and none of another.
+    //
+    // 'penalize' resources (see 'Resource::penalize') are handled
+    // separately, below, only for the 'Knapsack' objective: a 'penalize'
+    // resource never blocks packing and never affects any other objective
+    // (see 'Solution::update_indicators'), so it is simply skipped when
+    // '!is_knapsack' - there would be nothing for it to constrain or cost.
     for (BinTypeId bin_type_id = 0;
             bin_type_id < instance.number_of_bin_types();
             ++bin_type_id) {
@@ -683,7 +831,21 @@ MilpModel build_milp_model(
         for (ResourceId resource_id = 0;
                 resource_id < bin_type.number_of_resources();
                 ++resource_id) {
-            double capacity = bin_type.resource_capacities[resource_id];
+            const Resource& resource = bin_type.resource(resource_id);
+            if (resource.penalize) {
+                if (!is_knapsack)
+                    continue;
+                add_penalize_resource_constraints(
+                        instance,
+                        bin_type_id,
+                        resource_id,
+                        resource,
+                        number_of_bin_instances,
+                        multiplier_profit,
+                        milp_model);
+                continue;
+            }
+            double capacity = resource.capacity;
             for (BinPos bin_instance_pos = 0;
                     bin_instance_pos < number_of_bin_instances;
                     ++bin_instance_pos) {
@@ -697,7 +859,7 @@ MilpModel build_milp_model(
                         continue;
                     const std::vector<int>& slots = milp_model.x[item_type_id][bin_type_id][bin_instance_pos];
                     for (ItemPos copy = 0; copy < (ItemPos)slots.size(); ++copy) {
-                        double consumption = bin_type.item_resource_consumption(item_type_id, resource_id, copy);
+                        double consumption = resource.item_consumption(item_type_id, copy);
                         if (consumption == 0.0)
                             continue;
                         milp_model.model.elements_variables.push_back(slots[copy]);

--- a/src/onedimensional/solution.cpp
+++ b/src/onedimensional/solution.cpp
@@ -65,16 +65,24 @@ void Solution::update_indicators(
         }
 
         // Update bin.resource_consumption.
-        for (ResourceId resource_id = 0;
-                resource_id < bin_type.number_of_resources();
-                ++resource_id) {
+        for (ResourceId resource_id: item_type.resource_ids[bin.bin_type_id]) {
+            const Resource& resource = bin_type.resource(resource_id);
+            double previous_consumption = bin.resource_consumption[resource_id];
             bin.resource_consumption[resource_id]
-                += bin_type.item_resource_consumption(
+                += resource.item_consumption(
                         item.item_type_id,
-                        resource_id,
                         item_type_copies_in_bin[item.item_type_id]);
-            if (bin.resource_consumption[resource_id] > bin_type.resource_capacities[resource_id]) {
-                resource_feasible_ = false;
+            if (bin.resource_consumption[resource_id] > resource.capacity) {
+                if (resource.penalize) {
+                    // Charge the penalty only once per bin, the first time
+                    // consumption crosses the capacity (it never decreases
+                    // afterwards, so this check would otherwise keep firing
+                    // for every subsequent item added to the same bin).
+                    if (previous_consumption <= resource.capacity)
+                        item_profit_ -= resource.penalty;
+                } else {
+                    resource_feasible_ = false;
+                }
             }
         }
         ++item_type_copies_in_bin[item.item_type_id];

--- a/src/onedimensional/tree_search.cpp
+++ b/src/onedimensional/tree_search.cpp
@@ -71,6 +71,19 @@ BranchingScheme::Node BranchingScheme::child_tmp(
 
     node.item_type_id = insertion.item_type_id;
 
+    // Compute item_number_of_copies, number_of_items, items_area,
+    // squared_item_length and profit. 'node.profit' is further adjusted
+    // below by any 'penalize' resource whose consumption crosses its
+    // capacity for the first time as a result of this insertion (see
+    // 'Resource::penalize'), mirroring 'Solution::update_indicators' so the
+    // search optimizes the same objective the final solution will report.
+    node.item_number_of_copies = parent.item_number_of_copies;
+    node.item_number_of_copies[insertion.item_type_id]++;
+    node.number_of_items = parent.number_of_items + 1;
+    node.item_length = parent.item_length + item_type.length;
+    node.squared_item_length = parent.squared_item_length + item_type.length * item_type.length;
+    node.profit = parent.profit + item_type.profit;
+
     // Update number_of_bins and last_bin_direction.
     if (insertion.new_bin) {  // New bin.
         node.number_of_bins = insertion.new_bin_pos + 1;
@@ -82,11 +95,14 @@ BranchingScheme::Node BranchingScheme::child_tmp(
         node.last_bin_remaining_weight = item_type.maximum_weight_after;
         node.last_bin_item_number_of_copies.assign(instance().number_of_item_types(), 0);
         node.last_bin_resource_consumption.assign(bin_type.number_of_resources(), 0.0);
-        for (ResourceId resource_id = 0;
-                resource_id < bin_type.number_of_resources();
-                ++resource_id) {
-            node.last_bin_resource_consumption[resource_id]
-                = bin_type.item_resource_consumption(insertion.item_type_id, resource_id, 0);
+        for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            const Resource& resource = bin_type.resource(resource_id);
+            double consumption = resource.item_consumption(insertion.item_type_id, 0);
+            node.last_bin_resource_consumption[resource_id] = consumption;
+            // The bin is empty before this insertion, so any crossing here
+            // is necessarily the first one.
+            if (resource.penalize && consumption > resource.capacity)
+                node.profit -= resource.penalty;
         }
         node.last_bin_item_number_of_copies[insertion.item_type_id] = 1;
     } else {  // Same bin.
@@ -104,25 +120,21 @@ BranchingScheme::Node BranchingScheme::child_tmp(
         node.last_bin_item_number_of_copies = parent.last_bin_item_number_of_copies;
         ItemPos item_copy = node.last_bin_item_number_of_copies[insertion.item_type_id];
         node.last_bin_resource_consumption = parent.last_bin_resource_consumption;
-        for (ResourceId resource_id = 0;
-                resource_id < bin_type.number_of_resources();
-                ++resource_id) {
+        for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            const Resource& resource = bin_type.resource(resource_id);
+            double previous_consumption = node.last_bin_resource_consumption[resource_id];
             node.last_bin_resource_consumption[resource_id]
-                += bin_type.item_resource_consumption(insertion.item_type_id, resource_id, item_copy);
+                += resource.item_consumption(insertion.item_type_id, item_copy);
+            if (resource.penalize
+                    && node.last_bin_resource_consumption[resource_id] > resource.capacity
+                    && previous_consumption <= resource.capacity) {
+                node.profit -= resource.penalty;
+            }
         }
         node.last_bin_item_number_of_copies[insertion.item_type_id]++;
     }
 
     BinPos i = node.number_of_bins - 1;
-
-    // Compute item_number_of_copies, number_of_items, items_area,
-    // squared_item_length and profit.
-    node.item_number_of_copies = parent.item_number_of_copies;
-    node.item_number_of_copies[insertion.item_type_id]++;
-    node.number_of_items = parent.number_of_items + 1;
-    node.item_length = parent.item_length + item_type.length;
-    node.squared_item_length = parent.squared_item_length + item_type.length * item_type.length;
-    node.profit = parent.profit + item_type.profit;
 
     // Compute current_length, guide_length and width using uncovered_items.
     node.current_length = previous_bins_length_[i] + node.last_bin_length;
@@ -203,15 +215,18 @@ void BranchingScheme::insertion_item_same_bin(
     // Check maximum weight above.
     if (item_type.weight > parent->last_bin_remaining_weight * PSTOL)
         return;
-    // Check resource capacity.
+    // Check resource capacity. 'penalize' resources never block an
+    // insertion (see 'Resource::penalize'); the corresponding penalty is
+    // applied to 'node.profit' in 'child_tmp' instead.
     {
         ItemPos item_copy = parent->last_bin_item_number_of_copies[item_type_id];
-        for (ResourceId resource_id = 0;
-                resource_id < bin_type.number_of_resources();
-                ++resource_id) {
+        for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            const Resource& resource = bin_type.resource(resource_id);
+            if (resource.penalize)
+                continue;
             double consumption = parent->last_bin_resource_consumption[resource_id]
-                + bin_type.item_resource_consumption(item_type_id, resource_id, item_copy);
-            if (consumption > bin_type.resource_capacities[resource_id] * PSTOL)
+                + resource.item_consumption(item_type_id, item_copy);
+            if (consumption > resource.capacity * PSTOL)
                 return;
         }
     }
@@ -238,12 +253,15 @@ void BranchingScheme::insertion_item_new_bin(
     if (item_type.weight > bin_type.maximum_weight * PSTOL)
         return;
     // Check resource capacity (this item is the first copy of its type in
-    // the new bin).
-    for (ResourceId resource_id = 0;
-            resource_id < bin_type.number_of_resources();
-            ++resource_id) {
-        double consumption = bin_type.item_resource_consumption(item_type_id, resource_id, 0);
-        if (consumption > bin_type.resource_capacities[resource_id] * PSTOL)
+    // the new bin). 'penalize' resources never block an insertion (see
+    // 'Resource::penalize'); the corresponding penalty is applied to
+    // 'node.profit' in 'child_tmp' instead.
+    for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+        const Resource& resource = bin_type.resource(resource_id);
+        if (resource.penalize)
+            continue;
+        double consumption = resource.item_consumption(item_type_id, 0);
+        if (consumption > resource.capacity * PSTOL)
             return;
     }
 
@@ -260,7 +278,40 @@ bool BranchingScheme::dominates(
 {
     if (node_1->item_type_id != node_2->item_type_id)
         return false;
-    return node_1->current_length <= node_2->current_length;
+    // 'last_bin_resource_consumption' only tracks the current (last) bin,
+    // and is only meaningfully comparable - index-for-index - between nodes
+    // on the exact same bin: 'bin_type_ids_' is a fixed, position-indexed
+    // sequence, so this also guarantees both nodes are packing into the
+    // same bin type (same resources, same capacities), which the argument
+    // below relies on (the same future insertion would otherwise not
+    // consume the same resources by the same amounts on both nodes).
+    if (node_1->number_of_bins != node_2->number_of_bins)
+        return false;
+    if (node_1->current_length > node_2->current_length)
+        return false;
+    // Without 'penalize' resources, 'profit' is a deterministic function of
+    // 'item_number_of_copies' alone (already forced equal by 'NodeHasher'
+    // before 'dominates' is even called), so comparing it here used to be
+    // redundant. A 'penalize' resource breaks that invariant: which items
+    // ended up sharing a bin - not just how many of each were packed
+    // overall - now affects profit (see 'Resource::penalize'), so it must
+    // be compared explicitly.
+    if (node_1->profit < node_2->profit)
+        return false;
+    // Every resource's consumption in the current bin: node_1 having no
+    // more than node_2's leaves it at least as much remaining capacity for
+    // every future insertion into this bin, for both hard and 'penalize'
+    // resources alike (a 'penalize' resource already crossed on node_1 is
+    // already accounted for above, via 'profit').
+    for (ResourceId resource_id = 0;
+            resource_id < (ResourceId)node_1->last_bin_resource_consumption.size();
+            ++resource_id) {
+        if (node_1->last_bin_resource_consumption[resource_id]
+                > node_2->last_bin_resource_consumption[resource_id]) {
+            return false;
+        }
+    }
+    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/rectangle/benders_decomposition.cpp
+++ b/src/rectangle/benders_decomposition.cpp
@@ -23,7 +23,7 @@ namespace
  * bin type.
  *
  * A per-item-type consumption is a per-copy schedule (see
- * 'onedimensional::BinType::item_resource_consumptions'), not a single
+ * 'onedimensional::Resource::item_consumptions'), not a single
  * scalar: a dual-feasible-function cut is a plain linear inequality on item
  * counts, so a uniform (length-1) schedule is exact for it; a no-good cut
  * or pairwise-incompatibility cut instead needs "at least N copies of this

--- a/test/onedimensional/onedimensional_test.cpp
+++ b/test/onedimensional/onedimensional_test.cpp
@@ -41,7 +41,7 @@ TEST(OneDimensional, ResourceConsumptionCopiedFromOriginalInstance)
 
     EXPECT_EQ(sub_instance.bin_type(sub_bin_type_id).number_of_resources(), 1);
     EXPECT_EQ(
-            sub_instance.bin_type(sub_bin_type_id).item_resource_consumption(sub_item_type_id, 0, 0),
+            sub_instance.bin_type(sub_bin_type_id).resource(0).item_consumption(sub_item_type_id, 0),
             5.0);
 }
 
@@ -105,8 +105,8 @@ TEST(OneDimensional, WriteJsonRoundTripWithResource)
     EXPECT_EQ(read_instance.objective(), packingsolver::Objective::BinPacking);
     ASSERT_EQ(read_instance.number_of_bin_types(), 1);
     EXPECT_EQ(read_instance.bin_type(0).number_of_resources(), 1);
-    EXPECT_EQ(read_instance.bin_type(0).resource_capacities[0], 10.0);
-    EXPECT_EQ(read_instance.bin_type(0).item_resource_consumption(0, 0, 0), 5.0);
+    EXPECT_EQ(read_instance.bin_type(0).resource(0).capacity, 10.0);
+    EXPECT_EQ(read_instance.bin_type(0).resource(0).item_consumption(0, 0), 5.0);
 }
 
 TEST(OneDimensional, WriteCsvThrowsOnResource)


### PR DESCRIPTION
## Summary
- Introduce `onedimensional::Resource`, consolidating `BinType`'s two parallel arrays (`resource_capacities`, `item_resource_consumptions`) into one struct, with a new `penalize` mode: instead of making a bin infeasible when a resource's capacity is exceeded, `penalty` is subtracted from the solution's profit the first time (per bin) consumption crosses capacity.
- Add `ItemType::resource_ids`, a computed per-bin-type index of which resources an item type has non-zero consumption for, so per-item resource loops can skip resources that can't apply instead of scanning every resource of a bin type.
- Wire `penalize` through every place resources are read:
  - `Solution::update_indicators` subtracts the penalty from profit exactly once per bin, matching a Jepsen et al. (2008)-style "at least N of a set of item-type units are packed together" cut.
  - `tree_search`'s branching scheme no longer hard-prunes insertions on a `penalize` resource (only hard resources still block insertions); `child_tmp` charges the penalty to `node.profit` on the same first-crossing basis as `Solution`. `dominates()` now also compares node profit and every resource's current-bin consumption, since a `penalize` resource breaks the previous invariant that profit was a deterministic function of `item_number_of_copies` alone.
  - `milp_assignment`'s MILP model encodes a `penalize` resource shaped like a Jepsen/Wang et al. (2025) subset-row cut (capacity == 1, every involved item type's consumption a `threshold_schedule(N)` for some N) via the same pairwise/clique linearization as their G2KP formulation, applied to the flattened list of `(item type, copy)` units the resource involves — no big-M relaxation needed even when an item type contributes more than one unit, since each copy is already its own separate 0/1 variable. Scoped to the `Knapsack` objective, where profit is actually the thing being optimized.

## Test plan
- [x] Full `cmake --build` across all domains: clean, zero errors
- [x] `PackingSolver_onedimensional_test`: 33/33 pass
- [x] `PackingSolver_rectangle_test`: 70/70 pass
- [x] Hand-built JSON instances exercising the MILP path directly: single-item-per-type triplet (avoid vs. forced-together penalty), and multi-copy case (2 copies of item A + 1 copy of item B) — all match hand-derived optimal values, proven optimal (0% gap)