### PR TITLE
Fix Knapsack bounds to account for resources with negative penalties

### DIFF
--- a/include/packingsolver/algorithms/common.hpp
+++ b/include/packingsolver/algorithms/common.hpp
@@ -315,6 +315,47 @@ struct Resource
     }
 };
 
+/**
+ * Sum, over all 'penalize' resources with a negative 'penalty', of
+ * '-resource.penalty' (i.e. the magnitude of the profit gain each one could
+ * contribute if triggered).
+ *
+ * A negative penalty *increases* the reported profit when its resource's
+ * capacity is exceeded (see 'Resource'). A Knapsack bound computed without
+ * modeling resources at all (e.g. a closed-form area/weight relaxation) is
+ * only a valid upper bound on the profit actually reported once resources
+ * are taken into account if this worst-case gain - every negative-penalty
+ * resource triggering at once - is added back to it.
+ */
+inline Profit negative_penalty_sum(const std::vector<Resource>& resources)
+{
+    Profit sum = 0.0;
+    for (const Resource& resource: resources)
+        if (resource.penalize && resource.penalty < 0.0)
+            sum -= resource.penalty;
+    return sum;
+}
+
+/**
+ * Same as 'negative_penalty_sum(const std::vector<Resource>&)', summed over
+ * every bin type of 'instance', each weighted by its number of copies: since
+ * a 'penalize' resource is tracked per bin (see 'Resource'), each copy of a
+ * bin type can trigger it independently, so the worst case scales with the
+ * number of available copies.
+ */
+template <typename Instance>
+inline Profit negative_penalty_sum(const Instance& instance)
+{
+    Profit sum = 0.0;
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < instance.number_of_bin_types();
+            ++bin_type_id) {
+        const auto& bin_type = instance.bin_type(bin_type_id);
+        sum += bin_type.copies * negative_penalty_sum(bin_type.resources);
+    }
+    return sum;
+}
+
 template <typename Instance, typename Solution>
 class SolutionPool
 {

--- a/src/box/dual_feasible_functions.cpp
+++ b/src/box/dual_feasible_functions.cpp
@@ -539,6 +539,11 @@ DualFeasibleFunctionsOutput packingsolver::box::dual_feasible_functions(
         if (bound > instance.number_of_bins())
             algorithm_formatter.update_is_proven_infeasible();
     } else if (instance.objective() == Objective::Knapsack) {
+        // This bound ignores resources entirely. A 'penalize' resource with
+        // a negative penalty *increases* the reported profit when
+        // triggered (see 'Resource'), so add back the worst case - every
+        // such resource triggering at once - to keep the bound valid.
+        knapsack_bound += negative_penalty_sum(instance);
         algorithm_formatter.update_knapsack_bound(knapsack_bound);
     }
 

--- a/src/box/optimize.cpp
+++ b/src/box/optimize.cpp
@@ -75,6 +75,11 @@ void optimize_trivial_bound(
                 remaining_capacity = 0;
             }
         }
+        // This bound ignores resources entirely. A 'penalize' resource with
+        // a negative penalty *increases* the reported profit when
+        // triggered (see 'Resource'), so add back the worst case - every
+        // such resource triggering at once - to keep the bound valid.
+        bound += negative_penalty_sum(instance);
         algorithm_formatter.update_knapsack_bound(bound);
         return;
     }
@@ -201,8 +206,13 @@ void optimize_onedimensional_bound(
                 onedim_output.bin_packing_bound);
         break;
     } case Objective::Knapsack: {
+        // The 1D relaxation this bound comes from doesn't carry over
+        // resources at all. A 'penalize' resource with a negative penalty
+        // *increases* the reported profit when triggered (see 'Resource'),
+        // so add back the worst case - every such resource triggering at
+        // once - to keep the bound valid.
         algorithm_formatter.update_knapsack_bound(
-                onedim_output.knapsack_bound);
+                onedim_output.knapsack_bound + negative_penalty_sum(instance));
         break;
     } case Objective::VariableSizedBinPacking: {
         algorithm_formatter.update_variable_sized_bin_packing_bound(

--- a/src/irregular/optimize.cpp
+++ b/src/irregular/optimize.cpp
@@ -82,6 +82,11 @@ void optimize_trivial_bound(
                 remaining_capacity = 0;
             }
         }
+        // This bound ignores resources entirely. A 'penalize' resource with
+        // a negative penalty *increases* the reported profit when
+        // triggered (see 'Resource'), so add back the worst case - every
+        // such resource triggering at once - to keep the bound valid.
+        bound += negative_penalty_sum(instance);
         algorithm_formatter.update_knapsack_bound(bound);
         return;
     }
