### PR TITLE
Add tree-search-level enforcement of resources across all domains

### DIFF
--- a/src/box/tree_search.cpp
+++ b/src/box/tree_search.cpp
@@ -329,6 +329,48 @@ BranchingScheme::Node BranchingScheme::child_tmp(
     node.item_weight = parent.item_weight + item_type.weight;
     node.profit = parent.profit + item_type.profit;
 
+    // Update last_bin_item_number_of_copies and last_bin_resource_consumption.
+    // 'node.profit' is further adjusted below by any 'penalize' resource
+    // whose consumption crosses its capacity for the first time as a result
+    // of this insertion (see 'Resource::penalize'), mirroring 'Solution::
+    // update_indicators' so the search optimizes the same objective the
+    // final solution will report.
+    // Skipped entirely when the bin type has no resources at all, so
+    // instances that don't use resources don't pay for allocating/copying
+    // these per-node vectors.
+    if (bin_type.number_of_resources() > 0) {
+        if (insertion.new_bin > 0) {  // New bin.
+            node.last_bin_item_number_of_copies.assign(instance.number_of_item_types(), 0);
+            node.last_bin_resource_consumption.assign(bin_type.number_of_resources(), 0.0);
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                double consumption = resource.item_consumption(insertion.item_type_id, 0);
+                node.last_bin_resource_consumption[resource_id] = consumption;
+                // The bin is empty before this insertion, so any crossing here
+                // is necessarily the first one.
+                if (resource.penalize && consumption > resource.capacity)
+                    node.profit -= resource.penalty;
+            }
+            node.last_bin_item_number_of_copies[insertion.item_type_id] = 1;
+        } else {  // Same bin.
+            node.last_bin_item_number_of_copies = parent.last_bin_item_number_of_copies;
+            ItemPos item_copy = node.last_bin_item_number_of_copies[insertion.item_type_id];
+            node.last_bin_resource_consumption = parent.last_bin_resource_consumption;
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                double previous_consumption = node.last_bin_resource_consumption[resource_id];
+                node.last_bin_resource_consumption[resource_id]
+                    += resource.item_consumption(insertion.item_type_id, item_copy);
+                if (resource.penalize
+                        && node.last_bin_resource_consumption[resource_id] > resource.capacity
+                        && previous_consumption <= resource.capacity) {
+                    node.profit -= resource.penalty;
+                }
+            }
+            node.last_bin_item_number_of_copies[insertion.item_type_id]++;
+        }
+    }
+
     // Compute current_volume, guide_volume and width using uncovered_items.
     node.xs_max = (insertion.new_bin == 0)?
         std::max(parent.xs_max, insertion.x):
@@ -537,6 +579,34 @@ void BranchingScheme::insertion_item(
     if (last_bin_weight > bin_type.maximum_weight * PSTOL) {
         //std::cout << "maximum_weight" << std::endl;
         return;
+    }
+
+    // Check resource capacity. 'penalize' resources never block an
+    // insertion (see 'Resource::penalize'); only their non-'penalize'
+    // counterparts do. Skipped entirely when the bin type has no resources
+    // (see 'child_tmp').
+    if (bin_type.number_of_resources() > 0) {
+        if (new_bin == 0) {  // Same bin.
+            ItemPos item_copy = parent->last_bin_item_number_of_copies[item_type_id];
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                if (resource.penalize)
+                    continue;
+                double consumption = parent->last_bin_resource_consumption[resource_id]
+                    + resource.item_consumption(item_type_id, item_copy);
+                if (consumption > resource.capacity * PSTOL)
+                    return;
+            }
+        } else {  // New bin.
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                if (resource.penalize)
+                    continue;
+                double consumption = resource.item_consumption(item_type_id, 0);
+                if (consumption > resource.capacity * PSTOL)
+                    return;
+            }
+        }
     }
 
     // Check contact with y and z uncovered items.

--- a/src/box/tree_search.hpp
+++ b/src/box/tree_search.hpp
@@ -168,6 +168,17 @@ public:
 
         /** Width or height. */
         Length length = 0;
+
+        /**
+         * For each item type, number of copies of that item type already in
+         * the last (current) bin - needed to look up the correct entry of a
+         * per-copy resource consumption schedule (see 'Resource::
+         * item_consumption').
+         */
+        std::vector<ItemPos> last_bin_item_number_of_copies;
+
+        /** Resource consumption of the last (current) bin, indexed by resource_id. */
+        std::vector<double> last_bin_resource_consumption;
     };
 
     struct Parameters

