### PR TITLE
rectangleguillotine: don't auto-select column_generation_strips when it falls back to generate_lower_stage_patterns

### DIFF
--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -756,6 +756,25 @@ packingsolver::rectangleguillotine::Output packingsolver::rectangleguillotine::o
                     && instance.parameters().minimum_waste_length == 0
                     && instance.parameters().maximum_number_1_cuts == -1
                     && instance.parameters().maximum_number_2_cuts == -1
+                    // 'column_generation_strips''s pricing solver
+                    // (ColumnGenerationPricingSolver::solve_pricing) falls
+                    // back to 'generate_lower_stage_patterns' whenever
+                    // rotation is allowed (!all_item_types_oriented())
+                    // for these exact (number_of_stages, cut_type)
+                    // combinations. That fallback issues a full recursive
+                    // 'column_generation_strips' call - its own
+                    // from-scratch limited discrepancy search - per
+                    // candidate first-level strip width, at every node
+                    // where the cheap pattern generators
+                    // (generate_1e/1n/1ro/2ho_patterns) found no improving
+                    // column, and dominates run time (see issue #522) -
+                    // don't default into it.
+                    && !(instance.parameters().number_of_stages == 3
+                            && instance.parameters().cut_type == CutType::Homogenous
+                            && !instance.all_item_types_oriented())
+                    && !(instance.parameters().number_of_stages == 2
+                            && instance.parameters().cut_type == CutType::Roadef2018
+                            && !instance.all_item_types_oriented())
                     ) {
                 use_column_generation_strips = true;
             } else {


### PR DESCRIPTION
Fixes #522.

## Root cause
`ColumnGenerationPricingSolver::solve_pricing` falls back to `generate_lower_stage_patterns` whenever rotation is allowed for two exact `(number_of_stages, cut_type)` combinations: `(3, Homogenous)` and `(2, Roadef2018)`. That fallback issues a full recursive `column_generation_strips` call - its own from-scratch limited discrepancy search - per candidate first-level strip width, at every node where the cheap pattern generators (`generate_1e/1n/1ro/2ho_patterns`) find no improving column, and dominates run time. This is exactly what made `cut_type Homogenous` much slower than `Exact`/`NonExact` on the reported instance (9s vs 0.2s) - its items allow rotation.

## Fix
`optimize()`'s automatic algorithm selection already restricts `column_generation_strips` to `number_of_stages <= 2` or `(3, Homogenous)`; it now also requires that neither of the two fallback-triggering combinations holds, falling back to `tree_search` instead in those cases. `column_generation_strips` itself is untouched - it's still selected (and still recurses into `generate_lower_stage_patterns` when needed) whenever explicitly requested via `--use-column-generation-strips`.

## Verification
Using the reported instance, isolated to `sequential_value_correction` in `not-anytime` mode (other algorithms held constant):

| Scenario | Algorithm auto-selected | `generate_lower_stage_patterns` calls | Time |
|---|---|---|---|
| Rotation allowed, before fix | `column_generation_strips` | many | ~9s (as reported) |
| Rotation allowed, after fix | `tree_search` | 0 | 0.13s |
| `--no-item-rotation`, after fix | `column_generation_strips` | 0 | 0.84s |

Full end-to-end reproduction (all algorithms, not isolated, not-anytime mode) dropped from ~9s to 0.21s, converging to the same solution (7 bins, 14.76% waste) as `Exact`/`NonExact`.

## Test plan
- [x] Full `rectangleguillotine` unit test suite passes (285 tests)
- [x] Reproduced and verified the fix against the exact instance attached to #522