### PR TITLE
Detect proven infeasibility for BinPacking/VariableSizedBinPacking/Knapsack

### DIFF
--- a/include/packingsolver/box/algorithm_formatter.hpp
+++ b/include/packingsolver/box/algorithm_formatter.hpp
@@ -43,7 +43,7 @@ public:
             const Solution& solution,
             const std::string& s);
 
-    /** Mark the instance as proven infeasible (Feasibility objective only). */
+    /** Mark the instance as proven infeasible. */
     void update_is_proven_infeasible();
 
     /** Update the knapsack bound. */

--- a/include/packingsolver/box/optimize.hpp
+++ b/include/packingsolver/box/optimize.hpp
@@ -32,12 +32,16 @@ struct Output: packingsolver::Output<Instance, Solution>
     /** Open dimension Z bound. */
     Length open_dimension_z_bound = 0;
 
-    /** True if the instance has been proven infeasible (Feasibility objective only). */
+    /** True if the instance has been proven infeasible. */
     bool is_proven_infeasible = false;
 
     /** Return 'true' iff the current bound proves the best solution optimal. */
     bool is_proven_optimal() const
     {
+        // A proven-infeasible instance is done being searched regardless of
+        // objective: there is no better bound to wait for.
+        if (is_proven_infeasible)
+            return true;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             return equal_profit(knapsack_bound, solution_pool.best().profit());
@@ -57,9 +61,8 @@ struct Output: packingsolver::Output<Instance, Solution>
             return solution_pool.best().full()
                 && open_dimension_z_bound == solution_pool.best().z_max();
         case Objective::Feasibility:
-            return (solution_pool.best().full()
-                    && solution_pool.best().feasible())
-                || is_proven_infeasible;
+            return solution_pool.best().full()
+                && solution_pool.best().feasible();
         default:
             return false;
         }
@@ -76,6 +79,8 @@ struct Output: packingsolver::Output<Instance, Solution>
      */
     void update_bounds(const Output& output)
     {
+        if (output.is_proven_infeasible)
+            is_proven_infeasible = true;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             if (output.knapsack_bound < knapsack_bound)
@@ -101,10 +106,6 @@ struct Output: packingsolver::Output<Instance, Solution>
             if (output.open_dimension_z_bound > open_dimension_z_bound)
                 open_dimension_z_bound = output.open_dimension_z_bound;
             break;
-        case Objective::Feasibility:
-            if (output.is_proven_infeasible)
-                is_proven_infeasible = true;
-            break;
         default:
             break;
         }
@@ -127,6 +128,7 @@ struct Output: packingsolver::Output<Instance, Solution>
     {
         packingsolver::Output<Instance, Solution>::format(os);
         int width = format_width();
+        os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             write_bound(os, width, solution_pool.best().profit(), knapsack_bound);
@@ -147,7 +149,6 @@ struct Output: packingsolver::Output<Instance, Solution>
             write_bound(os, width, solution_pool.best().z_max(), open_dimension_z_bound);
             break;
         case Objective::Feasibility:
-            os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;
             break;
         default:
             break;

--- a/include/packingsolver/boxstacks/algorithm_formatter.hpp
+++ b/include/packingsolver/boxstacks/algorithm_formatter.hpp
@@ -43,7 +43,7 @@ public:
             const Solution& solution,
             const std::string& s);
 
-    /** Mark the instance as proven infeasible (Feasibility objective only). */
+    /** Mark the instance as proven infeasible. */
     void update_is_proven_infeasible();
 
     /** Update the knapsack bound. */

--- a/include/packingsolver/boxstacks/optimize.hpp
+++ b/include/packingsolver/boxstacks/optimize.hpp
@@ -23,12 +23,16 @@ struct Output: packingsolver::Output<Instance, Solution>
     /** Variable-sized bin packing bound. */
     Profit variable_sized_bin_packing_bound = 0;
 
-    /** True if the instance has been proven infeasible (Feasibility objective only). */
+    /** True if the instance has been proven infeasible. */
     bool is_proven_infeasible = false;
 
     /** Return 'true' iff the current bound proves the best solution optimal. */
     bool is_proven_optimal() const
     {
+        // A proven-infeasible instance is done being searched regardless of
+        // objective: there is no better bound to wait for.
+        if (is_proven_infeasible)
+            return true;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             return equal_profit(knapsack_bound, solution_pool.best().profit());
@@ -39,9 +43,8 @@ struct Output: packingsolver::Output<Instance, Solution>
             return solution_pool.best().full()
                 && equal_cost(variable_sized_bin_packing_bound, solution_pool.best().cost());
         case Objective::Feasibility:
-            return (solution_pool.best().full()
-                    && solution_pool.best().feasible())
-                || is_proven_infeasible;
+            return solution_pool.best().full()
+                && solution_pool.best().feasible();
         default:
             return false;
         }
@@ -61,6 +64,7 @@ struct Output: packingsolver::Output<Instance, Solution>
     {
         packingsolver::Output<Instance, Solution>::format(os);
         int width = format_width();
+        os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             write_bound(os, width, solution_pool.best().profit(), knapsack_bound);
@@ -72,7 +76,6 @@ struct Output: packingsolver::Output<Instance, Solution>
             write_bound(os, width, solution_pool.best().cost(), variable_sized_bin_packing_bound);
             break;
         case Objective::Feasibility:
-            os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;
             break;
         default:
             break;

--- a/include/packingsolver/irregular/algorithm_formatter.hpp
+++ b/include/packingsolver/irregular/algorithm_formatter.hpp
@@ -43,7 +43,7 @@ public:
             const Solution& solution,
             const std::string& s);
 
-    /** Mark the instance as proven infeasible (Feasibility objective only). */
+    /** Mark the instance as proven infeasible. */
     void update_is_proven_infeasible();
 
     /** Update the knapsack bound. */

--- a/include/packingsolver/irregular/optimize.hpp
+++ b/include/packingsolver/irregular/optimize.hpp
@@ -29,12 +29,16 @@ struct Output: packingsolver::Output<Instance, Solution>
     /** Open dimension Y bound. */
     LengthDbl open_dimension_y_bound = 0;
 
-    /** True if the instance has been proven infeasible (Feasibility objective only). */
+    /** True if the instance has been proven infeasible. */
     bool is_proven_infeasible = false;
 
     /** Return 'true' iff the current bound proves the best solution optimal. */
     bool is_proven_optimal() const
     {
+        // A proven-infeasible instance is done being searched regardless of
+        // objective: there is no better bound to wait for.
+        if (is_proven_infeasible)
+            return true;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             return equal_profit(knapsack_bound, solution_pool.best().profit());
@@ -51,9 +55,8 @@ struct Output: packingsolver::Output<Instance, Solution>
             return solution_pool.best().full()
                 && equal(open_dimension_y_bound, solution_pool.best().y_max());
         case Objective::Feasibility:
-            return (solution_pool.best().full()
-                    && solution_pool.best().feasible())
-                || is_proven_infeasible;
+            return solution_pool.best().full()
+                && solution_pool.best().feasible();
         default:
             return false;
         }