--- a/src/irregular/tree_search.cpp
+++ b/src/irregular/tree_search.cpp
@@ -1266,6 +1266,48 @@ BranchingScheme::Node BranchingScheme::child_tmp(
     node.item_convex_hull_area = parent.item_convex_hull_area
         + item_types_convex_hull_area_[trapezoid_set.item_type_id];
 
+    // Update last_bin_item_number_of_copies and last_bin_resource_consumption.
+    // 'node.profit' is further adjusted below by any 'penalize' resource
+    // whose consumption crosses its capacity for the first time as a result
+    // of this insertion (see 'Resource::penalize'), mirroring 'Solution::
+    // update_indicators' so the search optimizes the same objective the
+    // final solution will report.
+    // Skipped entirely when the bin type has no resources at all, so
+    // instances that don't use resources don't pay for allocating/copying
+    // these per-node vectors.
+    if (bin_type.number_of_resources() > 0) {
+        if (insertion.new_bin_direction != Direction::Any) {  // New bin.
+            node.last_bin_item_number_of_copies.assign(instance_.number_of_item_types(), 0);
+            node.last_bin_resource_consumption.assign(bin_type.number_of_resources(), 0.0);
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                double consumption = resource.item_consumption(trapezoid_set.item_type_id, 0);
+                node.last_bin_resource_consumption[resource_id] = consumption;
+                // The bin is empty before this insertion, so any crossing here
+                // is necessarily the first one.
+                if (resource.penalize && consumption > resource.capacity)
+                    node.profit -= resource.penalty;
+            }
+            node.last_bin_item_number_of_copies[trapezoid_set.item_type_id] = 1;
+        } else {  // Same bin.
+            node.last_bin_item_number_of_copies = parent.last_bin_item_number_of_copies;
+            ItemPos item_copy = node.last_bin_item_number_of_copies[trapezoid_set.item_type_id];
+            node.last_bin_resource_consumption = parent.last_bin_resource_consumption;
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                double previous_consumption = node.last_bin_resource_consumption[resource_id];
+                node.last_bin_resource_consumption[resource_id]
+                    += resource.item_consumption(trapezoid_set.item_type_id, item_copy);
+                if (resource.penalize
+                        && node.last_bin_resource_consumption[resource_id] > resource.capacity
+                        && previous_consumption <= resource.capacity) {
+                    node.profit -= resource.penalty;
+                }
+            }
+            node.last_bin_item_number_of_copies[trapezoid_set.item_type_id]++;
+        }
+    }
+
     // Compute, guide_area and width using uncovered_trapezoids.
     node.xs_max = (insertion.new_bin_direction == Direction::Any)?  // Same bin
         std::max(parent.xs_max, insertion.x + trapezoid_set.x_min):
@@ -1917,6 +1959,34 @@ void BranchingScheme::insertion_trapezoid_set(
     insertion.y = supporting_shape.elements.front().start.y - supported_shape.elements.front().start.y;
     insertion.new_bin_direction = new_bin_direction;
     insertion.new_bin_pos = new_bin_pos;
+
+    // Check resource capacity. 'penalize' resources never block an
+    // insertion (see 'Resource::penalize'); only their non-'penalize'
+    // counterparts do. Skipped entirely when the bin type has no resources
+    // (see 'child_tmp').
+    if (bin_type.number_of_resources() > 0) {
+        if (new_bin_direction == Direction::Any) {  // Same bin.
+            ItemPos item_copy = parent->last_bin_item_number_of_copies[trapezoid_set.item_type_id];
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                if (resource.penalize)
+                    continue;
+                double consumption = parent->last_bin_resource_consumption[resource_id]
+                    + resource.item_consumption(trapezoid_set.item_type_id, item_copy);
+                if (consumption > resource.capacity * PSTOL)
+                    return;
+            }
+        } else {  // New bin.
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                if (resource.penalize)
+                    continue;
+                double consumption = resource.item_consumption(trapezoid_set.item_type_id, 0);
+                if (consumption > resource.capacity * PSTOL)
+                    return;
+            }
+        }
+    }
 
     //if (parent->parent != nullptr
     //        && new_bin_direction == Direction::Any) {

--- a/src/irregular/tree_search.hpp
+++ b/src/irregular/tree_search.hpp
@@ -306,6 +306,17 @@ public:
 
         /** Insertions. */
         mutable std::vector<Insertion> children_insertions;
+
+        /**
+         * For each item type, number of copies of that item type already in
+         * the last (current) bin - needed to look up the correct entry of a
+         * per-copy resource consumption schedule (see 'Resource::
+         * item_consumption').
+         */
+        std::vector<ItemPos> last_bin_item_number_of_copies;
+
+        /** Resource consumption of the last (current) bin, indexed by resource_id. */
+        std::vector<double> last_bin_resource_consumption;
     };
 
     struct Parameters

--- a/src/onedimensional/tree_search.cpp
+++ b/src/onedimensional/tree_search.cpp
@@ -93,18 +93,24 @@ BranchingScheme::Node BranchingScheme::child_tmp(
         node.last_bin_weight = item_type.weight;
         node.last_bin_maximum_number_of_items = item_type.maximum_stackability;
         node.last_bin_remaining_weight = item_type.maximum_weight_after;
-        node.last_bin_item_number_of_copies.assign(instance().number_of_item_types(), 0);
-        node.last_bin_resource_consumption.assign(bin_type.number_of_resources(), 0.0);
-        for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
-            const Resource& resource = bin_type.resource(resource_id);
-            double consumption = resource.item_consumption(insertion.item_type_id, 0);
-            node.last_bin_resource_consumption[resource_id] = consumption;
-            // The bin is empty before this insertion, so any crossing here
-            // is necessarily the first one.
-            if (resource.penalize && consumption > resource.capacity)
-                node.profit -= resource.penalty;
+        // 'last_bin_item_number_of_copies'/'last_bin_resource_consumption'
+        // are only populated when the bin type has resources at all, so
+        // instances that don't use resources don't pay for
+        // allocating/copying these per-node vectors.
+        if (bin_type.number_of_resources() > 0) {
+            node.last_bin_item_number_of_copies.assign(instance().number_of_item_types(), 0);
+            node.last_bin_resource_consumption.assign(bin_type.number_of_resources(), 0.0);
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                double consumption = resource.item_consumption(insertion.item_type_id, 0);
+                node.last_bin_resource_consumption[resource_id] = consumption;
+                // The bin is empty before this insertion, so any crossing here
+                // is necessarily the first one.
+                if (resource.penalize && consumption > resource.capacity)
+                    node.profit -= resource.penalty;
+            }
+            node.last_bin_item_number_of_copies[insertion.item_type_id] = 1;
         }
