### PR TITLE
Fix Final statistics column misalignment from is_proven_infeasible

### DIFF
--- a/include/packingsolver/algorithms/common.hpp
+++ b/include/packingsolver/algorithms/common.hpp
@@ -503,16 +503,11 @@ struct Output: optimizationtools::Output
 
     virtual int format_width() const
     {
-        switch (solution_pool.best().instance().objective()) {
-        case Objective::Feasibility:
-            // Fits "Is proven infeasible: ", the only line printed for this
-            // objective besides "Time (s): ".
-            return 23;
-        default:
-            // Fits "Primal bound: ", the longest of the "Primal bound" /
-            // "Dual bound" / "Gap" lines printed for every other objective.
-            return 15;
-        }
+        // Fits "Is proven infeasible: ", now printed for every objective
+        // (not just 'Feasibility'), and "Primal bound: ", the longest of
+        // the "Primal bound" / "Dual bound" / "Gap" lines printed for every
+        // other objective.
+        return 23;
     }
 
     virtual void format(std::ostream& os) const


### PR DESCRIPTION
## Summary
- Every problem type's `Output::format()` now prints `"Is proven infeasible: "` unconditionally for every objective (added when infeasibility detection was wired into every objective, not just `Feasibility`), but the shared base `Output::format_width()` only widened the column for that label under objective `Feasibility` - every other objective still used the older, narrower width sized for `"Primal bound: "` alone.
- Since that label (23 chars) is longer than the column width used elsewhere (15), `std::setw` doesn't pad it at all, throwing off the alignment of every line below it in the "Final statistics" block (e.g. "Primal bound:", "Dual bound:", "Gap:").
- Fix: `format_width()` always returns the wider width, which comfortably fits every label now printed for every objective. This is a shared base method (`include/packingsolver/algorithms/common.hpp`), so it fixes the output for all six problem types at once.

## Test plan
- Verified visually via the CLI on `onedimensional` Knapsack and Feasibility instances - columns now align.
- Ran `onedimensional` (33/33), `box` (11/11), `boxstacks` (1/1) test suites, all passing (formatting-only change, no logic touched).
- `rectangle` suite running in the background; will follow up if anything surfaces.