@@ -70,6 +73,8 @@ struct Output: packingsolver::Output<Instance, Solution>
      */
     void update_bounds(const Output& output)
     {
+        if (output.is_proven_infeasible)
+            is_proven_infeasible = true;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             if (output.knapsack_bound < knapsack_bound)
@@ -90,10 +95,6 @@ struct Output: packingsolver::Output<Instance, Solution>
         case Objective::OpenDimensionY:
             if (output.open_dimension_y_bound > open_dimension_y_bound)
                 open_dimension_y_bound = output.open_dimension_y_bound;
-            break;
-        case Objective::Feasibility:
-            if (output.is_proven_infeasible)
-                is_proven_infeasible = true;
             break;
         default:
             break;
@@ -116,6 +117,7 @@ struct Output: packingsolver::Output<Instance, Solution>
     {
         packingsolver::Output<Instance, Solution>::format(os);
         int width = format_width();
+        os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             write_bound(os, width, solution_pool.best().profit(), knapsack_bound);
@@ -133,7 +135,6 @@ struct Output: packingsolver::Output<Instance, Solution>
             write_bound(os, width, solution_pool.best().y_max(), open_dimension_y_bound);
             break;
         case Objective::Feasibility:
-            os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;
             break;
         default:
             break;

--- a/include/packingsolver/onedimensional/algorithm_formatter.hpp
+++ b/include/packingsolver/onedimensional/algorithm_formatter.hpp
@@ -43,7 +43,7 @@ public:
             const Solution& solution,
             const std::string& s);
 
-    /** Mark the instance as proven infeasible (Feasibility objective only). */
+    /** Mark the instance as proven infeasible. */
     void update_is_proven_infeasible();
 
     /** Update the knapsack bound. */

--- a/include/packingsolver/onedimensional/optimize.hpp
+++ b/include/packingsolver/onedimensional/optimize.hpp
@@ -23,12 +23,16 @@ struct Output: packingsolver::Output<Instance, Solution>
     /** Variable-sized bin packing bound. */
     Profit variable_sized_bin_packing_bound = 0;
 
-    /** True if the instance has been proven infeasible (Feasibility objective only). */
+    /** True if the instance has been proven infeasible. */
     bool is_proven_infeasible = false;
 
     /** Return 'true' iff the current bound proves the best solution optimal. */
     bool is_proven_optimal() const
     {
+        // A proven-infeasible instance is done being searched regardless of
+        // objective: there is no better bound to wait for.
+        if (is_proven_infeasible)
+            return true;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             return equal_profit(knapsack_bound, solution_pool.best().profit());
@@ -39,9 +43,8 @@ struct Output: packingsolver::Output<Instance, Solution>
             return solution_pool.best().full()
                 && equal_cost(variable_sized_bin_packing_bound, solution_pool.best().cost());
         case Objective::Feasibility:
-            return (solution_pool.best().full()
-                    && solution_pool.best().feasible())
-                || is_proven_infeasible;
+            return solution_pool.best().full()
+                && solution_pool.best().feasible();
         default:
             return false;
         }
@@ -58,6 +61,8 @@ struct Output: packingsolver::Output<Instance, Solution>
      */
     void update_bounds(const Output& output)
     {
+        if (output.is_proven_infeasible)
+            is_proven_infeasible = true;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             if (output.knapsack_bound < knapsack_bound)
@@ -70,10 +75,6 @@ struct Output: packingsolver::Output<Instance, Solution>
         case Objective::VariableSizedBinPacking:
             if (output.variable_sized_bin_packing_bound > variable_sized_bin_packing_bound)
                 variable_sized_bin_packing_bound = output.variable_sized_bin_packing_bound;
-            break;
-        case Objective::Feasibility:
-            if (output.is_proven_infeasible)
-                is_proven_infeasible = true;
             break;
         default:
             break;
@@ -94,6 +95,7 @@ struct Output: packingsolver::Output<Instance, Solution>
     {
         packingsolver::Output<Instance, Solution>::format(os);
         int width = format_width();
+        os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             write_bound(os, width, solution_pool.best().profit(), knapsack_bound);
@@ -105,7 +107,6 @@ struct Output: packingsolver::Output<Instance, Solution>
             write_bound(os, width, solution_pool.best().cost(), variable_sized_bin_packing_bound);
             break;
         case Objective::Feasibility:
-            os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;
             break;
         default:
             break;

--- a/include/packingsolver/rectangle/algorithm_formatter.hpp
+++ b/include/packingsolver/rectangle/algorithm_formatter.hpp
@@ -43,7 +43,7 @@ public:
             const Solution& solution,
             const std::string& s);
 
-    /** Mark the instance as proven infeasible (Feasibility objective only). */
+    /** Mark the instance as proven infeasible. */
     void update_is_proven_infeasible();
 
     /** Update the knapsack bound. */

--- a/include/packingsolver/rectangle/optimize.hpp
+++ b/include/packingsolver/rectangle/optimize.hpp
@@ -30,12 +30,16 @@ struct Output: packingsolver::Output<Instance, Solution>
     /** Open dimension Y bound. */
     Length open_dimension_y_bound = 0;
 
-    /** True if the instance has been proven infeasible (Feasibility objective only). */
+    /** True if the instance has been proven infeasible. */
     bool is_proven_infeasible = false;
 
     /** Return 'true' iff the current bound proves the best solution optimal. */
     bool is_proven_optimal() const
     {
+        // A proven-infeasible instance is done being searched regardless of
+        // objective: there is no better bound to wait for.
+        if (is_proven_infeasible)
+            return true;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             return equal_profit(knapsack_bound, solution_pool.best().profit());
@@ -52,9 +56,8 @@ struct Output: packingsolver::Output<Instance, Solution>
             return solution_pool.best().full()
                 && open_dimension_y_bound == solution_pool.best().y_max();
         case Objective::Feasibility:
-            return (solution_pool.best().full()
-                    && solution_pool.best().feasible())
-                || is_proven_infeasible;
+            return solution_pool.best().full()
+                && solution_pool.best().feasible();
         default:
             return false;
         }
@@ -71,6 +74,8 @@ struct Output: packingsolver::Output<Instance, Solution>
      */
     void update_bounds(const Output& output)
     {
+        if (output.is_proven_infeasible)
+            is_proven_infeasible = true;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             if (output.knapsack_bound < knapsack_bound)
@@ -91,10 +96,6 @@ struct Output: packingsolver::Output<Instance, Solution>
         case Objective::OpenDimensionY:
             if (output.open_dimension_y_bound > open_dimension_y_bound)
                 open_dimension_y_bound = output.open_dimension_y_bound;
-            break;
-        case Objective::Feasibility:
-            if (output.is_proven_infeasible)
-                is_proven_infeasible = true;
             break;
         default:
             break;
@@ -117,6 +118,7 @@ struct Output: packingsolver::Output<Instance, Solution>
     {
         packingsolver::Output<Instance, Solution>::format(os);
         int width = format_width();
+        os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             write_bound(os, width, solution_pool.best().profit(), knapsack_bound);
@@ -134,7 +136,6 @@ struct Output: packingsolver::Output<Instance, Solution>
             write_bound(os, width, solution_pool.best().y_max(), open_dimension_y_bound);
             break;
         case Objective::Feasibility:
-            os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;
             break;
         default:
             break;

--- a/include/packingsolver/rectangleguillotine/algorithm_formatter.hpp
+++ b/include/packingsolver/rectangleguillotine/algorithm_formatter.hpp
@@ -43,7 +43,7 @@ public:
             const Solution& solution,
             const std::string& s);
 
-    /** Mark the instance as proven infeasible (Feasibility objective only). */
+    /** Mark the instance as proven infeasible. */
     void update_is_proven_infeasible();
 
     /** Update the knapsack bound. */

--- a/include/packingsolver/rectangleguillotine/optimize.hpp
+++ b/include/packingsolver/rectangleguillotine/optimize.hpp
@@ -29,12 +29,16 @@ struct Output: packingsolver::Output<Instance, Solution>
     /** Open dimension Y bound. */
     Length open_dimension_y_bound = 0;
 
-    /** True if the instance has been proven infeasible (Feasibility objective only). */
+    /** True if the instance has been proven infeasible. */
     bool is_proven_infeasible = false;
 
     /** Return 'true' iff the current bound proves the best solution optimal. */
     bool is_proven_optimal() const
     {
+        // A proven-infeasible instance is done being searched regardless of
+        // objective: there is no better bound to wait for.
+        if (is_proven_infeasible)
+            return true;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             return equal_profit(knapsack_bound, solution_pool.best().profit());
@@ -51,9 +55,8 @@ struct Output: packingsolver::Output<Instance, Solution>
             return solution_pool.best().full()
                 && open_dimension_y_bound == solution_pool.best().height();
         case Objective::Feasibility:
-            return (solution_pool.best().full()
-                    && solution_pool.best().feasible())
-                || is_proven_infeasible;
+            return solution_pool.best().full()
+                && solution_pool.best().feasible();
         default:
             return false;
         }
@@ -70,6 +73,8 @@ struct Output: packingsolver::Output<Instance, Solution>
      */
     void update_bounds(const Output& output)
     {
+        if (output.is_proven_infeasible)
+            is_proven_infeasible = true;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             if (output.knapsack_bound < knapsack_bound)
@@ -90,10 +95,6 @@ struct Output: packingsolver::Output<Instance, Solution>
         case Objective::OpenDimensionY:
             if (output.open_dimension_y_bound > open_dimension_y_bound)
                 open_dimension_y_bound = output.open_dimension_y_bound;
-            break;
-        case Objective::Feasibility:
-            if (output.is_proven_infeasible)
-                is_proven_infeasible = true;
             break;
         default:
             break;
@@ -116,6 +117,7 @@ struct Output: packingsolver::Output<Instance, Solution>
     {
         packingsolver::Output<Instance, Solution>::format(os);
         int width = format_width();
+        os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;
         switch (solution_pool.best().instance().objective()) {
         case Objective::Knapsack:
             write_bound(os, width, solution_pool.best().profit(), knapsack_bound);
@@ -133,7 +135,6 @@ struct Output: packingsolver::Output<Instance, Solution>
             write_bound(os, width, solution_pool.best().height(), open_dimension_y_bound);
             break;
         case Objective::Feasibility:
-            os << std::setw(width) << std::left << "Is proven infeasible: " << is_proven_infeasible << std::endl;
             break;
         default:
             break;

--- a/src/algorithms/column_generation.hpp
+++ b/src/algorithms/column_generation.hpp
@@ -660,7 +660,23 @@ Output column_generation(
     {
         const columngenerationsolver::LimitedDiscrepancySearchOutput& cgslds_output
             = static_cast<const columngenerationsolver::LimitedDiscrepancySearchOutput&>(cgs_output);
-        if (instance.objective() == Objective::VariableSizedBinPacking) {
+        // By the extended reals convention, the optimal value of an
+        // infeasible problem is +inf for a minimization objective
+        // (VariableSizedBinPacking, BinPacking, Feasibility) or -inf for a
+        // maximization one (Knapsack, the only Maximize objective here -
+        // see 'get_model''s own 'objective_sense' assignment above). This
+        // can happen for any objective (e.g. not enough bin copies to
+        // satisfy the item / bin count bounds, or item_type.copies_min too
+        // large to fit), so it is checked once up front here, before
+        // computing any objective-specific bound below - in particular
+        // before 'BinPacking''s own, since converting +inf to its integer
+        // 'BinPos' bound would be undefined behavior.
+        bool bound_proves_infeasible = (instance.objective() == Objective::Knapsack)?
+            (cgslds_output.bound == -std::numeric_limits<double>::infinity()):
+            (cgslds_output.bound == std::numeric_limits<double>::infinity());
+        if (bound_proves_infeasible) {
+            algorithm_formatter.update_is_proven_infeasible();
+        } else if (instance.objective() == Objective::VariableSizedBinPacking) {
             double multiplier_cost = largest_power_of_two_lesser_or_equal(instance.largest_bin_cost());
             algorithm_formatter.update_variable_sized_bin_packing_bound(
                     cgslds_output.bound * multiplier_cost);
@@ -672,11 +688,6 @@ Output column_generation(
             double multiplier_cost = largest_power_of_two_lesser_or_equal(instance.largest_bin_cost());
             algorithm_formatter.update_bin_packing_bound(std::ceil(
                     cgslds_output.bound * multiplier_cost / instance.bin_type(0).cost - 0.001));
-        } else if (instance.objective() == Objective::Feasibility) {
-            // By the extended reals convention, the optimal value of an
-            // infeasible minimization problem is +inf.
-            if (cgslds_output.bound == std::numeric_limits<double>::infinity())
-                algorithm_formatter.update_is_proven_infeasible();
         }
     };
     cgslds_parameters.column_generation_parameters.solver_name

--- a/src/box/algorithm_formatter.cpp
+++ b/src/box/algorithm_formatter.cpp
@@ -301,6 +301,12 @@ void AlgorithmFormatter::update_bin_packing_bound(
     mutex_.lock();
     if (number_of_bins > output_.bin_packing_bound) {
         output_.bin_packing_bound = number_of_bins;
+        // A proven bound above the number of bins actually available means
+        // no feasible solution exists. Set before the JSON push/callback/
+        // 'is_proven_optimal' check below so they see the complete,
+        // up-to-date state in a single update instead of a separate one.
+        if (output_.bin_packing_bound > instance_.number_of_bins())
+            output_.is_proven_infeasible = true;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
@@ -378,6 +384,8 @@ void AlgorithmFormatter::update_open_dimension_z_bound(
 void AlgorithmFormatter::update_bounds(
         const Output& output)
 {
+    if (output.is_proven_infeasible)
+        update_is_proven_infeasible();
     switch (instance_.objective()) {
     case Objective::Knapsack:
         update_knapsack_bound(output.knapsack_bound);
@@ -396,10 +404,6 @@ void AlgorithmFormatter::update_bounds(
         break;
     case Objective::OpenDimensionZ:
         update_open_dimension_z_bound(output.open_dimension_z_bound);
-        break;
-    case Objective::Feasibility:
-        if (output.is_proven_infeasible)
-            update_is_proven_infeasible();
         break;
     default:
         break;

--- a/src/box/tree_search.cpp
+++ b/src/box/tree_search.cpp
@@ -1136,12 +1136,21 @@ const packingsolver::box::TreeSearchOutput packingsolver::box::tree_search(
                 local_outputs[(size_t)scheme_idx].solution_pool.add(solution, ss.str());
 
                 if (tssibs_output.optimal) {
-                    if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
+                    // 'Solution::operator<' always ranks a feasible solution
+                    // above an infeasible one, regardless of objective, so
+                    // 'solution_pool.best()' can only be infeasible here if
+                    // no feasible solution was found anywhere in this
+                    // now-exhaustive search: a genuine infeasibility proof,
+                    // independent of objective.
+                    if (!solution.feasible()) {
+                        // For every non-Knapsack objective (Feasibility
+                        // included), 'copies_min' defaults to 'copies', so
+                        // this already subsumes "not everything got packed"
+                        // - no separate 'full()' check needed.
+                        local_outputs[(size_t)scheme_idx].is_proven_infeasible = true;
+                    } else if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
                         local_outputs[(size_t)scheme_idx].bin_packing_bound
                             = solution.number_of_bins();
-                    } else if (solution.instance().objective() == packingsolver::Objective::Feasibility) {
-                        if (!solution.full())
-                            local_outputs[(size_t)scheme_idx].is_proven_infeasible = true;
                     } else if (solution.instance().objective() == packingsolver::Objective::Knapsack) {
                         local_outputs[(size_t)scheme_idx].knapsack_bound
                             = solution.profit();

--- a/src/box/tree_search_maximal_spaces.cpp
+++ b/src/box/tree_search_maximal_spaces.cpp
@@ -868,7 +868,7 @@ const packingsolver::box::TreeSearchMaximalSpacesOutput packingsolver::box::tree
 
     std::vector<BranchingSchemeMaximalSpaces> branching_schemes;
     std::vector<treesearchsolver::IterativeBeamSearchParameters<BranchingSchemeMaximalSpaces>> ibs_parameters_list;
-    std::vector<packingsolver::Output<Instance, Solution>> local_outputs;
+    std::vector<Output> local_outputs;
     {
         BranchingSchemeMaximalSpaces::Parameters branching_scheme_parameters;
         branching_schemes.push_back(BranchingSchemeMaximalSpaces(instance, all_blocks, max_reachable_lengths, branching_scheme_parameters));
@@ -883,7 +883,7 @@ const packingsolver::box::TreeSearchMaximalSpacesOutput packingsolver::box::tree
             ibs_parameters.maximum_size_of_the_queue = parameters.not_anytime_tree_search_queue_size;
         }
         ibs_parameters_list.push_back(ibs_parameters);
-        local_outputs.push_back(packingsolver::Output<Instance, Solution>(instance));
+        local_outputs.push_back(Output(instance));
     }
 
     bool deterministic = (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic);
@@ -905,10 +905,31 @@ const packingsolver::box::TreeSearchMaximalSpacesOutput packingsolver::box::tree
                 std::stringstream ss;
                 ss << "n " << tssibs_output.maximum_size_of_the_queue;
                 local_outputs[(size_t)scheme_idx].solution_pool.add(solution, ss.str());
+
+                if (tssibs_output.optimal) {
+                    // 'Solution::operator<' always ranks a feasible solution
+                    // above an infeasible one, regardless of objective, so
+                    // 'solution_pool.best()' can only be infeasible here if
+                    // no feasible solution was found anywhere in this
+                    // now-exhaustive search: a genuine infeasibility proof,
+                    // independent of objective.
+                    if (!solution.feasible()) {
+                        // For every non-Knapsack objective (Feasibility
+                        // included), 'copies_min' defaults to 'copies', so
+                        // this already subsumes "not everything got packed"
+                        // - no separate 'full()' check needed.
+                        local_outputs[(size_t)scheme_idx].is_proven_infeasible = true;
+                    } else if (solution.instance().objective() == packingsolver::Objective::Knapsack) {
+                        local_outputs[(size_t)scheme_idx].knapsack_bound
+                            = solution.profit();
+                    }
+                }
+
                 if (!deterministic) {
                     algorithm_formatter.update_solution(
                             local_outputs[(size_t)scheme_idx].solution_pool.best(),
                             local_outputs[(size_t)scheme_idx].solution_pool.best_label());
+                    algorithm_formatter.update_bounds(local_outputs[(size_t)scheme_idx]);
                 }
             };
         exception_ptr_list.push_front(std::exception_ptr());
@@ -938,6 +959,7 @@ const packingsolver::box::TreeSearchMaximalSpacesOutput packingsolver::box::tree
             algorithm_formatter.update_solution(
                     local_outputs[(size_t)scheme_idx].solution_pool.best(),
                     local_outputs[(size_t)scheme_idx].solution_pool.best_label());
+            algorithm_formatter.update_bounds(local_outputs[(size_t)scheme_idx]);
         }
     }
 

--- a/src/boxstacks/algorithm_formatter.cpp
+++ b/src/boxstacks/algorithm_formatter.cpp
@@ -283,6 +283,12 @@ void AlgorithmFormatter::update_bin_packing_bound(
     mutex_.lock();
     if (number_of_bins > output_.bin_packing_bound) {
         output_.bin_packing_bound = number_of_bins;
+        // A proven bound above the number of bins actually available means
+        // no feasible solution exists. Set before the JSON push/callback/
+        // 'is_proven_optimal' check below so they see the complete,
+        // up-to-date state in a single update instead of a separate one.
+        if (output_.bin_packing_bound > instance_.number_of_bins())
+            output_.is_proven_infeasible = true;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
@@ -312,6 +318,8 @@ void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
 void AlgorithmFormatter::update_bounds(
         const Output& output)
 {
+    if (output.is_proven_infeasible)
+        update_is_proven_infeasible();
     switch (instance_.objective()) {
     case Objective::Knapsack:
         update_knapsack_bound(output.knapsack_bound);
@@ -321,10 +329,6 @@ void AlgorithmFormatter::update_bounds(
         break;
     case Objective::VariableSizedBinPacking:
         update_variable_sized_bin_packing_bound(output.variable_sized_bin_packing_bound);
-        break;
-    case Objective::Feasibility:
-        if (output.is_proven_infeasible)
-            update_is_proven_infeasible();
         break;
     default:
         break;

--- a/src/boxstacks/tree_search.cpp
+++ b/src/boxstacks/tree_search.cpp
@@ -1785,10 +1785,33 @@ const packingsolver::boxstacks::TreeSearchOutput packingsolver::boxstacks::tree_
                     << " " << tssibs_output.maximum_size_of_the_queue;
                 local_outputs[(size_t)scheme_idx].solution_pool.add(solution, ss.str());
 
+                if (tssibs_output.optimal) {
+                    // 'Solution::operator<' always ranks a feasible solution
+                    // above an infeasible one, regardless of objective, so
+                    // 'solution_pool.best()' can only be infeasible here if
+                    // no feasible solution was found anywhere in this
+                    // now-exhaustive search: a genuine infeasibility proof,
+                    // independent of objective.
+                    if (!solution.feasible()) {
+                        // For every non-Knapsack objective (Feasibility
+                        // included), 'copies_min' defaults to 'copies', so
+                        // this already subsumes "not everything got packed"
+                        // - no separate 'full()' check needed.
+                        local_outputs[(size_t)scheme_idx].is_proven_infeasible = true;
+                    } else if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
+                        local_outputs[(size_t)scheme_idx].bin_packing_bound
+                            = solution.number_of_bins();
+                    } else if (solution.instance().objective() == packingsolver::Objective::Knapsack) {
+                        local_outputs[(size_t)scheme_idx].knapsack_bound
+                            = solution.profit();
+                    }
+                }
+
                 if (!deterministic) {
                     algorithm_formatter.update_solution(
                             local_outputs[(size_t)scheme_idx].solution_pool.best(),
                             local_outputs[(size_t)scheme_idx].solution_pool.best_label());
+                    algorithm_formatter.update_bounds(local_outputs[(size_t)scheme_idx]);
                 }
             };
         exception_ptr_list.push_front(std::exception_ptr());
@@ -1818,6 +1841,7 @@ const packingsolver::boxstacks::TreeSearchOutput packingsolver::boxstacks::tree_
             algorithm_formatter.update_solution(
                     local_outputs[(size_t)scheme_idx].solution_pool.best(),
                     local_outputs[(size_t)scheme_idx].solution_pool.best_label());
+            algorithm_formatter.update_bounds(local_outputs[(size_t)scheme_idx]);
         }
     }
 

--- a/src/irregular/algorithm_formatter.cpp
+++ b/src/irregular/algorithm_formatter.cpp
@@ -298,6 +298,12 @@ void AlgorithmFormatter::update_bin_packing_bound(
     mutex_.lock();
     if (number_of_bins > output_.bin_packing_bound) {
         output_.bin_packing_bound = number_of_bins;
+        // A proven bound above the number of bins actually available means
+        // no feasible solution exists. Set before the JSON push/callback/
+        // 'is_proven_optimal' check below so they see the complete,
+        // up-to-date state in a single update instead of a separate one.
+        if (output_.bin_packing_bound > instance_.number_of_bins())
+            output_.is_proven_infeasible = true;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
@@ -359,6 +365,8 @@ void AlgorithmFormatter::update_open_dimension_y_bound(
 void AlgorithmFormatter::update_bounds(
         const Output& output)
 {
+    if (output.is_proven_infeasible)
+        update_is_proven_infeasible();
     switch (instance_.objective()) {
     case Objective::Knapsack:
         update_knapsack_bound(output.knapsack_bound);
@@ -374,10 +382,6 @@ void AlgorithmFormatter::update_bounds(
         break;
     case Objective::OpenDimensionY:
         update_open_dimension_y_bound(output.open_dimension_y_bound);
-        break;
-    case Objective::Feasibility:
-        if (output.is_proven_infeasible)
-            update_is_proven_infeasible();
         break;
     default:
         break;

--- a/src/onedimensional/algorithm_formatter.cpp
+++ b/src/onedimensional/algorithm_formatter.cpp
@@ -247,6 +247,12 @@ void AlgorithmFormatter::update_bin_packing_bound(
     mutex_.lock();
     if (number_of_bins > output_.bin_packing_bound) {
         output_.bin_packing_bound = number_of_bins;
+        // A proven bound above the number of bins actually available means
+        // no feasible solution exists. Set before the JSON push/callback/
+        // 'is_proven_optimal' check below so they see the complete,
+        // up-to-date state in a single update instead of a separate one.
+        if (output_.bin_packing_bound > instance_.number_of_bins())
+            output_.is_proven_infeasible = true;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
@@ -276,6 +282,8 @@ void AlgorithmFormatter::update_variable_sized_bin_packing_bound(
 void AlgorithmFormatter::update_bounds(
         const Output& output)
 {
+    if (output.is_proven_infeasible)
+        update_is_proven_infeasible();
     switch (instance_.objective()) {
     case Objective::Knapsack:
         update_knapsack_bound(output.knapsack_bound);
@@ -285,10 +293,6 @@ void AlgorithmFormatter::update_bounds(
         break;
     case Objective::VariableSizedBinPacking:
         update_variable_sized_bin_packing_bound(output.variable_sized_bin_packing_bound);
-        break;
-    case Objective::Feasibility:
-        if (output.is_proven_infeasible)
-            update_is_proven_infeasible();
         break;
     default:
         break;

--- a/src/onedimensional/milp_assignment.cpp
+++ b/src/onedimensional/milp_assignment.cpp
@@ -62,6 +62,13 @@ BinPos compute_bin_instance_upper_bound(
     // 'instance's when every item type fits (the common case is that they
     // don't, e.g. for other bin types in a multi-bin-type instance).
     std::vector<ItemTypeId> sub_item_type_ids;
+    // Sum of every compatible item type's own copies: since compatibility
+    // means a single copy always fits this bin type on its own, packing one
+    // item per bin trivially fits every compatible copy - a valid, if
+    // typically very loose, fallback upper bound that does not depend on
+    // 'sub_output' below being a complete packing (see its own use further
+    // down).
+    ItemPos total_compatible_item_copies = 0;
     for (ItemTypeId item_type_id = 0;
             item_type_id < instance.number_of_item_types();
             ++item_type_id) {
@@ -69,6 +76,7 @@ BinPos compute_bin_instance_upper_bound(
             continue;
         sub_instance_builder.add_item_type(instance, item_type_id);
         sub_item_type_ids.push_back(item_type_id);
+        total_compatible_item_copies += instance.item_type(item_type_id).copies;
     }
     if (sub_item_type_ids.empty())
         return 0;
@@ -99,6 +107,20 @@ BinPos compute_bin_instance_upper_bound(
             algorithm_formatter.update_variable_sized_bin_packing_bound(
                     (Profit)sub_output.bin_packing_bound * bin_type.cost);
         }
+    }
+
+    // This function's own soundness argument (see its doc comment) requires
+    // a *complete* packing of every compatible item type: 'sub_instance'
+    // always has a feasible solution (unlimited bin copies), but the search
+    // for it shares this function's own timer with its caller, so it can be
+    // cut short before finishing. In that case, 'sub_output''s bin count
+    // would undercount what packing everything actually needs, making it an
+    // unsound (too tight) bound - fall back to one that does not depend on
+    // completeness instead.
+    if (!sub_output.solution_pool.best().full()) {
+        return (bin_type.copies != -1)?
+            bin_type.copies:
+            total_compatible_item_copies;
     }
 
     BinPos bound = sub_output.solution_pool.best().number_of_bins();
@@ -1257,7 +1279,10 @@ std::vector<BinPos> compute_bin_type_upper_bounds_bin_packing(
     }
     auto sub_output = optimize(instance, sub_parameters);
     algorithm_formatter.update_solution(sub_output.solution_pool.best(), "tree search");
-    algorithm_formatter.update_bin_packing_bound(sub_output.bin_packing_bound);
+    // Via 'update_bounds' rather than 'update_bin_packing_bound' directly,
+    // so that a proven-infeasible 'sub_output' (its own 'bin_packing_bound'
+    // would otherwise carry no such signal) is correctly propagated too.
+    algorithm_formatter.update_bounds(sub_output);
     if (algorithm_formatter.end_boolean())
         return bin_type_upper_bounds;
 
@@ -1583,11 +1608,29 @@ MilpAssignmentOutput packingsolver::onedimensional::milp_assignment(
             } else if (instance.objective() == Objective::BinPacking) {
                 algorithm_formatter.update_bin_packing_bound((BinPos)std::ceil(bound - 1e-6));
             }
-        } else if (instance.objective() == Objective::Feasibility
-                && proven_infeasible) {
-            // The MILP exactly encodes the instance's fixed set of bins (no
-            // upper-bound approximation), so its infeasibility is a genuine
-            // proof that the instance itself is infeasible.
+        } else if (proven_infeasible) {
+            // For Feasibility/Knapsack, the MILP exactly encodes the
+            // instance's fixed set of bins (no upper-bound approximation -
+            // see 'compute_bin_type_upper_bounds''s own doc comment), so its
+            // infeasibility is a genuine proof that the instance itself is
+            // infeasible. For BinPacking, 'compute_bin_type_upper_bounds_
+            // bin_packing' can instead tighten the bounds to an
+            // already-found *complete* solution's own per-bin-type counts -
+            // but per that function's own doc comment, any solution using
+            // fewer or equal total bins (in particular any optimal one)
+            // provably never needs more of a given type than that solution
+            // does, so that solution itself remains a feasible point of the
+            // MILP built with those tightened bounds: this MILP cannot
+            // become infeasible in that case (short of an actual model bug),
+            // so whenever it does, the bounds in use must be the untightened
+            // (exact) ones instead, making the infeasibility genuine here
+            // too. For VariableSizedBinPacking, 'compute_bin_instance_
+            // upper_bound' computes each bin type's bound independently, but
+            // always soundly regardless of how it was derived (falling back
+            // to a completeness-independent bound - the bin type's own real
+            // capacity, or one bin per compatible item copy when
+            // unlimited - whenever its own sub-search wasn't a complete
+            // packing), so its own infeasibility is genuine too.
             algorithm_formatter.update_is_proven_infeasible();
         }
 #else

--- a/src/onedimensional/tree_search.cpp
+++ b/src/onedimensional/tree_search.cpp
@@ -612,12 +612,21 @@ const packingsolver::onedimensional::TreeSearchOutput packingsolver::onedimensio
                 local_outputs[(size_t)scheme_idx].solution_pool.add(solution, ss.str());
 
                 if (tssibs_output.optimal) {
-                    if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
+                    // 'Solution::operator<' always ranks a feasible solution
+                    // above an infeasible one, regardless of objective, so
+                    // 'solution_pool.best()' can only be infeasible here if
+                    // no feasible solution was found anywhere in this
+                    // now-exhaustive search: a genuine infeasibility proof,
+                    // independent of objective.
+                    if (!solution.feasible()) {
+                        // For every non-Knapsack objective (Feasibility
+                        // included), 'copies_min' defaults to 'copies', so
+                        // this already subsumes "not everything got packed"
+                        // - no separate 'full()' check needed.
+                        local_outputs[(size_t)scheme_idx].is_proven_infeasible = true;
+                    } else if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
                         local_outputs[(size_t)scheme_idx].bin_packing_bound
                             = solution.number_of_bins();
-                    } else if (solution.instance().objective() == packingsolver::Objective::Feasibility) {
-                        if (!solution.full())
-                            local_outputs[(size_t)scheme_idx].is_proven_infeasible = true;
                     } else if (solution.instance().objective() == packingsolver::Objective::Knapsack) {
                         local_outputs[(size_t)scheme_idx].knapsack_bound
                             = solution.profit();

--- a/src/rectangle/algorithm_formatter.cpp
+++ b/src/rectangle/algorithm_formatter.cpp
@@ -283,6 +283,12 @@ void AlgorithmFormatter::update_bin_packing_bound(
     mutex_.lock();
     if (number_of_bins > output_.bin_packing_bound) {
         output_.bin_packing_bound = number_of_bins;
+        // A proven bound above the number of bins actually available means
+        // no feasible solution exists. Set before the JSON push/callback/
+        // 'is_proven_optimal' check below so they see the complete,
+        // up-to-date state in a single update instead of a separate one.
+        if (output_.bin_packing_bound > instance_.number_of_bins())
+            output_.is_proven_infeasible = true;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
@@ -344,6 +350,8 @@ void AlgorithmFormatter::update_open_dimension_y_bound(
 void AlgorithmFormatter::update_bounds(
         const Output& output)
 {
+    if (output.is_proven_infeasible)
+        update_is_proven_infeasible();
     switch (instance_.objective()) {
     case Objective::Knapsack:
         update_knapsack_bound(output.knapsack_bound);
@@ -359,10 +367,6 @@ void AlgorithmFormatter::update_bounds(
         break;
     case Objective::OpenDimensionY:
         update_open_dimension_y_bound(output.open_dimension_y_bound);
-        break;
-    case Objective::Feasibility:
-        if (output.is_proven_infeasible)
-            update_is_proven_infeasible();
         break;
     default:
         break;

--- a/src/rectangle/bar_relaxation.cpp
+++ b/src/rectangle/bar_relaxation.cpp
@@ -571,6 +571,23 @@ BarRelaxationOutput packingsolver::rectangle::bar_relaxation(
     cgs_parameters.new_bound_callback = [&instance, &algorithm_formatter](
             const columngenerationsolver::Output& cgs_output)
     {
+        // By the extended reals convention, the optimal value of an
+        // infeasible problem is +inf for a minimization objective
+        // (VariableSizedBinPacking, BinPacking, Feasibility) or -inf for a
+        // maximization one (Knapsack, the only Maximize objective here).
+        // This can happen for any objective (e.g. not enough bin copies to
+        // satisfy the item / bin count bounds, or item_type.copies_min too
+        // large to fit), so it is checked once up front here, before
+        // computing any objective-specific bound below - in particular
+        // before BinPacking's own, since converting +inf to its integer
+        // 'BinPos' bound would be undefined behavior.
+        bool bound_proves_infeasible = (instance.objective() == Objective::Knapsack)?
+            (cgs_output.bound == -std::numeric_limits<double>::infinity()):
+            (cgs_output.bound == std::numeric_limits<double>::infinity());
+        if (bound_proves_infeasible) {
+            algorithm_formatter.update_is_proven_infeasible();
+            return;
+        }
         switch (instance.objective()) {
         case Objective::Knapsack: {
             // This bound ignores resources entirely. A 'penalize' resource
@@ -582,10 +599,6 @@ BarRelaxationOutput packingsolver::rectangle::bar_relaxation(
                     cgs_output.bound + negative_penalty_sum(instance));
             break;
         } case Objective::Feasibility: {
-            // By the extended reals convention, the optimal value of an
-            // infeasible minimization problem is +inf.
-            if (cgs_output.bound == std::numeric_limits<double>::infinity())
-                algorithm_formatter.update_is_proven_infeasible();
             break;
         } case Objective::VariableSizedBinPacking: {
             algorithm_formatter.update_variable_sized_bin_packing_bound(cgs_output.bound);

--- a/src/rectangle/benders_decomposition.cpp
+++ b/src/rectangle/benders_decomposition.cpp
@@ -577,7 +577,10 @@ std::vector<BinPos> compute_bin_type_upper_bounds_bin_packing(
     sub_parameters.not_anytime_tree_search_queue_size = parameters.subproblem_queue_size;
     auto sub_output = optimize(instance, sub_parameters);
     algorithm_formatter.update_solution(sub_output.solution_pool.best(), "tree search");
-    algorithm_formatter.update_bin_packing_bound(sub_output.bin_packing_bound);
+    // Via 'update_bounds' rather than 'update_bin_packing_bound' directly,
+    // so that a proven-infeasible 'sub_output' (its own 'bin_packing_bound'
+    // would otherwise carry no such signal) is correctly propagated too.
+    algorithm_formatter.update_bounds(sub_output);
 
     const Solution& sub_solution = sub_output.solution_pool.best();
     if (sub_solution.full()) {
@@ -1115,7 +1118,13 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
             break;
 
         if (all_cuts_proven_infeasible) {
-            if (instance.objective() == Objective::Knapsack) {
+            // 'master_output' is a 'onedimensional::Output', a different
+            // type from this 'rectangle::AlgorithmFormatter''s own, so it
+            // can't be forwarded via 'update_bounds' - checked manually
+            // instead.
+            if (master_output.is_proven_infeasible) {
+                algorithm_formatter.update_is_proven_infeasible();
+            } else if (instance.objective() == Objective::Knapsack) {
                 algorithm_formatter.update_knapsack_bound(master_output.knapsack_bound);
             } else if (instance.objective() == Objective::BinPacking) {
                 algorithm_formatter.update_bin_packing_bound(master_output.bin_packing_bound);

--- a/src/rectangle/tree_search.cpp
+++ b/src/rectangle/tree_search.cpp
@@ -1645,12 +1645,21 @@ const packingsolver::rectangle::TreeSearchOutput packingsolver::rectangle::tree_
                 local_outputs[(size_t)scheme_idx].solution_pool.add(solution, ss.str());
 
                 if (tssibs_output.optimal) {
-                    if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
+                    // 'Solution::operator<' always ranks a feasible solution
+                    // above an infeasible one, regardless of objective, so
+                    // 'solution_pool.best()' can only be infeasible here if
+                    // no feasible solution was found anywhere in this
+                    // now-exhaustive search: a genuine infeasibility proof,
+                    // independent of objective.
+                    if (!solution.feasible()) {
+                        // For every non-Knapsack objective (Feasibility
+                        // included), 'copies_min' defaults to 'copies', so
+                        // this already subsumes "not everything got packed"
+                        // - no separate 'full()' check needed.
+                        local_outputs[(size_t)scheme_idx].is_proven_infeasible = true;
+                    } else if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
                         local_outputs[(size_t)scheme_idx].bin_packing_bound
                             = solution.number_of_bins();
-                    } else if (solution.instance().objective() == packingsolver::Objective::Feasibility) {
-                        if (!solution.full())
-                            local_outputs[(size_t)scheme_idx].is_proven_infeasible = true;
                     } else if (solution.instance().objective() == packingsolver::Objective::Knapsack) {
                         local_outputs[(size_t)scheme_idx].knapsack_bound
                             = solution.profit();

--- a/src/rectangle/tree_search_maximal_spaces.cpp
+++ b/src/rectangle/tree_search_maximal_spaces.cpp
@@ -687,7 +687,7 @@ const packingsolver::rectangle::TreeSearchMaximalSpacesOutput packingsolver::rec
 
     std::vector<BranchingSchemeMaximalSpaces> branching_schemes;
     std::vector<treesearchsolver::IterativeBeamSearchParameters<BranchingSchemeMaximalSpaces>> ibs_parameters_list;
-    std::vector<packingsolver::Output<Instance, Solution>> local_outputs;
+    std::vector<Output> local_outputs;
     {
         BranchingSchemeMaximalSpaces::Parameters branching_scheme_parameters;
         branching_schemes.push_back(BranchingSchemeMaximalSpaces(instance, all_blocks, max_reachable_lengths, branching_scheme_parameters));
@@ -702,7 +702,7 @@ const packingsolver::rectangle::TreeSearchMaximalSpacesOutput packingsolver::rec
             ibs_parameters.maximum_size_of_the_queue = parameters.not_anytime_tree_search_queue_size;
         }
         ibs_parameters_list.push_back(ibs_parameters);
-        local_outputs.push_back(packingsolver::Output<Instance, Solution>(instance));
+        local_outputs.push_back(Output(instance));
     }
 
     std::vector<std::thread> threads;
@@ -720,6 +720,23 @@ const packingsolver::rectangle::TreeSearchMaximalSpacesOutput packingsolver::rec
                     std::stringstream ss;
                     ss << "n " << tssibs_output.maximum_size_of_the_queue;
                     algorithm_formatter.update_solution(solution, ss.str());
+                    if (tssibs_output.optimal) {
+                        // 'Solution::operator<' always ranks a feasible
+                        // solution above an infeasible one, regardless of
+                        // objective, so 'solution_pool.best()' can only be
+                        // infeasible here if no feasible solution was found
+                        // anywhere in this now-exhaustive search: a genuine
+                        // infeasibility proof, independent of objective.
+                        if (!solution.feasible()) {
+                            // For every non-Knapsack objective (Feasibility
+                            // included), 'copies_min' defaults to 'copies',
+                            // so this already subsumes "not everything got
+                            // packed" - no separate 'full()' check needed.
+                            algorithm_formatter.update_is_proven_infeasible();
+                        } else if (solution.instance().objective() == packingsolver::Objective::Knapsack) {
+                            algorithm_formatter.update_knapsack_bound(solution.profit());
+                        }
+                    }
                 };
         } else {
             ibs_parameters_list[scheme_idx].new_solution_callback
@@ -733,6 +750,25 @@ const packingsolver::rectangle::TreeSearchMaximalSpacesOutput packingsolver::rec
                     std::stringstream ss;
                     ss << "n " << tssibs_output.maximum_size_of_the_queue;
                     local_outputs[(size_t)scheme_idx].solution_pool.add(solution, ss.str());
+
+                    if (tssibs_output.optimal) {
+                        // 'Solution::operator<' always ranks a feasible
+                        // solution above an infeasible one, regardless of
+                        // objective, so 'solution_pool.best()' can only be
+                        // infeasible here if no feasible solution was found
+                        // anywhere in this now-exhaustive search: a genuine
+                        // infeasibility proof, independent of objective.
+                        if (!solution.feasible()) {
+                            // For every non-Knapsack objective (Feasibility
+                            // included), 'copies_min' defaults to 'copies',
+                            // so this already subsumes "not everything got
+                            // packed" - no separate 'full()' check needed.
+                            local_outputs[(size_t)scheme_idx].is_proven_infeasible = true;
+                        } else if (solution.instance().objective() == packingsolver::Objective::Knapsack) {
+                            local_outputs[(size_t)scheme_idx].knapsack_bound
+                                = solution.profit();
+                        }
+                    }
                 };
         }
         exception_ptr_list.push_front(std::exception_ptr());
@@ -762,6 +798,7 @@ const packingsolver::rectangle::TreeSearchMaximalSpacesOutput packingsolver::rec
             algorithm_formatter.update_solution(
                     local_outputs[(size_t)scheme_idx].solution_pool.best(),
                     local_outputs[(size_t)scheme_idx].solution_pool.best_label());
+            algorithm_formatter.update_bounds(local_outputs[(size_t)scheme_idx]);
         }
     }
 

--- a/src/rectangleguillotine/algorithm_formatter.cpp
+++ b/src/rectangleguillotine/algorithm_formatter.cpp
@@ -307,6 +307,12 @@ void AlgorithmFormatter::update_bin_packing_bound(
     mutex_.lock();
     if (number_of_bins > output_.bin_packing_bound) {
         output_.bin_packing_bound = number_of_bins;
+        // A proven bound above the number of bins actually available means
+        // no feasible solution exists. Set before the JSON push/callback/
+        // 'is_proven_optimal' check below so they see the complete,
+        // up-to-date state in a single update instead of a separate one.
+        if (output_.bin_packing_bound > instance_.number_of_bins())
+            output_.is_proven_infeasible = true;
         if (parameters_.write_json_output)
             output_.json["IntermediaryOutputs"].push_back(output_.to_json());
         parameters_.new_solution_callback(output_);
@@ -368,6 +374,8 @@ void AlgorithmFormatter::update_open_dimension_y_bound(
 void AlgorithmFormatter::update_bounds(
         const Output& output)
 {
+    if (output.is_proven_infeasible)
+        update_is_proven_infeasible();
     switch (instance_.objective()) {
     case Objective::Knapsack:
         update_knapsack_bound(output.knapsack_bound);
@@ -383,10 +391,6 @@ void AlgorithmFormatter::update_bounds(
         break;
     case Objective::OpenDimensionY:
         update_open_dimension_y_bound(output.open_dimension_y_bound);
-        break;
-    case Objective::Feasibility:
-        if (output.is_proven_infeasible)
-            update_is_proven_infeasible();
         break;
     default:
         break;

--- a/src/rectangleguillotine/column_generation_strips.cpp
+++ b/src/rectangleguillotine/column_generation_strips.cpp
@@ -2174,6 +2174,16 @@ void column_generation_strips_vertical(
     {
         const columngenerationsolver::LimitedDiscrepancySearchOutput& cgslds_output
             = static_cast<const columngenerationsolver::LimitedDiscrepancySearchOutput&>(cgs_output);
+        // By the extended reals convention, the optimal value of an
+        // infeasible maximization problem is -inf: item_type.copies_min too
+        // large to fit, for instance. OpenDimensionX has no such notion (an
+        // open-ended bin can always fit every item), so this is checked only
+        // for Knapsack, the sole objective handled below where it applies.
+        if (instance.objective() == Objective::Knapsack
+                && cgslds_output.bound == -std::numeric_limits<double>::infinity()) {
+            algorithm_formatter.update_is_proven_infeasible();
+            return;
+        }
         // 'cgslds_output.bound' is scaled differently depending on the
         // objective: by multiplier_profit for Knapsack (a profit upper
         // bound, matching the objective_coefficient scaling in
@@ -2241,7 +2251,9 @@ void column_generation_strips_horizontal(
             // (and leaves every other objective untouched), so
             // 'flipped_output''s bound must be routed back according to the
             // true (unflipped) 'instance' objective, not the flipped one.
-            if (instance.objective() == Objective::Knapsack) {
+            if (flipped_output.is_proven_infeasible) {
+                algorithm_formatter.update_is_proven_infeasible();
+            } else if (instance.objective() == Objective::Knapsack) {
                 algorithm_formatter.update_knapsack_bound(
                         flipped_output.knapsack_bound);
             } else if (instance.objective() == Objective::OpenDimensionX) {

--- a/src/rectangleguillotine/tree_search.cpp
+++ b/src/rectangleguillotine/tree_search.cpp
@@ -2514,12 +2514,23 @@ const packingsolver::rectangleguillotine::TreeSearchOutput packingsolver::rectan
                         && params.maximum_distance_2_cuts == -1
                         && params.maximum_number_2_cuts == -1;
                     if (exhaustive) {
-                        if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
+                        // 'Solution::operator<' always ranks a feasible
+                        // solution above an infeasible one, regardless of
+                        // objective (see its own 'if (!solution.feasible_)
+                        // ...' check, ahead of any objective-specific
+                        // comparison), so 'solution_pool.best()' can only be
+                        // infeasible here if no feasible solution was found
+                        // anywhere in this now-exhaustive search: a genuine
+                        // infeasibility proof, independent of objective.
+                        if (!solution.feasible()) {
+                            // For every non-Knapsack objective (Feasibility
+                            // included), 'copies_min' defaults to 'copies',
+                            // so this already subsumes "not everything got
+                            // packed" - no separate 'full()' check needed.
+                            local_outputs[(size_t)scheme_idx].is_proven_infeasible = true;
+                        } else if (solution.instance().objective() == packingsolver::Objective::BinPacking) {
                             local_outputs[(size_t)scheme_idx].bin_packing_bound
                                 = solution.number_of_bins();
-                        } else if (solution.instance().objective() == packingsolver::Objective::Feasibility) {
-                            if (!solution.full())
-                                local_outputs[(size_t)scheme_idx].is_proven_infeasible = true;
                         } else if (solution.instance().objective() == packingsolver::Objective::Knapsack) {
                             local_outputs[(size_t)scheme_idx].knapsack_bound
                                 = solution.profit();

--- a/src/rectangleguillotine/tree_search_maximal_spaces.cpp
+++ b/src/rectangleguillotine/tree_search_maximal_spaces.cpp
@@ -893,7 +893,7 @@ const packingsolver::rectangleguillotine::TreeSearchMaximalSpacesOutput packings
         ibs_parameters.maximum_size_of_the_queue = parameters.not_anytime_tree_search_queue_size;
     }
 
-    packingsolver::Output<Instance, Solution> local_output(instance);
+    Output local_output(instance);
 
     bool deterministic = (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic);
     // Always record into 'local_output' first (this is also what the
@@ -910,10 +910,30 @@ const packingsolver::rectangleguillotine::TreeSearchMaximalSpacesOutput packings
             std::stringstream ss;
             ss << "n " << tssibs_output.maximum_size_of_the_queue;
             local_output.solution_pool.add(solution, ss.str());
+
+            if (tssibs_output.optimal) {
+                // 'Solution::operator<' always ranks a feasible solution
+                // above an infeasible one, regardless of objective, so
+                // 'solution_pool.best()' can only be infeasible here if no
+                // feasible solution was found anywhere in this
+                // now-exhaustive search: a genuine infeasibility proof,
+                // independent of objective.
+                if (!solution.feasible()) {
+                    // For every non-Knapsack objective (Feasibility
+                    // included), 'copies_min' defaults to 'copies', so this
+                    // already subsumes "not everything got packed" - no
+                    // separate 'full()' check needed.
+                    local_output.is_proven_infeasible = true;
+                } else if (solution.instance().objective() == packingsolver::Objective::Knapsack) {
+                    local_output.knapsack_bound = solution.profit();
+                }
+            }
+
             if (!deterministic) {
                 algorithm_formatter.update_solution(
                         local_output.solution_pool.best(),
                         local_output.solution_pool.best_label());
+                algorithm_formatter.update_bounds(local_output);
             }
         };
 
@@ -937,8 +957,10 @@ const packingsolver::rectangleguillotine::TreeSearchMaximalSpacesOutput packings
     }
     if (exception_ptr)
         std::rethrow_exception(exception_ptr);
-    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic)
+    if (parameters.optimization_mode == OptimizationMode::NotAnytimeDeterministic) {
         algorithm_formatter.update_solution(local_output.solution_pool.best(), local_output.solution_pool.best_label());
+        algorithm_formatter.update_bounds(local_output);
+    }
 
     algorithm_formatter.end();
     return output;


### PR DESCRIPTION
## Summary

Dual-bound-driven infeasibility detection was previously only wired up for the `Feasibility` objective, even though the same underlying situations (not enough bin copies, `item_type.copies_min` too large to fit, etc.) can make any objective's instance infeasible too. A genuinely infeasible run for `BinPacking`/`VariableSizedBinPacking`/`Knapsack` would just silently return an empty/non-full solution — or, for `BinPacking`, hit undefined behavior converting `+inf` to the integer bin-count bound.

- `column_generation.hpp`: check the extended-reals infinity bound sentinel for every objective in the pricing bound callback, not just `Feasibility` (hoisted into a single up-front check, since only `Knapsack`'s Maximize sense flips the sentinel's sign).
- `AlgorithmFormatter::update_bin_packing_bound`: flag infeasibility when a proven bound exceeds the number of bins actually available.
- `AlgorithmFormatter::update_bounds` / `Output::update_bounds` / `Output::is_proven_optimal`: treat `is_proven_infeasible` as terminal for every objective (previously `Feasibility`-only), including when merging per-task outputs in parallel optimization modes.
- Always show "Is proven infeasible" in the final statistics output, regardless of objective.
- `rectangle/bar_relaxation.cpp`, `rectangleguillotine/column_generation_strips.cpp`: same extended-reals sentinel check as `column_generation.hpp`, for their own column-generation-based bound callbacks.
- `onedimensional/milp_assignment.cpp`: extend the MILP's own infeasibility detection to `BinPacking`/`VariableSizedBinPacking`, and forward sub-solve infeasibility instead of silently discarding it; fix `compute_bin_instance_upper_bound` to fall back to a completeness-independent bound when its own sub-search is cut short, so its result is always sound.
- `rectangle/benders_decomposition.cpp`: forward sub-solve/master-solve infeasibility that was previously dropped.
- Tree search (rectangle/rectangleguillotine/box/boxstacks/onedimensional, including the maximal-spaces variants): when a scheme's search is proven exhaustive, flag infeasibility whenever the best solution found isn't feasible — `Solution::operator<` always ranks a feasible solution above an infeasible one regardless of objective, so an infeasible `best()` is already a full search-space proof that no feasible solution exists (and `copies_min` defaulting to `copies` for every non-`Knapsack` objective means `feasible()` alone already subsumes "not everything got packed" for `Feasibility` instances). Deliberately **not** extended to irregular's tree search: its widening loop can conclude "optimal" while still using a loose geometric approximation ratio (0.20 by default), so that signal isn't a sound infeasibility proof there.

## Test plan

- [x] All six problem types (`box`, `rectangle`, `rectangleguillotine`, `irregular`, `onedimensional`, `boxstacks`) build cleanly.
- [x] `rectangleguillotine`: full test suite passes (285/285).
- [x] `box`, `irregular`, `boxstacks`: full test suites pass.
- [x] `rectangle`/`onedimensional`: hit a pre-existing `HighsCallback` assertion crash, confirmed (via an isolated worktree build of unmodified `origin/master`) to be unrelated to this change.
- [x] Verified against hand-built infeasible instances (not enough bins for `BinPacking`; `copies_min` unreachable for `Knapsack`).