### PR TITLE
Tighten column generation's Lagrangian overcost bound with the best BinPacking solution's own bin count

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -110,7 +110,7 @@ set(COLUMNGENERATIONSOLVER_BUILD_EXAMPLES OFF)
 FetchContent_Declare(
     columngenerationsolver
     GIT_REPOSITORY https://github.com/fontanf/columngenerationsolver.git
-    GIT_TAG a544232a23a0ab8acb37d06fd8ec7ed41a07261c
+    GIT_TAG 6f52aac3eceb7fb34a273e0813fe692b0674e29c
     #SOURCE_DIR "${PROJECT_SOURCE_DIR}/../columngenerationsolver/"
     EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(columngenerationsolver)

--- a/src/algorithms/column_generation.hpp
+++ b/src/algorithms/column_generation.hpp
@@ -67,8 +67,10 @@ public:
 
     ColumnGenerationPricingSolver(
             const Instance& instance,
+            const Output& output,
             const ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, Output>& pricing_function):
         instance_(instance),
+        output_(output),
         pricing_function_(pricing_function),
         fixed_bin_types_(instance.number_of_bin_types()),
         filled_demands_(instance.number_of_item_types()),
@@ -88,6 +90,8 @@ private:
 
     const Instance& instance_;
 
+    const Output& output_;
+
     ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, Output> pricing_function_;
 
     std::vector<BinPos> fixed_bin_types_;
@@ -102,6 +106,7 @@ private:
 template <typename Instance, typename InstanceBuilder, typename Solution, typename Output>
 columngenerationsolver::Model get_model(
         const Instance& instance,
+        const Output& output,
         const ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, Output>& pricing_function)
 {
     columngenerationsolver::Model model;
@@ -143,7 +148,7 @@ columngenerationsolver::Model get_model(
 
     // Pricing solver.
     model.pricing_solver = std::unique_ptr<columngenerationsolver::PricingSolver>(
-            new ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>(instance, pricing_function));
+            new ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>(instance, output, pricing_function));
     return model;
 }
 
@@ -353,9 +358,20 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution,
             bin_fixed_copies[fixed_item.item_type_id]--;
     }
 
+    // 'reduced_cost_bound' is a per-bin bound on the reduced cost, so the
+    // Lagrangian overcost is that times the largest number of bins any
+    // solution could ever use. If a feasible BinPacking solution has
+    // already been found, its own number of bins is a tighter such cap
+    // than the generic 'min(number_of_items, number_of_bins)' one (no
+    // solution using more bins than the best one found so far could ever
+    // be optimal).
+    BinPos maximum_number_of_bins = (std::min)((BinPos)instance_.number_of_items(), instance_.number_of_bins());
+    if (instance_.objective() == Objective::BinPacking
+            && output_.solution_pool.best().feasible()) {
+        maximum_number_of_bins = output_.solution_pool.best().number_of_bins();
+    }
     output.overcost
-        = (std::min)((BinPos)instance_.number_of_items(), instance_.number_of_bins())
-        * reduced_cost_bound;
+        = maximum_number_of_bins * reduced_cost_bound;
 
     //std::cout << "solve_pricing end" << std::endl;
     return output;
@@ -382,7 +398,7 @@ Output column_generation(
     algorithm_formatter.print_header();
 
     columngenerationsolver::Model cgs_model
-        = get_model<Instance, InstanceBuilder, Solution, Output>(instance, pricing_function);
+        = get_model<Instance, InstanceBuilder, Solution, Output>(instance, output, pricing_function);
     columngenerationsolver::LimitedDiscrepancySearchParameters cgslds_parameters;
     cgslds_parameters.verbosity_level = 0;
     cgslds_parameters.timer = parameters.timer;


### PR DESCRIPTION
## Summary
- `ColumnGenerationPricingSolver::solve_pricing` scales the per-bin reduced cost bound by the largest number of bins any solution could ever use, to get a valid Lagrangian bound on the master's total reduced cost (`overcost`). It used the generic `min(number_of_items, number_of_bins)` cap for this.
- Once a feasible BinPacking solution has been found, its own number of bins is a tighter cap: no solution using more bins than the best one found so far could ever be optimal.
- Threads the column generation loop's own `Output` (already tracking the incumbent solution pool) through `get_model`/the `ColumnGenerationPricingSolver` constructor so `solve_pricing` can read it.

## Test plan
- [x] Full test suite (`ctest --output-on-failure --parallel`): 100% passed, 0 failed.