### PR TITLE
box, irregular: add resource support to Instance/InstanceBuilder/Solution

### DIFF
--- a/include/packingsolver/box/instance.hpp
+++ b/include/packingsolver/box/instance.hpp
@@ -172,6 +172,16 @@ struct ItemType
 
     /** Number of fixed copies of the item type (pre-placed in bin types). */
     ItemPos copies_fixed = 0;
+
+    /**
+     * For each bin type (indexed by bin_type_id - a resource's id is only
+     * ever local to one bin type, see 'BinType::resources'), the ids of
+     * that bin type's resources this item type has a non-zero consumption
+     * for. Lets algorithms that need every resource a given item type
+     * (in a given bin type) might affect skip the rest, instead of scanning
+     * every resource of the bin type for every item.
+     */
+    std::vector<std::vector<ResourceId>> resource_ids;
 };
 
 std::ostream& operator<<(
@@ -213,6 +223,9 @@ struct BinType
     /** Fixed items pre-placed in every bin of this type. */
     std::vector<FixedItem> fixed_items;
 
+    /** Resources of this bin type; a resource's id is its index in this vector. */
+    std::vector<Resource> resources;
+
     /*
      * Computed attributes
      */
@@ -224,6 +237,12 @@ struct BinType
     inline Volume volume() const { return box.volume(); }
 
     inline Volume space() const { return volume(); }
+
+    /** Get the number of resources of this bin type. */
+    inline ResourceId number_of_resources() const { return resources.size(); }
+
+    /** Get a resource of this bin type. */
+    inline const Resource& resource(ResourceId resource_id) const { return resources[resource_id]; }
 
 };
 
@@ -363,6 +382,13 @@ public:
      */
     bool fits_some_bin(ItemTypeId item_type_id) const;
 
+    /**
+     * Return 'true' iff some bin type has at least one resource - i.e. iff
+     * it has an actual, non-trivial per-bin capacity constraint that
+     * algorithms need to track.
+     */
+    bool resources_matter() const;
+
     /*
      * Export
      */
@@ -372,8 +398,19 @@ public:
             std::ostream& os,
             int verbosity_level = 1) const;
 
-    /** Write the instance to a file. */
-    void write(const std::string& instance_path) const;
+    /**
+     * Write the instance to a file, in the given format (default 'Csv',
+     * matching the previous behavior). See 'InstanceFormat'.
+     */
+    void write(
+            const std::string& instance_path,
+            InstanceFormat format = InstanceFormat::Csv) const;
+
+    /** Write the instance as CSV files; see 'InstanceFormat::Csv'. */
+    void write_csv(const std::string& instance_path) const;
+
+    /** Write the instance as a single JSON file; see 'InstanceFormat::Json'. */
+    void write_json(const std::string& instance_path) const;
 
     /** Write the items to a file. */
     void write_item_types(const std::string& items_path) const;

--- a/include/packingsolver/box/instance_builder.hpp
+++ b/include/packingsolver/box/instance_builder.hpp
@@ -31,6 +31,15 @@ public:
     /** Read item types from a file. */
     void read_item_types(const std::string& items_path);
 
+    /**
+     * Read a full instance from a JSON file.
+     *
+     * Unlike the CSV readers above, this format supports every instance
+     * feature, including resources, and is meant for instances that need
+     * them; simple instances can keep using the CSV readers.
+     */
+    void read(const std::string& instance_path);
+
     /*
      * Set parameters
      */
@@ -60,6 +69,29 @@ public:
     void set_bin_type_maximum_weight(
             BinTypeId bin_type_id,
             Weight maximum_weight);
+
+    /**
+     * Add a resource to a bin type. Returns the resource's id (local to this
+     * bin type). See 'Resource' for the meaning of 'penalize'/'penalty'.
+     */
+    ResourceId add_bin_type_resource(
+            BinTypeId bin_type_id,
+            double capacity,
+            bool penalize = false,
+            double penalty = 0.0);
+
+    /**
+     * Set an item type's consumption of a bin type's resource for the
+     * 'item_copy'-th copy of the item type placed in the bin (0-indexed). See
+     * 'Resource::item_consumptions' for the exact semantics of a
+     * per-copy schedule.
+     */
+    void add_resource_consumption(
+            BinTypeId bin_type_id,
+            ResourceId resource_id,
+            ItemTypeId item_type_id,
+            ItemPos item_copy,
+            double consumption);
 
     /**
      * Add a bin type from another bin type.

--- a/include/packingsolver/box/solution.hpp
+++ b/include/packingsolver/box/solution.hpp
@@ -38,6 +38,9 @@ struct SolutionBin
 
     /** Item profit. */
     Profit profit = 0.0;
+
+    /** Resource consumption, indexed by resource_id. */
+    std::vector<double> resource_consumption;
 };
 
 bool operator==(const SolutionBin& solution_bin_1, const SolutionBin& solution_bin_2);
