### PR TITLE
Sync column generation pricing solvers with columngenerationsolver's branch-and-price interface

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -110,7 +110,7 @@ set(COLUMNGENERATIONSOLVER_BUILD_EXAMPLES OFF)
 FetchContent_Declare(
     columngenerationsolver
     GIT_REPOSITORY https://github.com/fontanf/columngenerationsolver.git
-    GIT_TAG 5254ab64641a22f244ab9ccb0b563b9b004ec095
+    GIT_TAG a544232a23a0ab8acb37d06fd8ec7ed41a07261c
     #SOURCE_DIR "${PROJECT_SOURCE_DIR}/../columngenerationsolver/"
     EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(columngenerationsolver)

--- a/src/algorithms/column_generation.hpp
+++ b/src/algorithms/column_generation.hpp
@@ -45,7 +45,6 @@
 
 #include "packingsolver/algorithms/common.hpp"
 
-#include "columngenerationsolver/algorithms/heuristic_tree_search.hpp"
 #include "columngenerationsolver/algorithms/limited_discrepancy_search.hpp"
 
 #include <sstream>
@@ -77,10 +76,13 @@ public:
     { }
 
     virtual std::vector<std::shared_ptr<const Column>> initialize_pricing(
-            const std::vector<std::pair<std::shared_ptr<const Column>, Value>>& fixed_columns);
+            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>& fixed_columns,
+            const std::vector<std::shared_ptr<const columngenerationsolver::Cut>>&,
+            const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&) override;
 
     virtual PricingOutput solve_pricing(
-            const std::vector<Value>& duals);
+            const std::vector<columngenerationsolver::Value>& duals,
+            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&) override;
 
 private:
 
@@ -147,7 +149,9 @@ columngenerationsolver::Model get_model(
 
 template <typename Instance, typename InstanceBuilder, typename Solution, typename Output>
 std::vector<std::shared_ptr<const Column>> ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>::initialize_pricing(
-        const std::vector<std::pair<std::shared_ptr<const Column>, Value>>& fixed_columns)
+        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>& fixed_columns,
+        const std::vector<std::shared_ptr<const columngenerationsolver::Cut>>&,
+        const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&)
 {
     //std::cout << "initialize_pricing " << fixed_columns.size() << std::endl;
     std::fill(fixed_bin_types_.begin(), fixed_bin_types_.end(), 0);
@@ -216,7 +220,8 @@ std::vector<std::shared_ptr<const Column>> solution_to_columns(
 
 template <typename Instance, typename InstanceBuilder, typename Solution, typename Output>
 PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>::solve_pricing(
-            const std::vector<Value>& duals)
+        const std::vector<Value>& duals,
+        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, Value>>&)
 {
     double multiplier_cost = largest_power_of_two_lesser_or_equal(instance_.largest_bin_cost());
     double multiplier_profit = largest_power_of_two_lesser_or_equal(instance_.largest_item_profit());
@@ -383,6 +388,7 @@ Output column_generation(
     cgslds_parameters.timer = parameters.timer;
     cgslds_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     cgslds_parameters.internal_diving = parameters.internal_diving;
+    cgslds_parameters.rounding_heuristic = true;
     cgslds_parameters.dummy_column_objective_coefficient
         = 2 * (double)instance.largest_item_copies();
     if (parameters.optimization_mode != OptimizationMode::Anytime)

--- a/src/rectangle/bar_relaxation.cpp
+++ b/src/rectangle/bar_relaxation.cpp
@@ -50,13 +50,16 @@ public:
     { }
 
     std::vector<std::shared_ptr<const columngenerationsolver::Column>> initialize_pricing(
-            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>&) override
+            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>& fixed_columns,
+            const std::vector<std::shared_ptr<const columngenerationsolver::Cut>>&,
+            const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&) override
     {
         return {};
     }
 
     columngenerationsolver::PricingSolver::PricingOutput solve_pricing(
-            const std::vector<columngenerationsolver::Value>& duals) override;
+            const std::vector<columngenerationsolver::Value>& duals,
+            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&) override;
 
 private:
 
@@ -218,7 +221,8 @@ double BarRelaxationPricingSolver::price_bars(
 }
 
 columngenerationsolver::PricingSolver::PricingOutput BarRelaxationPricingSolver::solve_pricing(
-        const std::vector<columngenerationsolver::Value>& duals)
+        const std::vector<columngenerationsolver::Value>& duals,
+        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&)
 {
     columngenerationsolver::PricingSolver::PricingOutput output;
     double overcost = 0.0;

--- a/src/rectangleguillotine/column_generation_strips.cpp
+++ b/src/rectangleguillotine/column_generation_strips.cpp
@@ -41,10 +41,13 @@ public:
     { }
 
     virtual std::vector<std::shared_ptr<const Column>> initialize_pricing(
-            const std::vector<std::pair<std::shared_ptr<const Column>, Value>>& fixed_columns);
+            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>& fixed_columns,
+            const std::vector<std::shared_ptr<const columngenerationsolver::Cut>>&,
+            const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&) override;
 
     virtual PricingOutput solve_pricing(
-            const std::vector<Value>& duals);
+            const std::vector<columngenerationsolver::Value>& duals,
+            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&) override;
 
     void set_all_columns_2e_patterns_generated() { all_columns_2e_patterns_generated_ = true; }
 