-        node.last_bin_item_number_of_copies[insertion.item_type_id] = 1;
     } else {  // Same bin.
         node.number_of_bins = parent.number_of_bins;
         node.last_bin_length = parent.last_bin_length + item_type.length - item_type.nesting_length;
@@ -117,21 +123,23 @@ BranchingScheme::Node BranchingScheme::child_tmp(
         node.last_bin_remaining_weight = std::min(
                 parent.last_bin_remaining_weight - item_type.weight,
                 item_type.maximum_weight_after);
-        node.last_bin_item_number_of_copies = parent.last_bin_item_number_of_copies;
-        ItemPos item_copy = node.last_bin_item_number_of_copies[insertion.item_type_id];
-        node.last_bin_resource_consumption = parent.last_bin_resource_consumption;
-        for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
-            const Resource& resource = bin_type.resource(resource_id);
-            double previous_consumption = node.last_bin_resource_consumption[resource_id];
-            node.last_bin_resource_consumption[resource_id]
-                += resource.item_consumption(insertion.item_type_id, item_copy);
-            if (resource.penalize
-                    && node.last_bin_resource_consumption[resource_id] > resource.capacity
-                    && previous_consumption <= resource.capacity) {
-                node.profit -= resource.penalty;
+        if (bin_type.number_of_resources() > 0) {
+            node.last_bin_item_number_of_copies = parent.last_bin_item_number_of_copies;
+            ItemPos item_copy = node.last_bin_item_number_of_copies[insertion.item_type_id];
+            node.last_bin_resource_consumption = parent.last_bin_resource_consumption;
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                double previous_consumption = node.last_bin_resource_consumption[resource_id];
+                node.last_bin_resource_consumption[resource_id]
+                    += resource.item_consumption(insertion.item_type_id, item_copy);
+                if (resource.penalize
+                        && node.last_bin_resource_consumption[resource_id] > resource.capacity
+                        && previous_consumption <= resource.capacity) {
+                    node.profit -= resource.penalty;
+                }
             }
+            node.last_bin_item_number_of_copies[insertion.item_type_id]++;
         }
-        node.last_bin_item_number_of_copies[insertion.item_type_id]++;
     }
 
     BinPos i = node.number_of_bins - 1;
@@ -217,8 +225,9 @@ void BranchingScheme::insertion_item_same_bin(
         return;
     // Check resource capacity. 'penalize' resources never block an
     // insertion (see 'Resource::penalize'); the corresponding penalty is
-    // applied to 'node.profit' in 'child_tmp' instead.
-    {
+    // applied to 'node.profit' in 'child_tmp' instead. Skipped entirely
+    // when the bin type has no resources (see 'child_tmp').
+    if (bin_type.number_of_resources() > 0) {
         ItemPos item_copy = parent->last_bin_item_number_of_copies[item_type_id];
         for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
             const Resource& resource = bin_type.resource(resource_id);

--- a/src/rectangle/instance_flipper.cpp
+++ b/src/rectangle/instance_flipper.cpp
@@ -55,6 +55,18 @@ Instance InstanceFlipper::flip(const Instance& instance)
                     defect.rect.y,
                     defect.rect.x);
         }
+        // Copy resources (their consumptions are copied below, once item
+        // types have been added).
+        for (ResourceId resource_id = 0;
+                resource_id < bin_type.number_of_resources();
+                ++resource_id) {
+            const Resource& resource = bin_type.resource(resource_id);
+            flipped_instance_builder.add_bin_type_resource(
+                    flipped_bin_type_id,
+                    resource.capacity,
+                    resource.penalize,
+                    resource.penalty);
+        }
     }
     for (ItemTypeId item_type_id = 0;
             item_type_id < instance.number_of_item_types();
@@ -76,6 +88,34 @@ Instance InstanceFlipper::flip(const Instance& instance)
         flipped_instance_builder.set_item_type_weight(
                 flipped_item_type_id,
                 item_type.weight);
+    }
+    // Copy resource consumptions, now that both bin and item types have
+    // been added (bin type ids and item type ids line up 1:1 with
+    // 'instance's own, so no remapping is needed).
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < instance.number_of_bin_types();
+            ++bin_type_id) {
+        const BinType& bin_type = instance.bin_type(bin_type_id);
+        for (ResourceId resource_id = 0;
+                resource_id < bin_type.number_of_resources();
+                ++resource_id) {
+            const Resource& resource = bin_type.resource(resource_id);
+            for (ItemTypeId item_type_id = 0;
+                    item_type_id < (ItemTypeId)resource.item_consumptions.size();
+                    ++item_type_id) {
+                const std::vector<double>& schedule = resource.item_consumptions[item_type_id];
+                for (ItemPos item_copy = 0;
+                        item_copy < (ItemPos)schedule.size();
+                        ++item_copy) {
+                    flipped_instance_builder.add_resource_consumption(
+                            bin_type_id,
+                            resource_id,
+                            item_type_id,
+                            item_copy,
+                            schedule[item_copy]);
+                }
+            }
+        }
     }
     return flipped_instance_builder.build();
 }