@@ -103,6 +106,9 @@ public:
 
     /** Overall feasibility. */
     inline bool feasible() const { return feasible_; }
+
+    /** Feasibility with respect to non-'penalize' resource capacities. */
+    inline bool resource_feasible() const { return resource_feasible_; }
 
     /*
      * Getters: bins
@@ -264,6 +270,9 @@ private:
 
     /** Overall feasibility. */
     bool feasible_ = true;
+
+    /** Feasibility with respect to non-'penalize' resource capacities. */
+    bool resource_feasible_ = true;
 
     /** Bins. */
     std::vector<SolutionBin> bins_;

--- a/include/packingsolver/irregular/instance.hpp
+++ b/include/packingsolver/irregular/instance.hpp
@@ -137,6 +137,9 @@ struct BinType
     /** Minimum distance between and item and the bin. */
     LengthDbl item_bin_minimum_spacing = 0.0;
 
+    /** Resources of this bin type; a resource's id is its index in this vector. */
+    std::vector<Resource> resources;
+
     /*
      * Computed attributes.
      */
@@ -163,6 +166,12 @@ struct BinType
     AreaDbl space() const { return area_orig; }
 
     AreaDbl packable_area(QualityRule quality_rule) const { (void)quality_rule; return 0; } // TODO
+
+    /** Get the number of resources of this bin type. */
+    inline ResourceId number_of_resources() const { return resources.size(); }
+
+    /** Get a resource of this bin type. */
+    inline const Resource& resource(ResourceId resource_id) const { return resources[resource_id]; }
 
     std::string to_string(Counter indentation) const;
 
@@ -320,6 +329,16 @@ struct ItemType
 
     /** True iff periodic_packings has already been computed for this item type. */
     bool periodic_packings_computed = false;
+
+    /**
+     * For each bin type (indexed by bin_type_id - a resource's id is only
+     * ever local to one bin type, see 'BinType::resources'), the ids of
+     * that bin type's resources this item type has a non-zero consumption
+     * for. Lets algorithms that need every resource a given item type
+     * (in a given bin type) might affect skip the rest, instead of scanning
+     * every resource of the bin type for every item.
+     */
+    std::vector<std::vector<ResourceId>> resource_ids;
 
     AreaDbl space() const { return area_orig; }
 
@@ -530,6 +549,12 @@ public:
      */
     bool fits_some_bin(ItemTypeId item_type_id) const;
 
+    /**
+     * Return 'true' iff some bin type has at least one resource - i.e. iff
+     * it has an actual, non-trivial per-bin capacity constraint that
+     * algorithms need to track.
+     */
+    bool resources_matter() const;
 
     /*
      * Export

--- a/include/packingsolver/irregular/instance_builder.hpp
+++ b/include/packingsolver/irregular/instance_builder.hpp
@@ -79,6 +79,29 @@ public:
             LengthDbl item_defect_minimum_spacing);
 
     /**
+     * Add a resource to a bin type. Returns the resource's id (local to this
+     * bin type). See 'Resource' for the meaning of 'penalize'/'penalty'.
+     */
+    ResourceId add_bin_type_resource(
+            BinTypeId bin_type_id,
+            double capacity,
+            bool penalize = false,
+            double penalty = 0.0);
+
+    /**
+     * Set an item type's consumption of a bin type's resource for the
+     * 'item_copy'-th copy of the item type placed in the bin (0-indexed). See
+     * 'Resource::item_consumptions' for the exact semantics of a
+     * per-copy schedule.
+     */
+    void add_resource_consumption(
+            BinTypeId bin_type_id,
+            ResourceId resource_id,
+            ItemTypeId item_type_id,
+            ItemPos item_copy,
+            double consumption);
+
+    /**
      * Add a bin type from another bin type.
      *
      * This method is used in the column generation procedure.

--- a/include/packingsolver/irregular/solution.hpp
+++ b/include/packingsolver/irregular/solution.hpp
@@ -32,6 +32,9 @@ struct SolutionBin
 
     /** Maximum y of the items in this bin. */
     LengthDbl y_max = -std::numeric_limits<LengthDbl>::infinity();
+
+    /** Resource consumption, indexed by resource_id. */
+    std::vector<double> resource_consumption;
 };
 
 bool operator==(const SolutionBin& solution_bin_1, const SolutionBin& solution_bin_2);
@@ -90,6 +93,9 @@ public:
 
     /** Overall feasibility. */
     inline bool feasible() const { return feasible_; }
+
+    /** Feasibility with respect to non-'penalize' resource capacities. */
+    inline bool resource_feasible() const { return resource_feasible_; }
 
     /*
      * Getters: bins
@@ -254,6 +260,9 @@ private:
 
     /** Overall feasibility. */
     bool feasible_ = true;
+
+    /** Feasibility with respect to non-'penalize' resource capacities. */
+    bool resource_feasible_ = true;
 
     /** bins. */
     std::vector<SolutionBin> bins_;