@@ -179,8 +184,13 @@ void optimize_onedimensional_bound(
                 onedim_output.bin_packing_bound);
         break;
     } case Objective::Knapsack: {
+        // The 1D relaxation this bound comes from doesn't carry over
+        // resources at all. A 'penalize' resource with a negative penalty
+        // *increases* the reported profit when triggered (see 'Resource'),
+        // so add back the worst case - every such resource triggering at
+        // once - to keep the bound valid.
         algorithm_formatter.update_knapsack_bound(
-                onedim_output.knapsack_bound);
+                onedim_output.knapsack_bound + negative_penalty_sum(instance));
         break;
     } case Objective::VariableSizedBinPacking: {
         algorithm_formatter.update_variable_sized_bin_packing_bound(

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -86,6 +86,11 @@ void optimize_trivial_bound(
                 remaining_capacity = 0;
             }
         }
+        // This bound ignores resources entirely. A 'penalize' resource with
+        // a negative penalty *increases* the reported profit when
+        // triggered (see 'Resource'), so add back the worst case - every
+        // such resource triggering at once - to keep the bound valid.
+        bound += negative_penalty_sum(instance);
         algorithm_formatter.update_knapsack_bound(bound);
         return;
     }

--- a/src/rectangle/bar_relaxation.cpp
+++ b/src/rectangle/bar_relaxation.cpp
@@ -580,7 +580,13 @@ BarRelaxationOutput packingsolver::rectangle::bar_relaxation(
     {
         switch (instance.objective()) {
         case Objective::Knapsack: {
-            algorithm_formatter.update_knapsack_bound(cgs_output.bound);
+            // This bound ignores resources entirely. A 'penalize' resource
+            // with a negative penalty *increases* the reported profit when
+            // triggered (see 'Resource'), so add back the worst case -
+            // every such resource triggering at once - to keep the bound
+            // valid.
+            algorithm_formatter.update_knapsack_bound(
+                    cgs_output.bound + negative_penalty_sum(instance));
             break;
         } case Objective::Feasibility: {
             // By the extended reals convention, the optimal value of an

--- a/src/rectangle/dual_feasible_functions.cpp
+++ b/src/rectangle/dual_feasible_functions.cpp
@@ -676,6 +676,11 @@ DualFeasibleFunctionsOutput packingsolver::rectangle::dual_feasible_functions(
         if (bound > instance.number_of_bins())
             algorithm_formatter.update_is_proven_infeasible();
     } else if (instance.objective() == Objective::Knapsack) {
+        // This bound ignores resources entirely. A 'penalize' resource with
+        // a negative penalty *increases* the reported profit when
+        // triggered (see 'Resource'), so add back the worst case - every
+        // such resource triggering at once - to keep the bound valid.
+        knapsack_bound += negative_penalty_sum(instance);
         algorithm_formatter.update_knapsack_bound(knapsack_bound);
     }
 

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -81,6 +81,11 @@ void optimize_trivial_bound(
                 remaining_capacity = 0;
             }
         }
+        // This bound ignores resources entirely. A 'penalize' resource with
+        // a negative penalty *increases* the reported profit when
+        // triggered (see 'Resource'), so add back the worst case - every
+        // such resource triggering at once - to keep the bound valid.
+        bound += negative_penalty_sum(instance);
         algorithm_formatter.update_knapsack_bound(bound);
         return;
     }
@@ -200,8 +205,13 @@ void optimize_onedimensional_bound(
                 onedim_output.bin_packing_bound);
         break;
     } case Objective::Knapsack: {
+        // The 1D relaxation this bound comes from doesn't carry over
+        // resources at all. A 'penalize' resource with a negative penalty
+        // *increases* the reported profit when triggered (see 'Resource'),
+        // so add back the worst case - every such resource triggering at
+        // once - to keep the bound valid.
         algorithm_formatter.update_knapsack_bound(
-                onedim_output.knapsack_bound);
+                onedim_output.knapsack_bound + negative_penalty_sum(instance));
         break;
     } case Objective::VariableSizedBinPacking: {
         algorithm_formatter.update_variable_sized_bin_packing_bound(

--- a/src/rectangleguillotine/column_generation_strips.cpp
+++ b/src/rectangleguillotine/column_generation_strips.cpp
@@ -2141,7 +2141,14 @@ void column_generation_strips_vertical(
         // below) has objective OpenDimensionX too.
         if (instance.objective() == Objective::Knapsack) {
             double multiplier_profit = largest_power_of_two_lesser_or_equal(instance.largest_item_profit());
-            algorithm_formatter.update_knapsack_bound(cgslds_output.bound * multiplier_profit);
+            // This bound ignores resources entirely (the pricing solver
+            // used here doesn't consume 'cuts'/resources). A 'penalize'
+            // resource with a negative penalty *increases* the reported
+            // profit when triggered (see 'Resource'), so add back the
+            // worst case - every such resource triggering at once - to
+            // keep the bound valid.
+            algorithm_formatter.update_knapsack_bound(
+                    cgslds_output.bound * multiplier_profit + negative_penalty_sum(instance));
         } else if (instance.objective() == Objective::OpenDimensionX) {
             const BinType& bin_type = instance.bin_type(0);
             double multiplier_length = largest_power_of_two_lesser_or_equal(bin_type.rect.w);

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -73,6 +73,11 @@ void optimize_trivial_bound(
                 remaining_capacity = 0;
             }
         }
+        // This bound ignores resources entirely. A 'penalize' resource with
+        // a negative penalty *increases* the reported profit when
+        // triggered (see 'Resource'), so add back the worst case - every
+        // such resource triggering at once - to keep the bound valid.
+        bound += negative_penalty_sum(instance);
         algorithm_formatter.update_knapsack_bound(bound);
         return;
     }
@@ -192,8 +197,13 @@ void optimize_onedimensional_bound(
                 onedim_output.bin_packing_bound);
         break;
     } case Objective::Knapsack: {
+        // The 1D relaxation this bound comes from doesn't carry over
+        // resources at all. A 'penalize' resource with a negative penalty
+        // *increases* the reported profit when triggered (see 'Resource'),
+        // so add back the worst case - every such resource triggering at
+        // once - to keep the bound valid.
         algorithm_formatter.update_knapsack_bound(
-                onedim_output.knapsack_bound);
+                onedim_output.knapsack_bound + negative_penalty_sum(instance));
         break;
     } case Objective::VariableSizedBinPacking: {
         algorithm_formatter.update_variable_sized_bin_packing_bound(


### PR DESCRIPTION
## Summary
- A `penalize` resource's `penalty` is allowed to be negative (needed for subset-row cuts, whose LP dual can have either sign), which *increases* the reported profit when the resource triggers rather than decreasing it.
- Every Knapsack bound computed without modeling resources at all (the trivial area/volume Dantzig bound, the onedimensional relaxation bound, dual feasible functions, and the bar-relaxation/column-generation-strips LP bounds) stopped being a valid upper bound whenever such a resource could fire, since none of them accounted for that possible profit increase.
- Adds a shared `negative_penalty_sum()` helper (`include/packingsolver/algorithms/common.hpp`) and uses it to add back the worst-case sum of all negative penalties in each of these bound computations, across `rectangle`, `rectangleguillotine`, `box`, `irregular` and `onedimensional`.

## Test plan
- [x] Full test suite (`ctest --output-on-failure --parallel`): 100% passed, 0 failed.
- [x] Reproduced the original invalid-bound case (a Knapsack instance whose bin type carries several negative-penalty resources) and confirmed the Dual bound is now ≥ the Primal bound.