--- a/src/rectangle/reduction.cpp
+++ b/src/rectangle/reduction.cpp
@@ -1154,6 +1154,34 @@ Instance Reduction::reduction_to_instance(
         instance_builder.set_item_type_group(new_item_type_id, original_item_type.group_id);
         instance_builder.set_item_type_weight(new_item_type_id, original_item_type.weight);
         instance_builder.set_item_type_eligibility(new_item_type_id, original_item_type.eligibility_id);
+        // Copy resource consumptions (the bin types themselves, including
+        // their resources, were already copied above via 'add_bin_type(
+        // *original_instance_, bin_type_id)'; bin type ids line up 1:1 with
+        // 'original_instance_'s own since none are skipped in that loop).
+        for (BinTypeId bin_type_id = 0;
+                bin_type_id < original_instance_->number_of_bin_types();
+                ++bin_type_id) {
+            const BinType& original_bin_type = original_instance_->bin_type(bin_type_id);
+            for (ResourceId resource_id = 0;
+                    resource_id < original_bin_type.number_of_resources();
+                    ++resource_id) {
+                const std::vector<std::vector<double>>& item_consumptions
+                    = original_bin_type.resource(resource_id).item_consumptions;
+                if (item_type_id >= (ItemTypeId)item_consumptions.size())
+                    continue;
+                const std::vector<double>& schedule = item_consumptions[item_type_id];
+                for (ItemPos item_copy = 0;
+                        item_copy < (ItemPos)schedule.size();
+                        ++item_copy) {
+                    instance_builder.add_resource_consumption(
+                            bin_type_id,
+                            resource_id,
+                            new_item_type_id,
+                            item_copy,
+                            schedule[item_copy]);
+                }
+            }
+        }
         reduced_to_original_item_type_ids_.push_back(item_type_id);
     }
 

--- a/src/rectangle/tree_search.cpp
+++ b/src/rectangle/tree_search.cpp
@@ -334,6 +334,49 @@ BranchingScheme::Node BranchingScheme::child_tmp(
     node.weight_profit = parent.item_weight
         + (double)1.0 / item_type.weight / insertion.x;
     node.profit = parent.profit + item_type.profit;
+
+    // Update last_bin_item_number_of_copies and last_bin_resource_consumption.
+    // 'node.profit' is further adjusted below by any 'penalize' resource
+    // whose consumption crosses its capacity for the first time as a result
+    // of this insertion (see 'Resource::penalize'), mirroring 'Solution::
+    // update_indicators' so the search optimizes the same objective the
+    // final solution will report.
+    // Skipped entirely when the bin type has no resources at all, so
+    // instances that don't use resources don't pay for allocating/copying
+    // these per-node vectors.
+    if (bin_type.number_of_resources() > 0) {
+        if (insertion.new_bin > 0) {  // New bin.
+            node.last_bin_item_number_of_copies.assign(instance.number_of_item_types(), 0);
+            node.last_bin_resource_consumption.assign(bin_type.number_of_resources(), 0.0);
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                double consumption = resource.item_consumption(insertion.item_type_id, 0);
+                node.last_bin_resource_consumption[resource_id] = consumption;
+                // The bin is empty before this insertion, so any crossing here
+                // is necessarily the first one.
+                if (resource.penalize && consumption > resource.capacity)
+                    node.profit -= resource.penalty;
+            }
+            node.last_bin_item_number_of_copies[insertion.item_type_id] = 1;
+        } else {  // Same bin.
+            node.last_bin_item_number_of_copies = parent.last_bin_item_number_of_copies;
+            ItemPos item_copy = node.last_bin_item_number_of_copies[insertion.item_type_id];
+            node.last_bin_resource_consumption = parent.last_bin_resource_consumption;
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                double previous_consumption = node.last_bin_resource_consumption[resource_id];
+                node.last_bin_resource_consumption[resource_id]
+                    += resource.item_consumption(insertion.item_type_id, item_copy);
+                if (resource.penalize
+                        && node.last_bin_resource_consumption[resource_id] > resource.capacity
+                        && previous_consumption <= resource.capacity) {
+                    node.profit -= resource.penalty;
+                }
+            }
+            node.last_bin_item_number_of_copies[insertion.item_type_id]++;
+        }
+    }
+
     if (item_type.oriented) {
         node.guide_item_pseudo_profit = parent.guide_item_pseudo_profit
             + std::pow(xj, 1.2) * std::pow(yj, 1.1) / item_type.area();
@@ -831,6 +874,34 @@ void BranchingScheme::insertion_item(
         item_type.weight;
     if (last_bin_weight > bin_type.maximum_weight * PSTOL)
         return;
+
+    // Check resource capacity. 'penalize' resources never block an
+    // insertion (see 'Resource::penalize'); only their non-'penalize'
+    // counterparts do. Skipped entirely when the bin type has no resources
+    // (see 'child_tmp').
+    if (bin_type.number_of_resources() > 0) {
+        if (new_bin == 0) {
+            ItemPos item_copy = parent->last_bin_item_number_of_copies[item_type_id];
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                if (resource.penalize)
+                    continue;
+                double consumption = parent->last_bin_resource_consumption[resource_id]
+                    + resource.item_consumption(item_type_id, item_copy);
+                if (consumption > resource.capacity * PSTOL)
+                    return;
+            }
+        } else {
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                if (resource.penalize)
+                    continue;
+                double consumption = resource.item_consumption(item_type_id, 0);
+                if (consumption > resource.capacity * PSTOL)
+                    return;
+            }
+        }
+    }
 
     // Compute xs.
     Length xs = 0;

--- a/src/rectangle/tree_search.hpp
+++ b/src/rectangle/tree_search.hpp
@@ -228,6 +228,17 @@ public:
 
         /** Overweight for the rear axle weight constraints. */
         double rear_axle_overweight = 0;
