### PR TITLE
rectangle, box, onedimensional: fix JSON round-trip of infinite maximum_weight

### DIFF
--- a/src/box/instance.cpp
+++ b/src/box/instance.cpp
@@ -321,7 +321,12 @@ void Instance::write_json(
         json_bin_type["cost"] = bin_type.cost;
         json_bin_type["copies"] = bin_type.copies;
         json_bin_type["copies_min"] = bin_type.copies_min;
-        json_bin_type["maximum_weight"] = bin_type.maximum_weight;
+        // Infinity (the default - no maximum weight) has no JSON
+        // representation and would serialize as 'null'; omit the field
+        // instead, matching the default the reader falls back to when it's
+        // absent.
+        if (bin_type.maximum_weight != std::numeric_limits<Weight>::infinity())
+            json_bin_type["maximum_weight"] = bin_type.maximum_weight;
 
         if (bin_type.number_of_resources() > 0) {
             json_bin_type["resources"] = nlohmann::json::array();

--- a/src/box/instance_builder.cpp
+++ b/src/box/instance_builder.cpp
@@ -793,7 +793,11 @@ void InstanceBuilder::read(
             set_bin_type_copies(bin_type_id, json_bin_type["copies"]);
         if (json_bin_type.contains("copies_min"))
             set_bin_type_copies_min(bin_type_id, json_bin_type["copies_min"]);
-        if (json_bin_type.contains("maximum_weight"))
+        // A JSON 'null' (as written by an older version that serialized
+        // infinity directly, instead of omitting the field - see
+        // 'Instance::write_json') means the same as the field being absent:
+        // no maximum weight.
+        if (json_bin_type.contains("maximum_weight") && !json_bin_type["maximum_weight"].is_null())
             set_bin_type_maximum_weight(bin_type_id, json_bin_type["maximum_weight"]);
 
         // Read resources.

--- a/src/box/main.cpp
+++ b/src/box/main.cpp
@@ -61,7 +61,8 @@ int main(int argc, char *argv[])
         desc.add_options()
             (",h", "Produce help message")
 
-            ("items,i", po::value<std::string>()->required(), "Items path")
+            ("input,", po::value<std::string>(), "Input path (JSON format; alternative to --items/--bins/--parameters, required for instances using resources)")
+            ("items,i", po::value<std::string>(), "Items path")
             ("bins,b", po::value<std::string>(), "Bins path")
             ("parameters", po::value<std::string>(), "Parameters path")
 
@@ -127,52 +128,60 @@ int main(int argc, char *argv[])
 
         InstanceBuilder instance_builder;
 
-        std::string instance_path = vm["items"].as<std::string>();
-        if (fs::is_regular_file(instance_path)) {
-            instance_path = "";
-        } else if (fs::is_regular_file(instance_path + "_items.csv")) {
-            instance_path = instance_path + "_";
-        } else if (fs::is_regular_file(instance_path + "items.csv")) {
-            instance_path = instance_path;
-        } else if (fs::is_regular_file(instance_path + "/items.csv")) {
-            instance_path = instance_path + "/";
+        if (vm.count("input")) {
+            instance_builder.read(vm["input"].as<std::string>());
+        } else if (vm.count("items")) {
+            std::string instance_path = vm["items"].as<std::string>();
+            if (fs::is_regular_file(instance_path)) {
+                instance_path = "";
+            } else if (fs::is_regular_file(instance_path + "_items.csv")) {
+                instance_path = instance_path + "_";
+            } else if (fs::is_regular_file(instance_path + "items.csv")) {
+                instance_path = instance_path;
+            } else if (fs::is_regular_file(instance_path + "/items.csv")) {
+                instance_path = instance_path + "/";
+            } else {
+                throw std::invalid_argument(FUNC_SIGNATURE);
+            }
+
+            if (instance_path.empty()) {
+                instance_builder.read_item_types(vm["items"].as<std::string>());
+            } else {
+                instance_builder.read_item_types(instance_path + "items.csv");
+            }
+
+            if (vm.count("bins")) {
+                instance_builder.read_bin_types(vm["bins"].as<std::string>());
+            } else {
+                instance_builder.read_bin_types(instance_path + "bins.csv");
+            }
+
+            if (vm.count("bin-infinite-x"))
+                instance_builder.set_bin_types_infinite_x();
+            if (vm.count("bin-infinite-y"))
+                instance_builder.set_bin_types_infinite_y();
+            if (vm.count("bin-infinite-copies"))
+                instance_builder.set_bin_types_infinite_copies();
+            if (vm.count("item-infinite-copies"))
+                instance_builder.set_item_types_infinite_copies();
+            if (vm.count("no-item-rotation"))
+                instance_builder.set_item_types_oriented();
+            if (vm.count("unweighted"))
+                instance_builder.set_item_types_unweighted();
+            if (vm.count("bin-unweighted"))
+                instance_builder.set_bin_types_unweighted();
+            if (vm.count("item-profits-auto"))
+                instance_builder.set_item_types_profits_auto();
+
+            if (vm.count("parameters")) {
+                instance_builder.read_parameters(vm["parameters"].as<std::string>());
+            } else if (fs::is_regular_file(instance_path + "parameters.csv")) {
+                instance_builder.read_parameters(instance_path + "parameters.csv");
+            }
         } else {
-            throw std::invalid_argument(FUNC_SIGNATURE);
-        }
-
-        if (instance_path.empty()) {
-            instance_builder.read_item_types(vm["items"].as<std::string>());
-        } else {
-            instance_builder.read_item_types(instance_path + "items.csv");
-        }
-
-        if (vm.count("bins")) {
-            instance_builder.read_bin_types(vm["bins"].as<std::string>());
-        } else {
-            instance_builder.read_bin_types(instance_path + "bins.csv");
-        }
-
-        if (vm.count("bin-infinite-x"))
-            instance_builder.set_bin_types_infinite_x();
-        if (vm.count("bin-infinite-y"))
-            instance_builder.set_bin_types_infinite_y();
-        if (vm.count("bin-infinite-copies"))
-            instance_builder.set_bin_types_infinite_copies();
-        if (vm.count("item-infinite-copies"))
-            instance_builder.set_item_types_infinite_copies();
-        if (vm.count("no-item-rotation"))
-            instance_builder.set_item_types_oriented();
-        if (vm.count("unweighted"))
-            instance_builder.set_item_types_unweighted();
-        if (vm.count("bin-unweighted"))
-            instance_builder.set_bin_types_unweighted();
-        if (vm.count("item-profits-auto"))
-            instance_builder.set_item_types_profits_auto();
-
-        if (vm.count("parameters")) {
-            instance_builder.read_parameters(vm["parameters"].as<std::string>());
-        } else if (fs::is_regular_file(instance_path + "parameters.csv")) {
-            instance_builder.read_parameters(instance_path + "parameters.csv");
+            std::cout << "Missing --input or --items." << std::endl
+                << desc << std::endl;
+            return 1;
         }
 
         if (vm.count("objective"))

--- a/src/onedimensional/instance_builder.cpp
+++ b/src/onedimensional/instance_builder.cpp
@@ -756,7 +756,9 @@ void InstanceBuilder::read(
             set_bin_type_copies(bin_type_id, json_bin_type["copies"]);
         if (json_bin_type.contains("copies_min"))
             set_bin_type_copies_min(bin_type_id, json_bin_type["copies_min"]);
-        if (json_bin_type.contains("maximum_weight"))
+        // A JSON 'null' means the same as the field being absent: no
+        // maximum weight.
+        if (json_bin_type.contains("maximum_weight") && !json_bin_type["maximum_weight"].is_null())
             set_bin_type_maximum_weight(bin_type_id, json_bin_type["maximum_weight"]);
         if (json_bin_type.contains("eligibility_ids")) {
             for (const auto& json_eligibility_id: json_bin_type["eligibility_ids"])
@@ -821,7 +823,9 @@ void InstanceBuilder::read(
             set_item_type_nesting_length(item_type_id, json_item_type["nesting_length"]);
         if (json_item_type.contains("maximum_stackability"))
             set_item_type_maximum_stackability(item_type_id, json_item_type["maximum_stackability"]);
-        if (json_item_type.contains("maximum_weight_after"))
+        // A JSON 'null' means the same as the field being absent: no
+        // maximum weight after.
+        if (json_item_type.contains("maximum_weight_after") && !json_item_type["maximum_weight_after"].is_null())
             set_item_type_maximum_weight_after(item_type_id, json_item_type["maximum_weight_after"]);
         if (json_item_type.contains("eligibility_id"))
             set_item_type_eligibility(item_type_id, json_item_type["eligibility_id"]);

--- a/src/rectangle/instance.cpp
+++ b/src/rectangle/instance.cpp
@@ -654,7 +654,12 @@ void Instance::write_json(
         json_bin_type["cost"] = bin_type.cost;
         json_bin_type["copies"] = bin_type.copies;
         json_bin_type["copies_min"] = bin_type.copies_min;
-        json_bin_type["maximum_weight"] = bin_type.maximum_weight;
+        // Infinity (the default - no maximum weight) has no JSON
+        // representation and would serialize as 'null'; omit the field
+        // instead, matching the default the reader falls back to when it's
+        // absent.
+        if (bin_type.maximum_weight != std::numeric_limits<Weight>::infinity())
+            json_bin_type["maximum_weight"] = bin_type.maximum_weight;
         json_bin_type["eligibility_ids"] = bin_type.eligibility_ids;
 
         if (!bin_type.defects.empty()) {

--- a/src/rectangle/instance_builder.cpp
+++ b/src/rectangle/instance_builder.cpp
@@ -942,7 +942,11 @@ void InstanceBuilder::read(
             set_bin_type_copies(bin_type_id, json_bin_type["copies"]);
         if (json_bin_type.contains("copies_min"))
             set_bin_type_copies_min(bin_type_id, json_bin_type["copies_min"]);
-        if (json_bin_type.contains("maximum_weight"))
+        // A JSON 'null' (as written by an older version that serialized
+        // infinity directly, instead of omitting the field - see
+        // 'Instance::write_json') means the same as the field being absent:
+        // no maximum weight.
+        if (json_bin_type.contains("maximum_weight") && !json_bin_type["maximum_weight"].is_null())
             set_bin_type_maximum_weight(bin_type_id, json_bin_type["maximum_weight"]);
         if (json_bin_type.contains("eligibility_ids")) {
             for (const auto& json_eligibility_id: json_bin_type["eligibility_ids"])

--- a/src/rectangle/main.cpp
+++ b/src/rectangle/main.cpp
@@ -60,7 +60,8 @@ int main(int argc, char *argv[])
         desc.add_options()
             (",h", "Produce help message")
 
-            ("items,i", po::value<std::string>()->required(), "Items path")
+            ("input,", po::value<std::string>(), "Input path (JSON format; alternative to --items/--bins/--defects/--parameters, required for instances using resources)")
+            ("items,i", po::value<std::string>(), "Items path")
             ("bins,b", po::value<std::string>(), "Bins path")
             ("defects,d", po::value<std::string>(), "Defects path")
             ("parameters", po::value<std::string>(), "Parameters path")
@@ -132,58 +133,66 @@ int main(int argc, char *argv[])
 
         InstanceBuilder instance_builder;
 
-        std::string instance_path = vm["items"].as<std::string>();
-        if (fs::is_regular_file(instance_path)) {
-            instance_path = "";
-        } else if (fs::is_regular_file(instance_path + "_items.csv")) {
-            instance_path = instance_path + "_";
-        } else if (fs::is_regular_file(instance_path + "items.csv")) {
-            instance_path = instance_path;
-        } else if (fs::is_regular_file(instance_path + "/items.csv")) {
-            instance_path = instance_path + "/";
+        if (vm.count("input")) {
+            instance_builder.read(vm["input"].as<std::string>());
+        } else if (vm.count("items")) {
+            std::string instance_path = vm["items"].as<std::string>();
+            if (fs::is_regular_file(instance_path)) {
+                instance_path = "";
+            } else if (fs::is_regular_file(instance_path + "_items.csv")) {
+                instance_path = instance_path + "_";
+            } else if (fs::is_regular_file(instance_path + "items.csv")) {
+                instance_path = instance_path;
+            } else if (fs::is_regular_file(instance_path + "/items.csv")) {
+                instance_path = instance_path + "/";
+            } else {
+                throw std::invalid_argument(FUNC_SIGNATURE);
+            }
+
+            if (instance_path.empty()) {
+                instance_builder.read_item_types(vm["items"].as<std::string>());
+            } else {
+                instance_builder.read_item_types(instance_path + "items.csv");
+            }
+
+            if (vm.count("bins")) {
+                instance_builder.read_bin_types(vm["bins"].as<std::string>());
+            } else {
+                instance_builder.read_bin_types(instance_path + "bins.csv");
+            }
+
+            if (vm.count("defects")) {
+                instance_builder.read_defects(vm["defects"].as<std::string>());
+            } else if (fs::is_regular_file(instance_path + "defects.csv")) {
+                instance_builder.read_defects(instance_path + "defects.csv");
+            }
+
+            if (vm.count("item-multiply-copies"))
+                instance_builder.multiply_item_types_copies(vm["item-multiply-copies"].as<ItemPos>());
+            if (vm.count("bin-infinite-x"))
+                instance_builder.set_bin_types_infinite_x();
+            if (vm.count("bin-infinite-y"))
+                instance_builder.set_bin_types_infinite_y();
+            if (vm.count("bin-infinite-copies"))
+                instance_builder.set_bin_types_infinite_copies();
+            if (vm.count("bin-unweighted"))
+                instance_builder.set_bin_types_unweighted();
+            if (vm.count("no-item-rotation"))
+                instance_builder.set_item_types_oriented();
+            if (vm.count("item-infinite-copies"))
+                instance_builder.set_item_types_infinite_copies();
+            if (vm.count("unweighted"))
+                instance_builder.set_item_types_unweighted();
+
+            if (vm.count("parameters")) {
+                instance_builder.read_parameters(vm["parameters"].as<std::string>());
+            } else if (fs::is_regular_file(instance_path + "parameters.csv")) {
+                instance_builder.read_parameters(instance_path + "parameters.csv");
+            }
         } else {
-            throw std::invalid_argument(FUNC_SIGNATURE);
-        }
-
-        if (instance_path.empty()) {
-            instance_builder.read_item_types(vm["items"].as<std::string>());
-        } else {
-            instance_builder.read_item_types(instance_path + "items.csv");
-        }
-
-        if (vm.count("bins")) {
-            instance_builder.read_bin_types(vm["bins"].as<std::string>());
-        } else {
-            instance_builder.read_bin_types(instance_path + "bins.csv");
-        }
-
-        if (vm.count("defects")) {
-            instance_builder.read_defects(vm["defects"].as<std::string>());
-        } else if (fs::is_regular_file(instance_path + "defects.csv")) {
-            instance_builder.read_defects(instance_path + "defects.csv");
-        }
-
-        if (vm.count("item-multiply-copies"))
-            instance_builder.multiply_item_types_copies(vm["item-multiply-copies"].as<ItemPos>());
-        if (vm.count("bin-infinite-x"))
-            instance_builder.set_bin_types_infinite_x();
-        if (vm.count("bin-infinite-y"))
-            instance_builder.set_bin_types_infinite_y();
-        if (vm.count("bin-infinite-copies"))
-            instance_builder.set_bin_types_infinite_copies();
-        if (vm.count("bin-unweighted"))
-            instance_builder.set_bin_types_unweighted();
-        if (vm.count("no-item-rotation"))
-            instance_builder.set_item_types_oriented();
-        if (vm.count("item-infinite-copies"))
-            instance_builder.set_item_types_infinite_copies();
-        if (vm.count("unweighted"))
-            instance_builder.set_item_types_unweighted();
-
-        if (vm.count("parameters")) {
-            instance_builder.read_parameters(vm["parameters"].as<std::string>());
-        } else if (fs::is_regular_file(instance_path + "parameters.csv")) {
-            instance_builder.read_parameters(instance_path + "parameters.csv");
+            std::cout << "Missing --input or --items." << std::endl
+                << desc << std::endl;
+            return 1;
         }
 
         if (vm.count("objective"))

--- a/src/rectangleguillotine/main.cpp
+++ b/src/rectangleguillotine/main.cpp
@@ -58,7 +58,8 @@ int main(int argc, char *argv[])
         desc.add_options()
             (",h", "Produce help message")
 
-            ("items,i", po::value<std::string>()->required(), "Items path")
+            ("input,", po::value<std::string>(), "Input path (JSON format; alternative to --items/--bins/--defects/--parameters, required for instances using resources)")
+            ("items,i", po::value<std::string>(), "Items path")
             ("bins,b", po::value<std::string>(), "Bins path")
             ("defects,d", po::value<std::string>(), "Defects path")
             ("parameters", po::value<std::string>(), "Parameters path")
@@ -154,58 +155,67 @@ int main(int argc, char *argv[])
         // Build instance.
 
         InstanceBuilder instance_builder;
-        std::string instance_path = vm["items"].as<std::string>();
-        if (fs::is_regular_file(instance_path)) {
-            instance_path = "";
-        } else if (fs::is_regular_file(instance_path + "_items.csv")) {
-            instance_path = instance_path + "_";
-        } else if (fs::is_regular_file(instance_path + "items.csv")) {
-            instance_path = instance_path;
-        } else if (fs::is_regular_file(instance_path + "/items.csv")) {
-            instance_path = instance_path + "/";
+
+        if (vm.count("input")) {
+            instance_builder.read(vm["input"].as<std::string>());
+        } else if (vm.count("items")) {
+            std::string instance_path = vm["items"].as<std::string>();
+            if (fs::is_regular_file(instance_path)) {
+                instance_path = "";
+            } else if (fs::is_regular_file(instance_path + "_items.csv")) {
+                instance_path = instance_path + "_";
+            } else if (fs::is_regular_file(instance_path + "items.csv")) {
+                instance_path = instance_path;
+            } else if (fs::is_regular_file(instance_path + "/items.csv")) {
+                instance_path = instance_path + "/";
+            } else {
+                throw std::invalid_argument("");
+            }
+
+            if (instance_path.empty()) {
+                instance_builder.read_item_types(vm["items"].as<std::string>());
+            } else {
+                instance_builder.read_item_types(instance_path + "items.csv");
+            }
+
+            if (vm.count("bins")) {
+                instance_builder.read_bin_types(vm["bins"].as<std::string>());
+            } else {
+                instance_builder.read_bin_types(instance_path + "bins.csv");
+            }
+
+            if (vm.count("defects")) {
+                instance_builder.read_defects(vm["defects"].as<std::string>());
+            } else if (fs::is_regular_file(instance_path + "defects.csv")) {
+                instance_builder.read_defects(instance_path + "defects.csv");
+            }
+
+            if (vm.count("item-multiply-copies"))
+                instance_builder.multiply_item_types_copies(vm["item-multiply-copies"].as<ItemPos>());
+            if (vm.count("bin-infinite-x"))
+                instance_builder.set_bin_types_infinite_x();
+            if (vm.count("bin-infinite-y"))
+                instance_builder.set_bin_types_infinite_y();
+            if (vm.count("bin-infinite-copies"))
+                instance_builder.set_bin_types_infinite_copies();
+            if (vm.count("no-item-rotation"))
+                instance_builder.set_item_types_oriented();
+            if (vm.count("item-infinite-copies"))
+                instance_builder.set_item_types_infinite_copies();
+            if (vm.count("unweighted"))
+                instance_builder.set_item_types_unweighted();
+            if (vm.count("bin-unweighted"))
+                instance_builder.set_bin_types_unweighted();
+
+            if (vm.count("parameters")) {
+                instance_builder.read_parameters(vm["parameters"].as<std::string>());
+            } else if (fs::is_regular_file(instance_path + "parameters.csv")) {
+                instance_builder.read_parameters(instance_path + "parameters.csv");
+            }
         } else {
-            throw std::invalid_argument("");
-        }
-
-        if (instance_path.empty()) {
-            instance_builder.read_item_types(vm["items"].as<std::string>());
-        } else {
-            instance_builder.read_item_types(instance_path + "items.csv");
-        }
-
-        if (vm.count("bins")) {
-            instance_builder.read_bin_types(vm["bins"].as<std::string>());
-        } else {
-            instance_builder.read_bin_types(instance_path + "bins.csv");
-        }
-
-        if (vm.count("defects")) {
-            instance_builder.read_defects(vm["defects"].as<std::string>());
-        } else if (fs::is_regular_file(instance_path + "defects.csv")) {
-            instance_builder.read_defects(instance_path + "defects.csv");
-        }
-
-        if (vm.count("item-multiply-copies"))
-            instance_builder.multiply_item_types_copies(vm["item-multiply-copies"].as<ItemPos>());
-        if (vm.count("bin-infinite-x"))
-            instance_builder.set_bin_types_infinite_x();
-        if (vm.count("bin-infinite-y"))
-            instance_builder.set_bin_types_infinite_y();
-        if (vm.count("bin-infinite-copies"))
-            instance_builder.set_bin_types_infinite_copies();
-        if (vm.count("no-item-rotation"))
-            instance_builder.set_item_types_oriented();
-        if (vm.count("item-infinite-copies"))
-            instance_builder.set_item_types_infinite_copies();
-        if (vm.count("unweighted"))
-            instance_builder.set_item_types_unweighted();
-        if (vm.count("bin-unweighted"))
-            instance_builder.set_bin_types_unweighted();
-
-        if (vm.count("parameters")) {
-            instance_builder.read_parameters(vm["parameters"].as<std::string>());
-        } else if (fs::is_regular_file(instance_path + "parameters.csv")) {
-            instance_builder.read_parameters(instance_path + "parameters.csv");
+            std::cout << "Missing --input or --items." << std::endl
+                << desc << std::endl;
+            return 1;
         }
 
         if (vm.count("objective"))


### PR DESCRIPTION
## Summary
- Writing an infinite `maximum_weight` (bin type) or `maximum_weight_after` (onedimensional item type) — the default, meaning no limit — serialized to JSON `null` (nlohmann::json's default for non-finite doubles), which the reader then failed to parse back into a `Weight`.
- Write now omits the field instead when infinite, matching the default the reader already falls back to when the field is absent.
- Read now also tolerates an explicit JSON `null` the same way, for files already written with it before this fix.

## Test plan
- [x] Verified round-trip (write JSON with default/infinite `maximum_weight`, read it back) produces no `maximum_weight` key in the JSON and restores infinity correctly
- [x] Build succeeds for `rectangle`, `box`, `onedimensional`