--- a/src/box/instance.cpp
+++ b/src/box/instance.cpp
@@ -1,6 +1,7 @@
 #include "packingsolver/box/instance.hpp"
 
 #include <fstream>
+#include <sstream>
 
 using namespace packingsolver;
 using namespace packingsolver::box;
@@ -150,6 +151,12 @@ bool Instance::fits_some_bin(
     return false;
 }
 
+bool Instance::resources_matter() const
+{
+    return number_of_bin_types() == 1
+        && bin_type(0).number_of_resources() > 0;
+}
+
 std::ostream& Instance::format(
         std::ostream& os,
         int verbosity_level) const
@@ -254,11 +261,127 @@ std::ostream& Instance::format(
 }
 
 void Instance::write(
+        const std::string& instance_path,
+        InstanceFormat format) const
+{
+    switch (format) {
+    case InstanceFormat::Csv:
+        write_csv(instance_path);
+        break;
+    case InstanceFormat::Json:
+        write_json(instance_path);
+        break;
+    }
+}
+
+void Instance::write_csv(
         const std::string& instance_path) const
 {
+    // Check every feature of the instance can actually be represented in
+    // the CSV format before writing anything (so a rejected write doesn't
+    // leave partial files behind).
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < number_of_bin_types();
+            ++bin_type_id) {
+        const BinType& bin_type = this->bin_type(bin_type_id);
+        if (bin_type.number_of_resources() > 0) {
+            throw std::invalid_argument(
+                    FUNC_SIGNATURE + ": "
+                    "bin type " + std::to_string(bin_type_id) + " has "
+                    "resources, which the CSV format cannot represent; use "
+                    "'InstanceFormat::Json' instead.");
+        }
+    }
+
     this->write_item_types(instance_path + "_items.csv");
     this->write_bin_types(instance_path + "_bins.csv");
     this->write_parameters(instance_path + "_parameters.csv");