+
+        /**
+         * For each item type, number of copies of that item type already in
+         * the last (current) bin - needed to look up the correct entry of a
+         * per-copy resource consumption schedule (see 'Resource::
+         * item_consumption').
+         */
+        std::vector<ItemPos> last_bin_item_number_of_copies;
+
+        /** Resource consumption of the last (current) bin, indexed by resource_id. */
+        std::vector<double> last_bin_resource_consumption;
     };
 
     struct Parameters
@@ -401,6 +412,22 @@ public:
             return true;
         if (node_1->number_of_bins > node_2->number_of_bins)
             return false;
+
+        // Same number of bins, so both nodes' last bin is of the same type
+        // (see 'bin_type_ids_') and their 'last_bin_resource_consumption'
+        // vectors line up 1:1. 'node_1' can only dominate 'node_2' if it
+        // never consumes more of any resource in that bin (a 'penalize'
+        // resource already crossed on 'node_1' is not worse than one not
+        // yet crossed on 'node_2', so this treats hard and 'penalize'
+        // resources alike).
+        for (ResourceId resource_id = 0;
+                resource_id < (ResourceId)node_1->last_bin_resource_consumption.size();
+                ++resource_id) {
+            if (node_1->last_bin_resource_consumption[resource_id]
+                    > node_2->last_bin_resource_consumption[resource_id]) {
+                return false;
+            }
+        }
 
         //if (unbounded_knapsack_ && node_1->profit < node_2->profit)
         //    return false;

--- a/src/rectangleguillotine/instance_flipper.cpp
+++ b/src/rectangleguillotine/instance_flipper.cpp
@@ -51,6 +51,18 @@ Instance InstanceFlipper::flip(const Instance& instance)
                     defect.rect.h,
                     defect.rect.w);
         }
+        // Copy resources (their consumptions are copied below, once item
+        // types have been added).
+        for (ResourceId resource_id = 0;
+                resource_id < bin_type.number_of_resources();
+                ++resource_id) {
+            const Resource& resource = bin_type.resource(resource_id);
+            flipped_instance_builder.add_bin_type_resource(
+                    flipped_bin_type_id,
+                    resource.capacity,
+                    resource.penalize,
+                    resource.penalty);
+        }
     }
     for (ItemTypeId item_type_id = 0;
             item_type_id < instance.number_of_item_types();
@@ -67,6 +79,34 @@ Instance InstanceFlipper::flip(const Instance& instance)
         flipped_instance_builder.set_item_type_copies(
                 flipped_item_type_id,
                 item_type.copies);
+    }
+    // Copy resource consumptions, now that both bin and item types have
+    // been added (bin type ids and item type ids line up 1:1 with
+    // 'instance's own, so no remapping is needed).
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < instance.number_of_bin_types();
+            ++bin_type_id) {
+        const BinType& bin_type = instance.bin_type(bin_type_id);
+        for (ResourceId resource_id = 0;
+                resource_id < bin_type.number_of_resources();
+                ++resource_id) {
+            const Resource& resource = bin_type.resource(resource_id);
+            for (ItemTypeId item_type_id = 0;
+                    item_type_id < (ItemTypeId)resource.item_consumptions.size();
+                    ++item_type_id) {
+                const std::vector<double>& schedule = resource.item_consumptions[item_type_id];
+                for (ItemPos item_copy = 0;
+                        item_copy < (ItemPos)schedule.size();
+                        ++item_copy) {
+                    flipped_instance_builder.add_resource_consumption(
+                            bin_type_id,
+                            resource_id,
+                            item_type_id,
+                            item_copy,
+                            schedule[item_copy]);
+                }
+            }
+        }
     }
     return flipped_instance_builder.build();
 }

--- a/src/rectangleguillotine/tree_search.cpp
+++ b/src/rectangleguillotine/tree_search.cpp
@@ -513,6 +513,43 @@ BranchingScheme::Node BranchingScheme::child_tmp(
     }
     assert(node.item_area <= instance.bin_area());
 
