### PR TITLE
Update columngenerationsolver to the rounding heuristic improvements

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -110,7 +110,7 @@ set(COLUMNGENERATIONSOLVER_BUILD_EXAMPLES OFF)
 FetchContent_Declare(
     columngenerationsolver
     GIT_REPOSITORY https://github.com/fontanf/columngenerationsolver.git
-    GIT_TAG 9dc3e8ad71329dac70de936ad108adfc8e34f592
+    GIT_TAG b9b2761203531ca26edabddc47116c50b865775b
     #SOURCE_DIR "${PROJECT_SOURCE_DIR}/../columngenerationsolver/"
     EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(columngenerationsolver)

--- a/src/algorithms/column_generation.hpp
+++ b/src/algorithms/column_generation.hpp
@@ -85,7 +85,8 @@ public:
     virtual PricingOutput solve_pricing(
             bool solve_feasibility,
             const std::vector<columngenerationsolver::Value>& duals,
-            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&) override;
+            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&,
+            columngenerationsolver::Counter pricing_level) override;
 
 private:
 
@@ -238,7 +239,8 @@ template <typename Instance, typename InstanceBuilder, typename Solution, typena
 PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>::solve_pricing(
         bool solve_feasibility,
         const std::vector<Value>& duals,
-        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, Value>>&)
+        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, Value>>&,
+        columngenerationsolver::Counter)
 {
     double multiplier_cost = largest_power_of_two_lesser_or_equal(instance_.largest_bin_cost());
     double multiplier_profit = largest_power_of_two_lesser_or_equal(instance_.largest_item_profit());

--- a/src/rectangle/bar_relaxation.cpp
+++ b/src/rectangle/bar_relaxation.cpp
@@ -65,7 +65,8 @@ public:
     columngenerationsolver::PricingSolver::PricingOutput solve_pricing(
             bool solve_feasibility,
             const std::vector<columngenerationsolver::Value>& duals,
-            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&) override;
+            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&,
+            columngenerationsolver::Counter pricing_level) override;
 
 private:
 
@@ -229,7 +230,8 @@ double BarRelaxationPricingSolver::price_bars(
 columngenerationsolver::PricingSolver::PricingOutput BarRelaxationPricingSolver::solve_pricing(
         bool,
         const std::vector<columngenerationsolver::Value>& duals,
-        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&)
+        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&,
+        columngenerationsolver::Counter)
 {
     columngenerationsolver::PricingSolver::PricingOutput output;
     double overcost = 0.0;

--- a/src/rectangleguillotine/column_generation_strips.cpp
+++ b/src/rectangleguillotine/column_generation_strips.cpp
@@ -48,7 +48,8 @@ public:
     virtual PricingOutput solve_pricing(
             bool solve_feasibility,
             const std::vector<columngenerationsolver::Value>& duals,
-            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&) override;
+            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&,
+            columngenerationsolver::Counter pricing_level) override;
 
     void set_all_columns_2e_patterns_generated() { all_columns_2e_patterns_generated_ = true; }
 
@@ -1940,7 +1941,8 @@ void ColumnGenerationPricingSolver::generate_duals_zero(
 PricingOutput ColumnGenerationPricingSolver::solve_pricing(
         bool solve_feasibility,
         const std::vector<columngenerationsolver::Value>& duals,
-        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&)
+        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&,
+        columngenerationsolver::Counter)
 {
     //std::cout << "solve_pricing" << std::endl;
 


### PR DESCRIPTION
## Summary
- Bumps the pinned `columngenerationsolver` commit to [fontanf/columngenerationsolver#65](https://github.com/fontanf/columngenerationsolver/pull/65) (merged), which reworks the rounding heuristic's Phase 1/Phase 2 transition (estimated remaining columns instead of a fixed infeasibility percentage, with an exhaustion fallback) and gates the heuristic on whether the previous column generation iteration actually needed the pricing solver.
- On a hard 500-item-type BinPacking instance (`csAA500_2`, gschwind2016), this takes the pricing solver from being starved almost entirely by redundant heuristic pricing calls to converging to a 0.98% gap in 30s.
- That commit also added a `pricing_level` parameter to `PricingSolver::solve_pricing` (for escalating pricing thoroughness, unrelated to this change) - updates every `PricingSolver` override to match: the shared `ColumnGenerationPricingSolver` (`src/algorithms/column_generation.hpp`, used by rectangle, box, onedimensional, boxstacks and irregular), `BarRelaxationPricingSolver` (`src/rectangle/bar_relaxation.cpp`), and rectangleguillotine's `ColumnGenerationPricingSolver` (`column_generation_strips.cpp`). None of them override `number_of_pricing_levels()` (default: 1, never escalates), so `pricing_level` is always 0 and this is a signature-only change.

## Test plan
- `onedimensional` (37/37) and `box` (11/11) test suites pass.
- Verified end-to-end via the CLI: the hard `csAA500_2` instance now converges to a 0.98% gap in 30s.
- `rectangle` and `rectangleguillotine` suites running in the background; will report results once they finish.