+}
+
+void Instance::write_json(
+        const std::string& instance_path) const
+{
+    nlohmann::json j;
+
+    {
+        std::stringstream ss;
+        ss << objective();
+        j["objective"] = ss.str();
+    }
+
+    j["bin_types"] = nlohmann::json::array();
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < number_of_bin_types();
+            ++bin_type_id) {
+        const BinType& bin_type = this->bin_type(bin_type_id);
+        nlohmann::json json_bin_type;
+        json_bin_type["x"] = bin_type.box.x;
+        json_bin_type["y"] = bin_type.box.y;
+        json_bin_type["z"] = bin_type.box.z;
+        json_bin_type["cost"] = bin_type.cost;
+        json_bin_type["copies"] = bin_type.copies;
+        json_bin_type["copies_min"] = bin_type.copies_min;
+        json_bin_type["maximum_weight"] = bin_type.maximum_weight;
+
+        if (bin_type.number_of_resources() > 0) {
+            json_bin_type["resources"] = nlohmann::json::array();
+            for (ResourceId resource_id = 0;
+                    resource_id < bin_type.number_of_resources();
+                    ++resource_id) {
+                const Resource& resource = bin_type.resource(resource_id);
+                nlohmann::json json_resource;
+                json_resource["capacity"] = resource.capacity;
+                json_resource["penalize"] = resource.penalize;
+                json_resource["penalty"] = resource.penalty;
+                json_resource["consumptions"] = nlohmann::json::array();
+                for (ItemTypeId item_type_id = 0;
+                        item_type_id < (ItemTypeId)resource.item_consumptions.size();
+                        ++item_type_id) {
+                    const std::vector<double>& schedule = resource.item_consumptions[item_type_id];
+                    if (schedule.empty())
+                        continue;
+                    nlohmann::json json_consumption;
+                    json_consumption["item_type_id"] = item_type_id;
+                    if (schedule.size() == 1) {
+                        json_consumption["consumption"] = schedule[0];
+                    } else {
+                        json_consumption["consumption_schedule"] = schedule;
+                    }
+                    json_resource["consumptions"].push_back(json_consumption);
+                }
+                json_bin_type["resources"].push_back(json_resource);
+            }
+        }
+
+        j["bin_types"].push_back(json_bin_type);
+    }
+
+    j["item_types"] = nlohmann::json::array();
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < number_of_item_types();
+            ++item_type_id) {
+        const ItemType& item_type = this->item_type(item_type_id);
+        nlohmann::json json_item_type;
+        json_item_type["x"] = item_type.box.x;
+        json_item_type["y"] = item_type.box.y;
+        json_item_type["z"] = item_type.box.z;
+        json_item_type["profit"] = item_type.profit;
+        json_item_type["copies"] = item_type.copies;
+        json_item_type["copies_min"] = item_type.copies_min;
+        json_item_type["weight"] = item_type.weight;
+        json_item_type["rotations"] = nlohmann::json::array();
+        for (Rotation rotation: item_type.rotations)
+            json_item_type["rotations"].push_back(to_string(rotation));
+        j["item_types"].push_back(json_item_type);
+    }
+
+    std::ofstream file(instance_path);
+    if (!file.good()) {
+        throw std::runtime_error(
+                FUNC_SIGNATURE + ": "
+                "unable to open file \"" + instance_path + "\".");
+    }
+    file << j.dump(4) << std::endl;
 }
 
 void Instance::write_item_types(

--- a/src/box/instance_builder.cpp
+++ b/src/box/instance_builder.cpp
@@ -85,6 +85,69 @@ void InstanceBuilder::set_bin_type_maximum_weight(
     instance_.bin_types_[bin_type_id].maximum_weight = maximum_weight;
 }
 
+ResourceId InstanceBuilder::add_bin_type_resource(
+        BinTypeId bin_type_id,
+        double capacity,
+        bool penalize,
+        double penalty)
+{
+    if (bin_type_id < 0 || bin_type_id >= (BinTypeId)instance_.bin_types_.size()) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "invalid 'bin_type_id'; "
+                "bin_type_id: " + std::to_string(bin_type_id) + "; "
+                "instance_.bin_types_.size(): " + std::to_string(instance_.bin_types_.size()) + ".");
+    }
+
+    BinType& bin_type = instance_.bin_types_[bin_type_id];
+    ResourceId resource_id = bin_type.resources.size();
+    Resource resource;
+    resource.capacity = capacity;
+    resource.penalize = penalize;
+    resource.penalty = penalty;
+    bin_type.resources.push_back(resource);
+    return resource_id;
+}
+
+void InstanceBuilder::add_resource_consumption(
+        BinTypeId bin_type_id,
+        ResourceId resource_id,
+        ItemTypeId item_type_id,
+        ItemPos item_copy,
+        double consumption)
+{
+    if (bin_type_id < 0 || bin_type_id >= (BinTypeId)instance_.bin_types_.size()) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "invalid 'bin_type_id'; "
+                "bin_type_id: " + std::to_string(bin_type_id) + "; "
+                "instance_.bin_types_.size(): " + std::to_string(instance_.bin_types_.size()) + ".");
+    }
+
+    BinType& bin_type = instance_.bin_types_[bin_type_id];
+    if (resource_id < 0 || resource_id >= (ResourceId)bin_type.resources.size()) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "invalid 'resource_id'; "
+                "resource_id: " + std::to_string(resource_id) + "; "
+                "bin_type.resources.size(): " + std::to_string(bin_type.resources.size()) + ".");
+    }
+    if (item_copy < 0) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "invalid 'item_copy'; "
+                "item_copy: " + std::to_string(item_copy) + ".");
+    }
+
+    std::vector<std::vector<double>>& item_consumptions = bin_type.resources[resource_id].item_consumptions;
+    if (item_type_id >= (ItemTypeId)item_consumptions.size())
+        item_consumptions.resize(item_type_id + 1);
+    std::vector<double>& schedule = item_consumptions[item_type_id];
+    if (item_copy >= (ItemPos)schedule.size())
+        schedule.resize(item_copy + 1, 0.0);
+    schedule[item_copy] = consumption;
+}
+
 BinTypeId InstanceBuilder::add_bin_type(
         const Instance& original_instance,
         BinTypeId original_bin_type_id)
@@ -103,6 +166,18 @@ BinTypeId InstanceBuilder::add_bin_type(
     set_bin_type_maximum_weight(
             bin_type_id,
             bin_type.maximum_weight);
+    // Copy resources (their consumptions are copied in 'add_item_type',
+    // which assumes the corresponding bin types have already been added).
+    for (ResourceId resource_id = 0;
+            resource_id < bin_type.number_of_resources();
+            ++resource_id) {
+        const Resource& resource = bin_type.resource(resource_id);
+        add_bin_type_resource(
+                bin_type_id,
+                resource.capacity,
+                resource.penalize,
+                resource.penalty);
+    }
     return bin_type_id;
 }
 
@@ -301,6 +376,36 @@ ItemTypeId InstanceBuilder::add_item_type(
     set_item_type_weight(
             item_type_id,
             item_type.weight);
+    // Copy the consumption of this item type for the resources of
+    // already-added bin types. Assumes the relevant bin types have already
+    // been added via 'add_bin_type(original_instance, ...)'.
+    for (BinTypeId original_bin_type_id = 0;
+            original_bin_type_id < (BinTypeId)orig_to_sub_bin_type_ids_.size();
+            ++original_bin_type_id) {
+        BinTypeId sub_bin_type_id = orig_to_sub_bin_type_ids_[original_bin_type_id];
+        if (sub_bin_type_id == -1)
+            continue;
+        const BinType& original_bin_type = original_instance.bin_type(original_bin_type_id);
+        for (ResourceId resource_id = 0;
+                resource_id < original_bin_type.number_of_resources();
+                ++resource_id) {
+            const std::vector<std::vector<double>>& item_consumptions
+                = original_bin_type.resource(resource_id).item_consumptions;
+            if (original_item_type_id >= (ItemTypeId)item_consumptions.size())
+                continue;
+            const std::vector<double>& schedule = item_consumptions[original_item_type_id];
+            for (ItemPos item_copy = 0;
+                    item_copy < (ItemPos)schedule.size();
+                    ++item_copy) {
+                add_resource_consumption(
+                        sub_bin_type_id,
+                        resource_id,
+                        item_type_id,
+                        item_copy,
+                        schedule[item_copy]);
+            }
+        }
+    }
     return item_type_id;
 }
 