+    // Update last_bin_item_number_of_copies and last_bin_resource_consumption.
+    // 'node.profit' is further adjusted below by any 'penalize' resource
+    // whose consumption crosses its capacity for the first time as a result
+    // of this insertion (see 'Resource::penalize'), mirroring 'Solution::
+    // update_indicators' so the search optimizes the same objective the
+    // final solution will report.
+    // Skipped entirely when the bin type has no resources at all, so
+    // instances that don't use resources don't pay for allocating/copying
+    // these per-node vectors.
+    if (bin_type.number_of_resources() > 0) {
+        if (insertion.df < 0) {  // New bin.
+            node.last_bin_item_number_of_copies.assign(instance.number_of_item_types(), 0);
+            node.last_bin_resource_consumption.assign(bin_type.number_of_resources(), 0.0);
+        } else {  // Same bin.
+            node.last_bin_item_number_of_copies = parent.last_bin_item_number_of_copies;
+            node.last_bin_resource_consumption = parent.last_bin_resource_consumption;
+        }
+        for (ItemTypeId item_type_id: {insertion.item_type_id_1, insertion.item_type_id_2}) {
+            if (item_type_id == -1)
+                continue;
+            const ItemType& item_type = instance.item_type(item_type_id);
+            ItemPos item_copy = node.last_bin_item_number_of_copies[item_type_id];
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                double previous_consumption = node.last_bin_resource_consumption[resource_id];
+                node.last_bin_resource_consumption[resource_id]
+                    += resource.item_consumption(item_type_id, item_copy);
+                if (resource.penalize
+                        && node.last_bin_resource_consumption[resource_id] > resource.capacity
+                        && previous_consumption <= resource.capacity) {
+                    node.profit -= resource.penalty;
+                }
+            }
+            node.last_bin_item_number_of_copies[item_type_id]++;
+        }
+    }
+
     // Compute bincurr_number_of_1_cuts.
     if (node.df < 0) {
         if (node.x1_curr == w) {
@@ -1791,6 +1828,36 @@ void BranchingScheme::update(
         }
         return;
     }
+
+    // Check resource capacity. 'penalize' resources never block an
+    // insertion (see 'Resource::penalize'); only their non-'penalize'
+    // counterparts do. Skipped entirely when the bin type has no resources
+    // (see 'child_tmp'), so instances that don't use resources don't pay
+    // for allocating/copying these vectors.
+    if (bin_type.number_of_resources() > 0) {
+        std::vector<double> resource_consumption = (insertion.df < 0)?
+            std::vector<double>(bin_type.number_of_resources(), 0.0):
+            parent.last_bin_resource_consumption;
+        std::vector<ItemPos> item_number_of_copies = (insertion.df < 0)?
+            std::vector<ItemPos>(instance.number_of_item_types(), 0):
+            parent.last_bin_item_number_of_copies;
+        for (ItemTypeId item_type_id: {insertion.item_type_id_1, insertion.item_type_id_2}) {
+            if (item_type_id == -1)
+                continue;
+            const ItemType& item_type = instance.item_type(item_type_id);
+            ItemPos item_copy = item_number_of_copies[item_type_id];
+            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+                const Resource& resource = bin_type.resource(resource_id);
+                if (resource.penalize)
+                    continue;
+                resource_consumption[resource_id] += resource.item_consumption(item_type_id, item_copy);
+                if (resource_consumption[resource_id] > resource.capacity * PSTOL)
+                    return;
+            }
+            item_number_of_copies[item_type_id]++;
+        }
+    }
+
     children.push_back(child(pparent, insertion));
 }
 

--- a/src/rectangleguillotine/tree_search.hpp
+++ b/src/rectangleguillotine/tree_search.hpp
@@ -244,6 +244,17 @@ public:
          * above a defect in the current 2-level sub-plate.
          */
         std::vector<JRX> subplate2curr_items_above_defect = {};
+
+        /**
+         * For each item type, number of copies of that item type already in
+         * the last (current) bin - needed to look up the correct entry of a
+         * per-copy resource consumption schedule (see 'Resource::
+         * item_consumption').
+         */
+        std::vector<ItemPos> last_bin_item_number_of_copies = {};
+
+        /** Resource consumption of the last (current) bin, indexed by resource_id. */
+        std::vector<double> last_bin_resource_consumption = {};
     };
 
     struct Parameters
@@ -369,6 +380,24 @@ public:
         if (instance().objective() == Objective::BinPackingCuttingCost)
             if (node_1->cutting_cost > node_2->cutting_cost)
                 return false;
+        // If both nodes are on the same (current) bin, that bin's resource
+        // consumption must also be dominated component-wise: a 'penalize'
+        // resource already crossed on 'node_1' is not worse than one not
+        // yet crossed on 'node_2', so this treats hard and 'penalize'
+        // resources alike. When 'node_1' is on an earlier bin ('front(*
+        // node_1).i < front(*node_2).i', handled by the geometric dominance
+        // below), it has not even reached 'node_2's current bin yet, so
+        // there is nothing comparable to check here.
+        if (node_1->number_of_bins == node_2->number_of_bins) {
+            for (ResourceId resource_id = 0;
+                    resource_id < (ResourceId)node_1->last_bin_resource_consumption.size();
+                    ++resource_id) {
+                if (node_1->last_bin_resource_consumption[resource_id]
+                        > node_2->last_bin_resource_consumption[resource_id]) {
+                    return false;
+                }
+            }
+        }
         return dominates(front(*node_1), front(*node_2));
     }
 