@@ -649,7 +652,9 @@ GetModelOutput get_model(
 }
 
 std::vector<std::shared_ptr<const Column>> ColumnGenerationPricingSolver::initialize_pricing(
-        const std::vector<std::pair<std::shared_ptr<const Column>, Value>>& fixed_columns)
+        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>& fixed_columns,
+        const std::vector<std::shared_ptr<const columngenerationsolver::Cut>>&,
+        const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&)
 {
     const BinType& bin_type = instance_.bin_type(0);
     double multiplier_length = largest_power_of_two_lesser_or_equal(bin_type.rect.w);
@@ -793,7 +798,9 @@ void ColumnGenerationPricingSolver::generate_1e_patterns(
                 // (OpenDimensionX); accumulate 'reduced_cost_bound' via max
                 // for the former, min for the latter, so it always tracks
                 // the most improving reduced cost found so far.
-                Value rc = columngenerationsolver::compute_reduced_cost(column, duals);
+                Value rc = column.objective_coefficient;
+                for (const columngenerationsolver::LinearTerm& element: column.elements)
+                    rc -= duals[element.row] * element.coefficient;
                 if (instance_.objective() == Objective::Knapsack) {
                     reduced_cost_bound = (std::max)(reduced_cost_bound, rc);
                 } else if (instance_.objective() == Objective::OpenDimensionX) {
@@ -984,7 +991,9 @@ void ColumnGenerationPricingSolver::generate_1n_patterns(
             // accumulate 'reduced_cost_bound' via max for the former, min
             // for the latter, so it always tracks the most improving
             // reduced cost found so far.
-            Value rc = columngenerationsolver::compute_reduced_cost(column, duals);
+            Value rc = column.objective_coefficient;
+            for (const columngenerationsolver::LinearTerm& element: column.elements)
+                rc -= duals[element.row] * element.coefficient;
             if (instance_.objective() == Objective::Knapsack) {
                 reduced_cost_bound = (std::max)(reduced_cost_bound, rc);
             } else if (instance_.objective() == Objective::OpenDimensionX) {
@@ -1265,7 +1274,9 @@ void ColumnGenerationPricingSolver::generate_1ro_patterns(
             // accumulate 'reduced_cost_bound' via max for the former, min
             // for the latter, so it always tracks the most improving
             // reduced cost found so far.
-            Value rc = columngenerationsolver::compute_reduced_cost(column, duals);
+            Value rc = column.objective_coefficient;
+            for (const columngenerationsolver::LinearTerm& element: column.elements)
+                rc -= duals[element.row] * element.coefficient;
             if (instance_.objective() == Objective::Knapsack) {
                 reduced_cost_bound = (std::max)(reduced_cost_bound, rc);
             } else if (instance_.objective() == Objective::OpenDimensionX) {
@@ -1505,7 +1516,9 @@ void ColumnGenerationPricingSolver::generate_2ho_patterns(
             // accumulate 'reduced_cost_bound' via max for the former, min
             // for the latter, so it always tracks the most improving
             // reduced cost found so far.
-            Value rc = columngenerationsolver::compute_reduced_cost(column, duals);
+            Value rc = column.objective_coefficient;
+            for (const columngenerationsolver::LinearTerm& element: column.elements)
+                rc -= duals[element.row] * element.coefficient;
             if (instance_.objective() == Objective::Knapsack) {
                 reduced_cost_bound = (std::max)(reduced_cost_bound, rc);
             } else if (instance_.objective() == Objective::OpenDimensionX) {
@@ -1858,7 +1871,9 @@ void ColumnGenerationPricingSolver::generate_lower_stage_patterns(
         Length width_next = actual_used_width - 1;
         if (instance_.objective() == Objective::Knapsack
                 && strictly_greater(width_dual, 0.0)) {
-            Value rc = columngenerationsolver::compute_reduced_cost(column, duals);
+            Value rc = column.objective_coefficient;
+            for (const columngenerationsolver::LinearTerm& element: column.elements)
+                rc -= duals[element.row] * element.coefficient;
             if (!strictly_greater(rc, 0.0)) {
                 double bound = actual_used_width
                     + rc * multiplier_length / width_dual
@@ -1901,7 +1916,8 @@ void ColumnGenerationPricingSolver::generate_duals_zero(
 }
 
 PricingOutput ColumnGenerationPricingSolver::solve_pricing(
-            const std::vector<Value>& duals)
+        const std::vector<columngenerationsolver::Value>& duals,
+        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&)
 {
     //std::cout << "solve_pricing" << std::endl;
 
@@ -2001,7 +2017,9 @@ PricingOutput ColumnGenerationPricingSolver::solve_pricing(
     // accept a generated column.
     bool has_good_column = false;
     for (const auto& column: output.columns) {
-        Value rc = columngenerationsolver::compute_reduced_cost(*column, duals);
+        Value rc = column->objective_coefficient;
+        for (const columngenerationsolver::LinearTerm& element: column->elements)
+            rc -= duals[element.row] * element.coefficient;
         if (instance_.objective() == Objective::Knapsack) {
             if (strictly_greater(rc, 0)) {
                 has_good_column = true;


### PR DESCRIPTION
## Summary
- Bumps the pinned `columngenerationsolver` commit to `a544232` ("Replace tree search's free-text Comment column with structured columns"), which introduced its exact branch-and-price algorithm alongside the cutting-planes framework.
- `PricingSolver::initialize_pricing` now also takes the active branch-and-price `branching_decisions` - unused by every pricing solver here so far (`algorithms/column_generation.hpp`'s generic template, `rectangle/bar_relaxation.cpp`, `rectangleguillotine/column_generation_strips.cpp`), all three just accept and ignore it.
- The now-removed free function `compute_reduced_cost` is inlined at its call sites in `column_generation_strips.cpp` instead (`objective_coefficient` minus the dot product of each column element's dual and coefficient).
- Enables `rounding_heuristic` in the shared column generation template's limited-discrepancy-search parameters, a new heuristic the same commit range added to speed up convergence.

## Test plan
- [x] Full test suite (`ctest --output-on-failure --parallel`), built against the newly-pinned commit: 100% passed, 0 failed.