@@ -644,6 +749,118 @@ void InstanceBuilder::read_item_types(
     }
 }
 
+void InstanceBuilder::read(
+        const std::string& instance_path)
+{
+    std::ifstream file(instance_path);
+    if (!file.good()) {
+        throw std::runtime_error(
+                FUNC_SIGNATURE + ": "
+                "unable to open file \"" + instance_path + "\".");
+    }
+
+    nlohmann::json j;
+    file >> j;
+
+    if (!j.contains("objective")) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "missing \"objective\" field.");
+    }
+    {
+        std::string objective_string = j["objective"];
+        std::stringstream objective_ss(objective_string);
+        Objective objective;
+        objective_ss >> objective;
+        if (objective_ss.fail()) {
+            throw std::invalid_argument(
+                    FUNC_SIGNATURE + ": "
+                    "unrecognized \"objective\" value \""
+                    + objective_string + "\".");
+        }
+        set_objective(objective);
+    }
+
+    // Read bin types.
+    for (const auto& json_bin_type: j["bin_types"]) {
+        Length x = json_bin_type["x"];
+        Length y = json_bin_type["y"];
+        Length z = json_bin_type["z"];
+        BinTypeId bin_type_id = add_bin_type(x, y, z);
+        if (json_bin_type.contains("cost"))
+            set_bin_type_cost(bin_type_id, json_bin_type["cost"]);
+        if (json_bin_type.contains("copies"))
+            set_bin_type_copies(bin_type_id, json_bin_type["copies"]);
+        if (json_bin_type.contains("copies_min"))
+            set_bin_type_copies_min(bin_type_id, json_bin_type["copies_min"]);
+        if (json_bin_type.contains("maximum_weight"))
+            set_bin_type_maximum_weight(bin_type_id, json_bin_type["maximum_weight"]);
+
+        // Read resources.
+        if (json_bin_type.contains("resources")) {
+            for (const auto& json_resource: json_bin_type["resources"]) {
+                double capacity = json_resource["capacity"];
+                bool penalize = json_resource.value("penalize", false);
+                double penalty = json_resource.value("penalty", 0.0);
+                ResourceId resource_id = add_bin_type_resource(bin_type_id, capacity, penalize, penalty);
+                if (json_resource.contains("consumptions")) {
+                    for (const auto& json_consumption: json_resource["consumptions"]) {
+                        ItemTypeId item_type_id = json_consumption["item_type_id"];
+                        if (json_consumption.contains("consumption_schedule")) {
+                            // Per-copy consumption schedule (a copy past
+                            // the end of the schedule repeats its last
+                            // entry); see 'Resource::item_consumptions'.
+                            std::vector<double> schedule = json_consumption["consumption_schedule"];
+                            for (ItemPos item_copy = 0;
+                                    item_copy < (ItemPos)schedule.size();
+                                    ++item_copy) {
+                                add_resource_consumption(
+                                        bin_type_id,
+                                        resource_id,
+                                        item_type_id,
+                                        item_copy,
+                                        schedule[item_copy]);
+                            }
+                        } else {
+                            // Uniform consumption, regardless of how many
+                            // copies are already packed.
+                            double consumption = json_consumption["consumption"];
+                            add_resource_consumption(
+                                    bin_type_id,
+                                    resource_id,
+                                    item_type_id,
+                                    0,
+                                    consumption);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Read item types.
+    for (const auto& json_item_type: j["item_types"]) {
+        Length x = json_item_type["x"];
+        Length y = json_item_type["y"];
+        Length z = json_item_type["z"];
+        ItemTypeId item_type_id = add_item_type(x, y, z);
+        if (json_item_type.contains("profit"))
+            set_item_type_profit(item_type_id, json_item_type["profit"]);
+        if (json_item_type.contains("copies"))
+            set_item_type_copies(item_type_id, json_item_type["copies"]);
+        if (json_item_type.contains("copies_min"))
+            set_item_type_copies_min(item_type_id, json_item_type["copies_min"]);
+        if (json_item_type.contains("weight"))
+            set_item_type_weight(item_type_id, json_item_type["weight"]);
+        if (json_item_type.contains("rotations")) {
+            for (const auto& json_rotation: json_item_type["rotations"]) {
+                std::string rotation_string = json_rotation;
+                add_item_type_rotation(item_type_id, rotation_from_string(rotation_string));
+            }
+        }
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////// Build /////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -779,6 +996,31 @@ Instance InstanceBuilder::build()
         }
         for (const FixedItem& fixed_item: bin_type.fixed_items)
             instance_.item_types_[fixed_item.item_type_id].copies_fixed += bin_type.copies;
+    }
+
+    // Compute item_type.resource_ids (see its own doc comment).
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance_.number_of_item_types();
+            ++item_type_id) {
+        instance_.item_types_[item_type_id].resource_ids.resize(instance_.number_of_bin_types());
+    }
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < instance_.number_of_bin_types();
+            ++bin_type_id) {
+        const BinType& bin_type = instance_.bin_types_[bin_type_id];
+        for (ResourceId resource_id = 0;
+                resource_id < bin_type.number_of_resources();
+                ++resource_id) {
+            const Resource& resource = bin_type.resource(resource_id);
+            for (ItemTypeId item_type_id = 0;
+                    item_type_id < (ItemTypeId)resource.item_consumptions.size();
+                    ++item_type_id) {
+                if (!resource.item_consumptions[item_type_id].empty()) {
+                    instance_.item_types_[item_type_id].resource_ids[bin_type_id]
+                        .push_back(resource_id);
+                }
+            }
+        }
     }
 
     return std::move(instance_);

--- a/src/box/solution.cpp
+++ b/src/box/solution.cpp
@@ -30,9 +30,14 @@ void Solution::update_indicators(
     bin_weight_ += bin.copies * bin_type.maximum_weight;
     bin_cost_ += bin.copies * bin_type.cost;
     number_of_bins_ += bin.copies;
+    bin.resource_consumption.assign(bin_type.number_of_resources(), 0.0);
     x_max_ = 0;
     y_max_ = 0;
 
+    // Number of copies of each item type already placed in this bin, so
+    // far, at the point each item below is processed - needed to look up
+    // the correct entry of a per-copy resource consumption schedule.
+    std::vector<ItemPos> item_type_copies_in_bin(instance().number_of_item_types(), 0);
     for (const SolutionItem& item: bin.items) {
         const ItemType& item_type = instance().item_type(item.item_type_id);
         Box box = item_type.box.rotate(item.rotation);
@@ -48,6 +53,29 @@ void Solution::update_indicators(
         item_volume_ += bin.copies * item_type.box.volume();
         item_weight_ += bin.copies * item_type.weight;
         item_profit_ += bin.copies * item_type.profit;
+
+        // Update bin.resource_consumption.
+        for (ResourceId resource_id: item_type.resource_ids[bin.bin_type_id]) {
+            const Resource& resource = bin_type.resource(resource_id);
+            double previous_consumption = bin.resource_consumption[resource_id];
+            bin.resource_consumption[resource_id]
+                += resource.item_consumption(
+                        item.item_type_id,
+                        item_type_copies_in_bin[item.item_type_id]);
+            if (bin.resource_consumption[resource_id] > resource.capacity) {
+                if (resource.penalize) {
+                    // Charge the penalty only once per bin, the first time
+                    // consumption crosses the capacity (it never decreases
+                    // afterwards, so this check would otherwise keep firing
+                    // for every subsequent item added to the same bin).
+                    if (previous_consumption <= resource.capacity)
+                        this->item_profit_ -= resource.penalty;
+                } else {
+                    this->resource_feasible_ = false;
+                }
+            }
+        }
+        ++item_type_copies_in_bin[item.item_type_id];
 
         if (bin_pos == (BinPos)bins_.size() - 1) {
             if (x_max_ < xe)
@@ -77,6 +105,7 @@ void Solution::update_indicators(
     callback_feasible_ = instance().feasibility_callback()(*this);
     feasible_ = item_copies_feasible_
         && callback_feasible_
+        && resource_feasible_
         && (number_of_infeasible_item_copies_min_ == 0);
 }
 

--- a/src/irregular/instance.cpp
+++ b/src/irregular/instance.cpp
@@ -395,6 +395,12 @@ bool Instance::fits_some_bin(
     return false;
 }
 
+bool Instance::resources_matter() const
+{
+    return number_of_bin_types() == 1
+        && bin_type(0).number_of_resources() > 0;
+}
+
 std::ostream& Instance::format(
         std::ostream& os,
         int verbosity_level) const

--- a/src/irregular/instance_builder.cpp
+++ b/src/irregular/instance_builder.cpp
@@ -88,7 +88,82 @@ BinTypeId InstanceBuilder::add_bin_type(
                 fixed_item.angle,
                 fixed_item.mirror);
     }
+    // Copy resources (their consumptions are copied in 'add_item_type',
+    // which assumes the corresponding bin types have already been added).
+    for (ResourceId resource_id = 0;
+            resource_id < bin_type.number_of_resources();
+            ++resource_id) {
+        const Resource& resource = bin_type.resource(resource_id);
+        add_bin_type_resource(
+                bin_type_id,
+                resource.capacity,
+                resource.penalize,
+                resource.penalty);
+    }
     return bin_type_id;
+}
+
+ResourceId InstanceBuilder::add_bin_type_resource(
+        BinTypeId bin_type_id,
+        double capacity,
+        bool penalize,
+        double penalty)
+{
+    if (bin_type_id < 0 || bin_type_id >= (BinTypeId)instance_.bin_types_.size()) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "invalid 'bin_type_id'; "
+                "bin_type_id: " + std::to_string(bin_type_id) + "; "
+                "instance_.bin_types_.size(): " + std::to_string(instance_.bin_types_.size()) + ".");
+    }
+
+    BinType& bin_type = instance_.bin_types_[bin_type_id];
+    ResourceId resource_id = bin_type.resources.size();
+    Resource resource;
+    resource.capacity = capacity;
+    resource.penalize = penalize;
+    resource.penalty = penalty;
+    bin_type.resources.push_back(resource);
+    return resource_id;
+}
+
+void InstanceBuilder::add_resource_consumption(
+        BinTypeId bin_type_id,
+        ResourceId resource_id,
+        ItemTypeId item_type_id,
+        ItemPos item_copy,
+        double consumption)
+{
+    if (bin_type_id < 0 || bin_type_id >= (BinTypeId)instance_.bin_types_.size()) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "invalid 'bin_type_id'; "
+                "bin_type_id: " + std::to_string(bin_type_id) + "; "
+                "instance_.bin_types_.size(): " + std::to_string(instance_.bin_types_.size()) + ".");
+    }
+
+    BinType& bin_type = instance_.bin_types_[bin_type_id];
+    if (resource_id < 0 || resource_id >= (ResourceId)bin_type.resources.size()) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "invalid 'resource_id'; "
+                "resource_id: " + std::to_string(resource_id) + "; "
+                "bin_type.resources.size(): " + std::to_string(bin_type.resources.size()) + ".");
+    }
+    if (item_copy < 0) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "invalid 'item_copy'; "
+                "item_copy: " + std::to_string(item_copy) + ".");
+    }
+
+    std::vector<std::vector<double>>& item_consumptions = bin_type.resources[resource_id].item_consumptions;
+    if (item_type_id >= (ItemTypeId)item_consumptions.size())
+        item_consumptions.resize(item_type_id + 1);
+    std::vector<double>& schedule = item_consumptions[item_type_id];
+    if (item_copy >= (ItemPos)schedule.size())
+        schedule.resize(item_copy + 1, 0.0);
+    schedule[item_copy] = consumption;
 }
 
 void InstanceBuilder::set_bin_type_cost(
@@ -316,6 +391,38 @@ ItemTypeId InstanceBuilder::add_item_type(
     if ((ItemTypeId)orig_to_sub_item_type_ids_.size() <= original_item_type_id)
         orig_to_sub_item_type_ids_.resize(original_item_type_id + 1, -1);
     orig_to_sub_item_type_ids_[original_item_type_id] = item_type_id;
+
+    // Copy the consumption of this item type for the resources of
+    // already-added bin types. Assumes the relevant bin types have already
+    // been added via 'add_bin_type(original_instance, ...)'.
+    for (BinTypeId original_bin_type_id = 0;
+            original_bin_type_id < (BinTypeId)orig_to_sub_bin_type_ids_.size();
+            ++original_bin_type_id) {
+        BinTypeId sub_bin_type_id = orig_to_sub_bin_type_ids_[original_bin_type_id];
+        if (sub_bin_type_id == -1)
+            continue;
+        const BinType& original_bin_type = original_instance.bin_type(original_bin_type_id);
+        for (ResourceId resource_id = 0;
+                resource_id < original_bin_type.number_of_resources();
+                ++resource_id) {
+            const std::vector<std::vector<double>>& item_consumptions
+                = original_bin_type.resource(resource_id).item_consumptions;
+            if (original_item_type_id >= (ItemTypeId)item_consumptions.size())
+                continue;
+            const std::vector<double>& schedule = item_consumptions[original_item_type_id];
+            for (ItemPos item_copy = 0;
+                    item_copy < (ItemPos)schedule.size();
+                    ++item_copy) {
+                add_resource_consumption(
+                        sub_bin_type_id,
+                        resource_id,
+                        item_type_id,
+                        item_copy,
+                        schedule[item_copy]);
+            }
+        }
+    }
+
     return item_type_id;
 }
 
@@ -975,6 +1082,31 @@ Instance InstanceBuilder::build()
                 FUNC_SIGNATURE + ": "
                 "the instance has objective OpenDimensionY and contains " + std::to_string(instance_.number_of_bins()) + " bins; "
                 "an instance with objective OpenDimensionY must contain exactly one bin.");