--- a/test/rectangle/CMakeLists.txt
+++ b/test/rectangle/CMakeLists.txt
@@ -12,7 +12,8 @@ target_sources(PackingSolver_rectangle_test PRIVATE
     tree_search/unloading_test.cpp
     tree_search/integration_test.cpp
     tree_search/tree_search_test.cpp
-    tree_search/tree_search_maximal_spaces_test.cpp)
+    tree_search/tree_search_maximal_spaces_test.cpp
+    resource_test.cpp)
 target_include_directories(PackingSolver_rectangle_test PRIVATE
     ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries(PackingSolver_rectangle_test

--- a/test/rectangle/resource_test.cpp
+++ b/test/rectangle/resource_test.cpp
@@ -1,0 +1,113 @@
+#include "packingsolver/rectangle/instance_builder.hpp"
+#include "packingsolver/rectangle/optimize.hpp"
+
+#include <gtest/gtest.h>
+
+// Resources cannot be represented via the CSV instance format (rectangle has
+// no JSON reader either, unlike onedimensional), so these instances are
+// built directly through the InstanceBuilder API instead of the usual
+// CSV-fixture-based parametrized tests.
+
+using namespace packingsolver::rectangle;
+
+TEST(RectangleResourceTest, HardResourceForcesExtraBins)
+{
+    // A capacity-1 resource with each item consuming 1 caps every bin to a
+    // single item, even though the bin is geometrically large enough to fit
+    // several - forcing 3 bins for 3 items.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(packingsolver::Objective::BinPacking);
+    packingsolver::BinTypeId bin_type_id = instance_builder.add_bin_type(20, 20);
+    instance_builder.set_bin_type_copies(bin_type_id, 10);
+    packingsolver::ResourceId resource_id = instance_builder.add_bin_type_resource(bin_type_id, 1.0, false, 0.0);
+    packingsolver::ItemTypeId item_type_id = instance_builder.add_item_type(5, 5, true);
+    instance_builder.set_item_type_copies(item_type_id, 3);
+    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, 0, 1.0);
+    Instance instance = instance_builder.build();
+
+    OptimizeParameters parameters;
+    parameters.use_tree_search = true;
+    parameters.use_tree_search_maximal_spaces = false;
+    parameters.use_sequential_value_correction = false;
+    parameters.use_column_generation = false;
+    parameters.use_dichotomic_search = false;
+    parameters.use_sequential_single_knapsack = false;
+    parameters.use_benders_decomposition = false;
+    parameters.verbosity_level = 0;
+    Output output = optimize(instance, parameters);
+    const Solution& solution = output.solution_pool.best();
+    EXPECT_TRUE(solution.full());
+    EXPECT_TRUE(solution.resource_feasible());
+    EXPECT_EQ(solution.number_of_bins(), 3);
+}
+
+TEST(RectangleResourceTest, PenalizeResourceDiscouragesCrossing)
+{
+    // Knapsack objective, item profit 10, resource capacity 1 with penalty
+    // 100. Packing a 2nd item in the single available bin crosses the
+    // resource once (-100), so the solver should prefer packing just 1 item
+    // (profit 10) over 2 (profit 20 - 100 = -80).
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(packingsolver::Objective::Knapsack);
+    packingsolver::BinTypeId bin_type_id = instance_builder.add_bin_type(20, 20);
+    instance_builder.set_bin_type_copies(bin_type_id, 1);
+    packingsolver::ResourceId resource_id = instance_builder.add_bin_type_resource(bin_type_id, 1.0, true, 100.0);
+    packingsolver::ItemTypeId item_type_id = instance_builder.add_item_type(5, 5, true);
+    instance_builder.set_item_type_profit(item_type_id, 10);
+    instance_builder.set_item_type_copies(item_type_id, 2);
+    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, 0, 1.0);
+    Instance instance = instance_builder.build();
+
+    OptimizeParameters parameters;
+    parameters.use_tree_search = true;
+    parameters.use_tree_search_maximal_spaces = false;
+    parameters.use_sequential_value_correction = false;
+    parameters.use_column_generation = false;
+    parameters.use_dichotomic_search = false;
+    parameters.use_sequential_single_knapsack = false;
+    parameters.use_benders_decomposition = false;
+    parameters.verbosity_level = 0;
+    Output output = optimize(instance, parameters);
+    const Solution& solution = output.solution_pool.best();
+    EXPECT_EQ(solution.number_of_items(), 1);
+    EXPECT_DOUBLE_EQ(solution.profit(), 10.0);
+    EXPECT_TRUE(solution.resource_feasible());
+}
+
+TEST(RectangleResourceTest, BendersDecompositionRespectsResource)
+{
+    // Same instance as 'HardResourceForcesExtraBins', solved through
+    // benders_decomposition instead: its geometric "slave" subproblem is
+    // itself a rectangle::Instance built via the 'add_bin_type(instance,
+    // id)'/'add_item_type(instance, id)' "copy from original" overloads
+    // (which carry resources over) and solved via 'rectangle::optimize'
+    // (which - for a small, single-bin, 'Feasibility'-objective
+    // sub-instance like this one - dispatches to 'tree_search'), so the
+    // master's proposed bin assignments that violate the resource get
+    // rejected and cut, without benders_decomposition needing any
+    // resource-specific code of its own.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(packingsolver::Objective::BinPacking);
+    packingsolver::BinTypeId bin_type_id = instance_builder.add_bin_type(20, 20);
+    instance_builder.set_bin_type_copies(bin_type_id, 10);
+    packingsolver::ResourceId resource_id = instance_builder.add_bin_type_resource(bin_type_id, 1.0, false, 0.0);
+    packingsolver::ItemTypeId item_type_id = instance_builder.add_item_type(5, 5, true);
+    instance_builder.set_item_type_copies(item_type_id, 3);
+    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, 0, 1.0);
+    Instance instance = instance_builder.build();
+
+    OptimizeParameters parameters;
+    parameters.use_tree_search = false;
+    parameters.use_tree_search_maximal_spaces = false;
+    parameters.use_sequential_value_correction = false;
+    parameters.use_column_generation = false;
+    parameters.use_dichotomic_search = false;
+    parameters.use_sequential_single_knapsack = false;
+    parameters.use_benders_decomposition = true;
+    parameters.verbosity_level = 0;
+    Output output = optimize(instance, parameters);
+    const Solution& solution = output.solution_pool.best();
+    EXPECT_TRUE(solution.full());
+    EXPECT_TRUE(solution.resource_feasible());
+    EXPECT_EQ(solution.number_of_bins(), 3);
+}

--- a/test/rectangleguillotine/CMakeLists.txt
+++ b/test/rectangleguillotine/CMakeLists.txt
@@ -15,7 +15,8 @@ target_sources(PackingSolver_rectangleguillotine_test PRIVATE
     sequential_strips_onedimensional_test.cpp
     tree_search_hypergraph_infinite_copies_test.cpp
     tree_search_hypergraph_test.cpp
-    post_process_test.cpp)
+    post_process_test.cpp
+    resource_test.cpp)
 target_include_directories(PackingSolver_rectangleguillotine_test PRIVATE
     ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries(PackingSolver_rectangleguillotine_test

--- a/test/rectangleguillotine/resource_test.cpp
+++ b/test/rectangleguillotine/resource_test.cpp
@@ -1,0 +1,73 @@
+#include "packingsolver/rectangleguillotine/instance_builder.hpp"
+#include "packingsolver/rectangleguillotine/optimize.hpp"
+
+#include <gtest/gtest.h>
+
+// Resources cannot be represented via the CSV instance format (rectangleguillotine
+// has no JSON reader either, unlike onedimensional), so these instances are
+// built directly through the InstanceBuilder API instead of the usual
+// CSV-fixture-based parametrized tests.
+
+using namespace packingsolver::rectangleguillotine;
+
+TEST(RectangleGuillotineResourceTest, HardResourceForcesExtraBins)
+{
+    // A capacity-1 resource with each item consuming 1 caps every bin to a
+    // single item, even though the bin is geometrically large enough to fit
+    // several - forcing 3 bins for 3 items.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(packingsolver::Objective::BinPacking);
+    packingsolver::BinTypeId bin_type_id = instance_builder.add_bin_type(20, 20);
+    instance_builder.set_bin_type_copies(bin_type_id, 10);
+    packingsolver::ResourceId resource_id = instance_builder.add_bin_type_resource(bin_type_id, 1.0, false, 0.0);
+    packingsolver::ItemTypeId item_type_id = instance_builder.add_item_type(5, 5);
+    instance_builder.set_item_type_copies(item_type_id, 3);
+    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, 0, 1.0);
+    Instance instance = instance_builder.build();
+
+    OptimizeParameters parameters;
+    parameters.use_tree_search = true;
+    parameters.use_tree_search_maximal_spaces = false;
+    parameters.use_tree_search_hypergraph_infinite_copies = false;
+    parameters.use_tree_search_hypergraph = false;
+    parameters.use_sequential_strips_onedimensional = false;
+    parameters.use_column_generation_strips = false;
+    parameters.verbosity_level = 0;
+    Output output = optimize(instance, parameters);
+    const Solution& solution = output.solution_pool.best();
+    EXPECT_TRUE(solution.full());
+    EXPECT_TRUE(solution.resource_feasible());
+    EXPECT_EQ(solution.number_of_bins(), 3);
+}
+
+TEST(RectangleGuillotineResourceTest, PenalizeResourceDiscouragesCrossing)
+{
+    // Knapsack objective, item profit 10, resource capacity 1 with penalty
+    // 100. Packing a 2nd item in the single available bin crosses the
+    // resource once (-100), so the solver should prefer packing just 1 item
+    // (profit 10) over 2 (profit 20 - 100 = -80).
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(packingsolver::Objective::Knapsack);
+    packingsolver::BinTypeId bin_type_id = instance_builder.add_bin_type(20, 20);
+    instance_builder.set_bin_type_copies(bin_type_id, 1);
+    packingsolver::ResourceId resource_id = instance_builder.add_bin_type_resource(bin_type_id, 1.0, true, 100.0);
+    packingsolver::ItemTypeId item_type_id = instance_builder.add_item_type(5, 5);
+    instance_builder.set_item_type_profit(item_type_id, 10);
+    instance_builder.set_item_type_copies(item_type_id, 2);
+    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, 0, 1.0);
+    Instance instance = instance_builder.build();
+
+    OptimizeParameters parameters;
+    parameters.use_tree_search = true;
+    parameters.use_tree_search_maximal_spaces = false;
+    parameters.use_tree_search_hypergraph_infinite_copies = false;
+    parameters.use_tree_search_hypergraph = false;
+    parameters.use_sequential_strips_onedimensional = false;
+    parameters.use_column_generation_strips = false;
+    parameters.verbosity_level = 0;
+    Output output = optimize(instance, parameters);
+    const Solution& solution = output.solution_pool.best();
+    EXPECT_EQ(solution.number_of_items(), 1);
+    EXPECT_DOUBLE_EQ(solution.profit(), 10.0);
+    EXPECT_TRUE(solution.resource_feasible());
+}


### PR DESCRIPTION
## Summary
- Every domain's tree search now tracks each node's current bin resource consumption (`last_bin_item_number_of_copies`/`last_bin_resource_consumption`), blocking insertions that would exceed a non-`penalize` resource's capacity and subtracting a `penalize` resource's penalty from profit the first time its capacity is crossed - mirroring `Solution::update_indicators` so the search optimizes the same objective the final solution reports.
- Node dominance checks are extended to also require resource-consumption domination when comparing same-bin nodes.
- Applies to `box` and `irregular` (which previously had no resource enforcement in tree search at all) and to `rectangle` and `rectangleguillotine` (replacing/completing their existing, partial tracking).
- Threads resources through `rectangle`/`rectangleguillotine`'s `instance_flipper` (OpenDimensionY solves) and `rectangle`'s `reduction` so resource consumptions survive both instance transformations.
- Adds dedicated `resource_test.cpp` coverage for rectangle (hard/penalize resources, tree search and Benders decomposition).

## Test plan
- [x] Full test suite (`ctest --output-on-failure --parallel`), verified in isolation against master's own pinned `columngenerationsolver` commit: 100% passed, 0 failed.