+    }
+
+    // Compute item_type.resource_ids (see its own doc comment).
+    for (ItemTypeId item_type_id = 0;
+            item_type_id < instance_.number_of_item_types();
+            ++item_type_id) {
+        instance_.item_types_[item_type_id].resource_ids.resize(instance_.number_of_bin_types());
+    }
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < instance_.number_of_bin_types();
+            ++bin_type_id) {
+        const BinType& bin_type = instance_.bin_types_[bin_type_id];
+        for (ResourceId resource_id = 0;
+                resource_id < bin_type.number_of_resources();
+                ++resource_id) {
+            const Resource& resource = bin_type.resource(resource_id);
+            for (ItemTypeId item_type_id = 0;
+                    item_type_id < (ItemTypeId)resource.item_consumptions.size();
+                    ++item_type_id) {
+                if (!resource.item_consumptions[item_type_id].empty()) {
+                    instance_.item_types_[item_type_id].resource_ids[bin_type_id]
+                        .push_back(resource_id);
+                }
+            }
+        }
     }
 
     return std::move(instance_);

--- a/src/irregular/solution.cpp
+++ b/src/irregular/solution.cpp
@@ -36,8 +36,13 @@ void Solution::update_indicators(
     number_of_bins_ += bin.copies;
     bin_cost_ += bin.copies * bin_type.cost;
     bin_area_ += bin.copies * bin_type.area_orig;
+    bin.resource_consumption.assign(bin_type.number_of_resources(), 0.0);
     AxisAlignedBoundingBox bin_aabb = bin_type.shape_orig.compute_min_max();
 
+    // Number of copies of each item type already placed in this bin, so
+    // far, at the point each item below is processed - needed to look up
+    // the correct entry of a per-copy resource consumption schedule.
+    std::vector<ItemPos> item_type_copies_in_bin(instance().number_of_item_types(), 0);
     for (const SolutionItem& item: bin.items) {
         const ItemType& item_type = instance().item_type(item.item_type_id);
 
@@ -53,6 +58,29 @@ void Solution::update_indicators(
         bin.y_min = std::min(bin.y_min, item.bl_corner.y + aabb.y_min);
         bin.x_max = std::max(bin.x_max, item.bl_corner.x + aabb.x_max);
         bin.y_max = std::max(bin.y_max, item.bl_corner.y + aabb.y_max);
+
+        // Update bin.resource_consumption.
+        for (ResourceId resource_id: item_type.resource_ids[bin.bin_type_id]) {
+            const Resource& resource = bin_type.resource(resource_id);
+            double previous_consumption = bin.resource_consumption[resource_id];
+            bin.resource_consumption[resource_id]
+                += resource.item_consumption(
+                        item.item_type_id,
+                        item_type_copies_in_bin[item.item_type_id]);
+            if (bin.resource_consumption[resource_id] > resource.capacity) {
+                if (resource.penalize) {
+                    // Charge the penalty only once per bin, the first time
+                    // consumption crosses the capacity (it never decreases
+                    // afterwards, so this check would otherwise keep firing
+                    // for every subsequent item added to the same bin).
+                    if (previous_consumption <= resource.capacity)
+                        this->item_profit_ -= resource.penalty;
+                } else {
+                    this->resource_feasible_ = false;
+                }
+            }
+        }
+        ++item_type_copies_in_bin[item.item_type_id];
     }
 
     // x_min_/y_min_/x_max_/y_max_ and the leftover value track the last bin only.
@@ -122,6 +150,7 @@ void Solution::update_indicators(
     callback_feasible_ = instance().feasibility_callback()(*this);
     feasible_ = item_copies_feasible_
         && callback_feasible_
+        && resource_feasible_
         && (number_of_infeasible_item_copies_min_ == 0);
 }
 


### PR DESCRIPTION
## Summary
- Mirrors rectangle/rectangleguillotine's per-bin-type `Resource` mechanism (capacity/penalize/penalty, per-item-type-and-copy consumption schedules) in `box` and `irregular`: `ItemType::resource_ids`, `BinType::resources`, the `InstanceBuilder::add_bin_type_resource`/`add_resource_consumption` API (with copy-through in the column-generation sub-instance constructors and `resource_ids` computation in `build()`), and `Solution`-level enforcement (`resource_consumption` tracking, capacity/penalty bookkeeping in `update_indicators`, `resource_feasible()`).
- Adds full JSON instance read/write to `box` (previously CSV-only), since resources can't be represented in CSV.
- Tree search enforcement (incremental resource tracking during branching) is intentionally left for a separate change.

## Test plan
- [x] Full build (`build_claude`, all six domains) succeeds
- [x] Full test suite passes (513/514, 1 pre-existing disabled test)