### PR TITLE
rectangle: add merge-identical-items reduction, remove Reduction::applies

### DIFF
--- a/include/packingsolver/rectangle/instance.hpp
+++ b/include/packingsolver/rectangle/instance.hpp
@@ -476,9 +476,9 @@ public:
      * Return 'true' iff the instance has a single bin type with a finite
      * maximum weight and at least one item type with a nonzero weight -
      * i.e. iff its weight capacity is an actual, non-trivial per-bin
-     * aggregate constraint (see 'Reduction::applies' for why this matters
-     * there: a per-bin aggregate is invisible to per-group geometric-only
-     * reasoning).
+     * aggregate constraint (see 'Reduction::companion_absorption_applies'
+     * for why this matters there: a per-bin aggregate is invisible to
+     * per-group geometric-only reasoning).
      */
     bool weight_matters() const;
 
@@ -486,7 +486,7 @@ public:
      * Return 'true' iff the instance has a single bin type with at least
      * one resource - i.e. iff it has an actual, non-trivial per-bin
      * aggregate constraint beyond geometry and weight (see
-     * 'weight_matters' and 'Reduction::applies').
+     * 'weight_matters' and 'Reduction::companion_absorption_applies').
      */
     bool resources_matter() const;
 

--- a/include/packingsolver/rectangle/reduction.hpp
+++ b/include/packingsolver/rectangle/reduction.hpp
@@ -29,6 +29,48 @@ struct ReductionParameters: optimizationtools::Parameters
     /** Boolean indicating if the reduction should be performed. */
     bool reduce = true;
 
+    /**
+     * Enable/disable the wide/tall item enlargement sub-operation of
+     * companion absorption (gates 'Reduction::reduce_group', called for
+     * both 'EnlargementCase::Wide' and 'EnlargementCase::Tall' - see
+     * 'Reduction''s class-level doc comment). Still subject to
+     * 'Reduction::companion_absorption_applies' regardless of this flag.
+     */
+    bool enlarge_wide_tall_items = true;
+
+    /**
+     * Enable/disable the "both" item enlargement sub-operation of
+     * companion absorption (gates 'Reduction::reduce_both_groups'). Still
+     * subject to 'Reduction::companion_absorption_applies' regardless of
+     * this flag.
+     */
+    bool enlarge_both_items = true;
+
+    /**
+     * Enable/disable the full-bin-item dedicated-bin sub-operation of
+     * companion absorption (gates 'Reduction::reduce_full_bin_items').
+     * Still subject to 'Reduction::companion_absorption_applies'
+     * regardless of this flag.
+     */
+    bool reduce_full_bin_items = true;
+
+    /**
+     * Enable/disable the perfect-pair dedicated-bin sub-operation of
+     * companion absorption (gates 'Reduction::reduce_perfect_pairs').
+     * Still subject to 'Reduction::companion_absorption_applies'
+     * regardless of this flag.
+     */
+    bool reduce_perfect_pairs = true;
+
+    /**
+     * Enable/disable merging identical item types (gates
+     * 'Reduction::merge_identical_items'). Unlike the four flags above,
+     * not subject to 'Reduction::companion_absorption_applies' - see
+     * 'Reduction''s class-level doc comment for why this operation's
+     * soundness does not depend on the same preconditions.
+     */
+    bool merge_identical_items = true;
+
     /** Maximum number of rounds of the outer fixpoint loop. */
     Counter maximum_number_of_rounds = 999;
 
@@ -42,80 +84,95 @@ struct ReductionParameters: optimizationtools::Parameters
 /**
  * "Packing and removing some items" reduction (Côté, Haouari & Iori 2019,
  * "A Primal Decomposition Algorithm for the Two-dimensional Bin Packing
- * Problem", Section 4.2).
+ * Problem", Section 4.2), plus an identical-item-type merge (see
+ * 'merge_identical_items').
  *
- * Only meaningful for the 'BinPacking', 'VariableSizedBinPacking' and
- * 'Feasibility' objectives (every item must be packed there, which is what
- * makes the reduction sound - see below), and only for instances with a
- * single bin type (the paper's 2D-BPP has one bin size; classifying an item
- * as "wide"/"tall" depends on which bin's dimensions it is compared to, and
- * a reduction valid for one bin type isn't obviously valid for another).
+ * Only runs at all when 'parameters.reduce' is 'true' - unlike every
+ * previous version of this class, there is no shared objective/instance
+ * precondition beyond that: this class runs two largely independent
+ * operations, each gated by its own, narrower precondition (see
+ * 'companion_absorption_applies()' and 'merge_identical_items()'
+ * respectively), because their soundness rests on different arguments:
  *
- * Also skipped whenever the instance has defects, a finite bin weight
- * capacity together with non-trivial item weights, or a non-'None'
- * unloading constraint - every check this class performs (the companion-bin
- * 'Objective::Feasibility' solves, and the direct dimension-only matches in
- * 'reduce_full_bin_items'/'reduce_perfect_pairs') reasons purely about
- * geometry, which none of these three respect: a defect sitting where a
- * companion needs to go is invisible to a plain empty-rectangle check;
- * total bin weight and unloading order are *whole-bin* properties over
- * every item that ends up sharing a bin, but a validated-enlarged item's
- * real companions are invisibly removed from the reduced instance and only
- * reinserted by 'unreduce_solution' after the downstream solve has already
- * finished, so that solve can never verify either one still holds once it
- * additionally places other items - never part of the isolated companion
- * check - into that same bin.
+ * - Companion absorption (wide/tall/both, full-bin items, perfect pairs):
+ *   only for the 'BinPacking', 'VariableSizedBinPacking' and 'Feasibility'
+ *   objectives (every item must be packed there, which is what makes this
+ *   operation sound: it only preserves the number of bins used - and the
+ *   feasibility of the built solution - because nothing it removes could
+ *   ever legitimately be left unpacked, *not* true for 'Knapsack', where an
+ *   item may legitimately be left unpacked), only for instances with a
+ *   single bin type (the paper's 2D-BPP has one bin size; classifying an
+ *   item as "wide"/"tall" depends on which bin's dimensions it is compared
+ *   to, and a reduction valid for one bin type isn't obviously valid for
+ *   another), and skipped whenever the instance has defects, a finite bin
+ *   weight capacity together with non-trivial item weights, a non-'None'
+ *   unloading constraint, or resources - every check this part performs
+ *   (the companion-bin 'Objective::Feasibility' solves, and the direct
+ *   dimension-only matches in 'reduce_full_bin_items'/
+ *   'reduce_perfect_pairs') reasons purely about geometry, which none of
+ *   these four respect: a defect sitting where a companion needs to go is
+ *   invisible to a plain empty-rectangle check; bin weight, unloading
+ *   order, and resource capacity are all *whole-bin* properties over every
+ *   item that ends up sharing a bin, but a validated-enlarged item's real
+ *   companions are invisibly removed from the reduced instance and only
+ *   reinserted by 'unreduce_solution' after the downstream solve has
+ *   already finished, so that solve can never verify any of the three
+ *   still hold once it additionally places other items - never part of the
+ *   isolated companion check - into that same bin. See
+ *   'companion_absorption_applies()'.
  *
- * For every excluded case, this is a no-op: 'instance()' returns a copy of
- * the original instance, and 'unreduce_solution' is the identity function.
+ *   The idea: an item type whose width exceeds half the bin's width (a
+ *   "wide" item) can only ever share its row of the bin with items narrow
+ *   enough to fit in the leftover width. If *every* narrow-enough item type
+ *   can be proven (via an actual 'Objective::Feasibility' solve, small
+ *   time/node budget) to fit alongside the wide items, in the leftover
+ *   "companion" strips beside them, then those narrow items can be removed
+ *   from the instance entirely (their placement is fully determined by
+ *   wherever their paired wide item ends up) and the wide items enlarged to
+ *   the full bin width - a much smaller equivalent instance. The symmetric
+ *   case is applied for items taller than half the bin's height, and a
+ *   third case for items that are both wider than half the bin's width
+ *   *and* taller than half its height (paired with a full bin instead of a
+ *   strip). See 'reduction.cpp' for the exact algorithm (which follows the
+ *   paper's sorted, incrementally-growing candidate search, but uses
+ *   PackingSolver's own 'Objective::Feasibility' solver as the
+ *   packing-check primitive instead of the paper's bespoke greedy
+ *   heuristic).
  *
- * The idea: an item type whose width exceeds half the bin's width (a "wide"
- * item) can only ever share its row of the bin with items narrow enough to
- * fit in the leftover width. If *every* narrow-enough item type can be
- * proven (via an actual 'Objective::Feasibility' solve, small time/node
- * budget) to fit alongside the wide items, in the leftover "companion"
- * strips beside them, then those narrow items can be removed from the
- * instance entirely (their placement is fully determined by wherever their
- * paired wide item ends up) and the wide items enlarged to the full bin
- * width - a much smaller equivalent instance. The symmetric case is
- * applied for items taller than half the bin's height, and a third case
- * for items that are both wider than half the bin's width *and* taller
- * than half its height (paired with a full bin instead of a strip). See
- * 'reduction.cpp' for the exact algorithm (which follows the paper's
- * sorted, incrementally-growing candidate search, but uses PackingSolver's
- * own 'Objective::Feasibility' solver as the packing-check primitive
- * instead of the paper's bespoke greedy heuristic).
+ * - Merging identical item types (see 'merge_identical_items'): unlike
+ *   companion absorption, a merged item type's copies stay fully visible
+ *   and independently placed in the reduced instance (nothing is hidden
+ *   from the downstream solve), so none of the whole-bin arguments above
+ *   apply, and nothing about them depends on every item necessarily being
+ *   packed either - the downstream solve still sees, and can still
+ *   correctly enforce, every copy's true weight/resource
+ *   consumption/unloading group/minimum-vs-maximum copies, and defects are
+ *   irrelevant to it either way (they constrain *where* an item goes, not
+ *   *which* interchangeable copy goes there). This operation therefore
+ *   runs for *any* objective, regardless of defects, weight, resources,
+ *   unloading constraint, or the number of bin types - as long as its own
+ *   per-pair check (rect, plus every property that could make two items
+ *   behave differently: orientation, weight, group, eligibility,
+ *   mandatory-vs-optional copies, and - per bin type - resource
+ *   consumption schedule) finds them truly interchangeable - and, for
+ *   'Knapsack' specifically, profit too: every other objective here
+ *   ignores profit as a merge criterion (it is never the actual
+ *   objective, and 'unreduce_solution' always restores each copy's true
+ *   original profit regardless of merging), but 'Knapsack' optimizes
+ *   profit directly over a solve that may legitimately leave copies
+ *   unplaced, so merging two different-profit item types would report one
+ *   uniform profit for every copy and let the solve itself choose a
+ *   suboptimal subset on wrong information - restoring true profits
+ *   afterwards cannot undo that.
  *
- * Soundness: every removed item is guaranteed packed whenever its paired
- * big item is packed. This only preserves the number of bins used (and the
- * feasibility of the built solution) if the big item is itself guaranteed
- * to be packed - true for 'BinPacking'/'VariableSizedBinPacking' (every
- * item must be packed) and 'Feasibility' (same), but *not* true for
- * 'Knapsack' (an item may legitimately be left unpacked there), which is
- * why 'Knapsack' is excluded.
+ * For every excluded case, this class no-ops entirely: 'instance()' returns
+ * a copy of the original instance, and 'unreduce_solution' is the identity
+ * function.
  */
 class Reduction
 {
 
 public:
-
-    /**
-     * 'true' iff the reduction is meaningful for 'instance'/'parameters' -
-     * everything the class-level doc comment's "Only meaningful for..."/
-     * "Also skipped whenever..." paragraphs describe (the objective,
-     * single-bin-type, defect-free, unloading-constraint-free, weight
-     * conditions, together with 'parameters.reduce' itself). Exposed as
-     * its own static method - rather than left as an internal, constructor-
-     * only check - so that a caller about to construct a 'Reduction' (see
-     * 'optimize()') can decide not to at all when it would just no-op:
-     * constructing one always does at least a full pass over every item
-     * type (to build the working representation and, even in the
-     * no-op case, immediately rebuild an identical 'Instance' from it),
-     * work worth skipping entirely rather than paying for and discarding.
-     */
-    static bool applies(
-            const Instance& instance,
-            const ReductionParameters& parameters);
 
     /** Constructor. */
     Reduction(
@@ -168,6 +225,17 @@ public:
     bool proven_infeasible() const { return proven_infeasible_; }
 
 private:
+
+    /**
+     * 'true' iff companion absorption (wide/tall/both, full-bin items,
+     * perfect pairs) is meaningful for 'instance' - the class-level doc
+     * comment's "Companion absorption" paragraph (including the objective
+     * check; unlike 'merge_identical_items', this operation is only sound
+     * for 'BinPacking'/'VariableSizedBinPacking'/'Feasibility'). Does not
+     * check 'parameters.reduce' - the constructor only calls this after
+     * already checking it.
+     */
+    static bool companion_absorption_applies(const Instance& instance);
 
     /*
      * Private types
@@ -255,6 +323,18 @@ private:
     struct ReductionItemType
     {
         bool removed = false;
+
+        /**
+         * Item type id (original instance's id space) this one was merged
+         * into (see 'merge_identical_items'), or '-1' if it was not merged
+         * away. Only ever set alongside 'removed = true', but distinct from
+         * every other reason 'removed' can be 'true' (absorbed as a
+         * companion, or consumed into a dedicated bin): those hide the item
+         * from the reduced instance entirely, whereas a merged-away item's
+         * own 'copies' still contribute to the survivor's - see
+         * 'reduction_to_instance'.
+         */
+        ItemTypeId merged_into = -1;
 
         /** Current (possibly enlarged) dimensions. */
         Rectangle rect;
@@ -968,6 +1048,83 @@ private:
             Length bin_w,
             Length bin_h);
 
+    /**
+     * Merge every group of pairwise-'items_mergeable' item types in
+     * 'reduction_item_types' into a single survivor (the lowest item type
+     * id in the group) with the group's combined copies - see the
+     * class-level doc comment's "Merging identical item types" paragraph
+     * for why this is sound regardless of defects/weight/resources/
+     * unloading constraint/number of bin types. Unlike companion
+     * absorption, a merged-away item type's own 'copies'/
+     * 'companions_by_copy' are left untouched (only 'removed' and
+     * 'merged_into' are set) - 'reduction_to_instance' reads them directly
+     * when it later expands the survivor back into a per-copy origin list
+     * (see 'CopyOrigin'), so there is nothing to consolidate here.
+     *
+     * Returns 'true' iff at least one merge happened (unlike the other
+     * 'reduce_*' methods, this is not currently used to drive a fixpoint
+     * loop - merging item types never changes any 'rect'/'copies' value
+     * that could make a previously-failed companion-absorption check
+     * succeed - but is still reported for consistency and in case a future
+     * change relies on it).
+     */
+    bool merge_identical_items(
+            std::vector<ReductionItemType>& reduction_item_types);
+
+    /**
+     * 'true' iff item types 'item_type_id_1' and 'item_type_id_2' are
+     * interchangeable: same current (possibly already-enlarged) 'rect', and
+     * every original-instance property that could make them behave
+     * differently downstream - orientation, weight, group, eligibility,
+     * and, for every bin type/resource, the exact same per-copy
+     * consumption schedule (an empty/absent schedule only matches another
+     * empty/absent one, even though both mean "zero consumption" - a
+     * missed merge opportunity in that corner case, never an unsound one).
+     * Does *not* compare profit, except for 'Knapsack' - see this method's
+     * own doc comment in 'reduction.cpp' for why a mismatch is harmless
+     * for every other objective this class handles, but not for
+     * 'Knapsack', where profit is the actual objective and copies are
+     * optional.
+     *
+     * Also requires each candidate's own current (post-companion-
+     * absorption) copies to be either entirely mandatory (its effective
+     * 'copies_min' equals its 'copies' - see 'effective_copies_min') or
+     * entirely optional (effective 'copies_min' is 0) - a mix, or a
+     * genuinely partial requirement (0 < copies_min < copies, only
+     * possible for 'Knapsack', the one objective companion absorption
+     * never touches) would make 'reduction_to_instance''s per-copy origin
+     * list (see 'CopyOrigin') pick an arbitrary split between the two
+     * original item types that may not respect either one's own true
+     * minimum - see 'reduction.cpp' for a concrete counterexample.
+     *
+     * Does not look at 'removed'/'merged_into' - callers are responsible
+     * for only comparing candidates that are not already merged away.
+     */
+    bool items_mergeable(
+            const std::vector<ReductionItemType>& reduction_item_types,
+            ItemTypeId item_type_id_1,
+            ItemTypeId item_type_id_2) const;
+
+    /**
+     * 'item_type_id''s own minimum copies requirement, adjusted for
+     * whatever companion absorption has already consumed from its
+     * 'copies' (mirrors how 'reduction_to_instance' already adjusts a bin
+     * type's own 'copies_min' by 'number_of_dedicated_bins' - see there):
+     * 'max(0, original.copies_min - (original.copies -
+     * reduction_item_types[item_type_id].copies))'. For every objective
+     * except 'Knapsack', 'original.copies_min' always equals
+     * 'original.copies' (see 'InstanceBuilder::build'), so this always
+     * equals 'reduction_item_types[item_type_id].copies' exactly - the
+     * "still fully mandatory" case 'items_mergeable' and
+     * 'reduction_to_instance' both rely on. For 'Knapsack' (the one
+     * objective companion absorption never touches, so nothing is ever
+     * consumed from its 'copies'), this always equals
+     * 'original.copies_min' directly.
+     */
+    ItemPos effective_copies_min(
+            const std::vector<ReductionItemType>& reduction_item_types,
+            ItemTypeId item_type_id) const;
+
     /** Build the final reduced 'Instance' from the working representation. */
     Instance reduction_to_instance(
             const std::vector<ReductionItemType>& reduction_item_types);
@@ -993,19 +1150,41 @@ private:
      * thresholds). Symmetric for height. Only meaningful for instances
      * with a single bin type and finite item copies (an infinite-copies
      * item type can already saturate any capacity on its own, and can't be
-     * flattened into individual units below); returns the instance's own
-     * (unchanged) bin dimensions for every other case.
+     * flattened into individual units below); returns 'false' and leaves
+     * the bin's own (unchanged) dimensions in 'shrunk_bin_sizes' for every
+     * other case; returns 'true' when equation (7) actually ran.
+     *
+     * Computed over 'reduction_item_types''s *current* rect/copies,
+     * skipping already-'removed' item types entirely - not over
+     * 'original_instance_''s original, full population. This is
+     * deliberately recomputed every round (see the constructor's own
+     * comment at the call site) rather than once, upfront: a 'removed'
+     * item type (absorbed as a companion, consumed into a dedicated bin,
+     * ...) is no longer independently available to combine with anything
+     * else, so excluding it only ever lowers (or leaves unchanged) the
+     * genuinely achievable combination on either axis - it does not
+     * understate it, even though the item itself has not physically left
+     * the bin: its own contribution is either already folded into a
+     * survivor's current (possibly enlarged) dimensions, which this
+     * function does still count via that survivor's own current entry,
+     * or it is captured inside a dedicated bin that is entirely outside
+     * this bound's concern (dedicated bins are never shared with
+     * anything else - see 'number_of_dedicated_bins'). Once an item type
+     * is the *only* one left, this bound naturally collapses to exactly
+     * its own current dimensions - correctly proving nothing else
+     * remains that could ever share a bin with it, which
+     * 'reduce_full_bin_items' below then acts on.
      *
      * Computed via 'multiplechoicesubsetsumsolver' (as in
      * 'boxstacks::TreeSearch''s own "lift length" computation): one group
-     * per item copy, containing one candidate value per orientation the
-     * item type is allowed to present on this axis (its declared
-     * dimension, plus its rotated one too if not 'oriented') - the solver
-     * picks *at most* one candidate per group (a group can contribute
-     * nothing at all, i.e. that copy sits out of this particular
-     * combination), maximizing the total not exceeding the bin's true
-     * dimension on that axis. This is what lets a non-oriented item
-     * participate soundly, unlike a plain (single-choice) subset sum:
+     * per remaining item copy, containing one candidate value per
+     * orientation the item type is allowed to present on this axis (its
+     * declared dimension, plus its rotated one too if not 'oriented') -
+     * the solver picks *at most* one candidate per group (a group can
+     * contribute nothing at all, i.e. that copy sits out of this
+     * particular combination), maximizing the total not exceeding the
+     * bin's true dimension on that axis. This is what lets a non-oriented
+     * item participate soundly, unlike a plain (single-choice) subset sum:
      * each axis's computation independently picks whichever orientation
      * of a given copy contributes more, without needing that choice to
      * also be consistent with what the *other* axis's own (separately
@@ -1015,7 +1194,24 @@ private:
      * neither individually is ever exceeded by anything real, which is
      * all equation (7) needs.
      */
-    static ShrunkBinSizes compute_shrunk_bin_sizes(const Instance& instance);
+    bool compute_shrunk_bin_sizes(
+            const std::vector<ReductionItemType>& reduction_item_types,
+            ShrunkBinSizes& shrunk_bin_sizes) const;
+
+    /**
+     * Maximum achievable combination of not-yet-'removed' item widths (or
+     * heights) not exceeding 'capacity' - the inner multiple-choice
+     * subset-sum maximization of equation (7), shared by
+     * 'compute_shrunk_bin_sizes''s width/height calls, via
+     * 'multiplechoicesubsetsumsolver'. Takes 'original_instance' alongside
+     * 'reduction_item_types' only for each item type's own 'oriented'
+     * flag, which 'ReductionItemType' does not duplicate.
+     */
+    static Length max_achievable_dimension_sum(
+            const std::vector<ReductionItemType>& reduction_item_types,
+            const Instance& original_instance,
+            Length capacity,
+            bool width_axis);
 
     /*
      * Private attributes
@@ -1072,13 +1268,36 @@ private:
     std::vector<ReductionItemType> final_item_types_;
 
     /**
-     * For each item type of the reduced instance, the corresponding item
-     * type id in the original instance (removing items shifts ids, so this
-     * is never the identity mapping in general). Indexed by the reduced
-     * instance's own item type ids: populated once, alongside
-     * 'final_item_types_' (see 'reduction_to_instance').
+     * Where one particular copy of a reduced instance item type came from:
+     * the corresponding item type id in the *original* instance, and that
+     * original item type's own local copy index (needed to index its
+     * 'companions_by_copy', if any - see 'ReductionItemType''s own doc
+     * comment).
      */
-    std::vector<ItemTypeId> reduced_to_original_item_type_ids_;
+    struct CopyOrigin
+    {
+        /** Item type id, original instance's id space. */
+        ItemTypeId item_type_id;
+
+        /** 'item_type_id''s own local copy index (0-indexed). */
+        ItemPos copy_index;
+    };
+
+    /**
+     * For each item type of the reduced instance, one entry per copy (in
+     * the order copies will be encountered while scanning a reduced
+     * solution) giving where that specific copy came from (see
+     * 'CopyOrigin'). Every entry names the *same* original item type id
+     * unless that reduced item type absorbed one or more others via
+     * 'merge_identical_items', in which case its copies are the
+     * concatenation, in order, of every merged-together original item
+     * type's own copy range - any consistent order works, since merged
+     * item types are interchangeable by construction (see
+     * 'items_mergeable'). Indexed by the reduced instance's own item type
+     * ids: populated once, alongside 'final_item_types_' (see
+     * 'reduction_to_instance').
+     */
+    std::vector<std::vector<CopyOrigin>> reduced_copy_origins_;
 
     /**
      * Places 'item_type_id' (original instance's id space) at 'bl_corner'

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -620,22 +620,17 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
     // "Packing and removing some items" reduction (see 'Reduction'):
     // applied once, upfront, wrapping the whole dispatch logic below
     // uniformly for every algorithm (mirroring how e.g. setcoveringsolver's
-    // 'Reduction' wraps its own algorithms generically). Gated on
-    // 'Reduction::applies' directly, rather than constructing a
+    // 'Reduction' wraps its own algorithms generically). Gated directly on
+    // 'parameters.reduction_parameters.reduce', rather than constructing a
     // 'Reduction' unconditionally and letting its constructor no-op: when
-    // it would not apply anyway (wrong objective, multiple bin types,
-    // 'parameters.reduction_parameters.reduce' itself 'false', ...), this
-    // skips it entirely instead of paying for (and discarding) a full
-    // pass building its working representation - see 'applies''s own doc
-    // comment. 'reduced_parameters.reduction_parameters.reduce' is set to
-    // 'false' below to avoid re-running the reduction recursively on the
-    // already-reduced instance: 'applies' only checks instance-level
-    // characteristics (objective, single bin type, ...), which the
-    // reduced instance still satisfies just as well as the original one,
-    // so without this it would gate 'true' again there too - a pass that
-    // can only ever find nothing new (the reduction already ran to a
-    // fixpoint), just at the cost of a wasted full pass to confirm it.
-    if (Reduction::applies(instance, parameters.reduction_parameters)) {
+    // it is 'false', this skips the reduction entirely instead of paying
+    // for (and discarding) a full pass building its working
+    // representation. 'reduced_parameters.reduction_parameters.reduce' is
+    // set to 'false' below to avoid re-running the reduction recursively
+    // on the already-reduced instance - a pass that can only ever find
+    // nothing new (the reduction already ran to a fixpoint), just at the
+    // cost of a wasted full pass to confirm it.
+    if (parameters.reduction_parameters.reduce) {
         ReductionParameters reduction_parameters = parameters.reduction_parameters;
         reduction_parameters.timer = parameters.timer;
         Reduction reduction(instance, reduction_parameters);

--- a/src/rectangle/reduction.cpp
+++ b/src/rectangle/reduction.cpp
@@ -1066,6 +1066,143 @@ BinPos Reduction::number_of_dedicated_bins() const
     return total;
 }
 
+bool Reduction::items_mergeable(
+        const std::vector<ReductionItemType>& reduction_item_types,
+        ItemTypeId item_type_id_1,
+        ItemTypeId item_type_id_2) const
+{
+    const ReductionItemType& item_1 = reduction_item_types[item_type_id_1];
+    const ReductionItemType& item_2 = reduction_item_types[item_type_id_2];
+    if (item_1.rect.x != item_2.rect.x || item_1.rect.y != item_2.rect.y)
+        return false;
+
+    const ItemType& original_item_type_1 = original_instance_->item_type(item_type_id_1);
+    const ItemType& original_item_type_2 = original_instance_->item_type(item_type_id_2);
+    // Profit is only compared for 'Knapsack': for every other objective
+    // this class handles, profit is never the actual objective, and
+    // 'unreduce_solution' always restores the true original item type id
+    // (and so its true profit) for every placed copy regardless of which
+    // one a reduced-instance solve actually used, so a profit mismatch
+    // cannot affect correctness there - only, at most, the search guide's
+    // scoring while solving the reduced instance. This matters in
+    // practice: companion absorption enlarges a "wide"/"tall" item's
+    // 'rect' without touching its profit, so two originally different item
+    // types absorbed into the same footprint end up identical on every
+    // other property here but not on profit.
+    //
+    // For 'Knapsack', profit *is* the actual objective, and copies are
+    // optional (a solve may legitimately leave some unplaced) - merging
+    // two different-profit item types would report a single, uniform
+    // profit for every copy in the reduced instance (see
+    // 'reduction_to_instance', which always takes the survivor's own
+    // profit), so the solve itself would optimize against the wrong
+    // values and could pick a suboptimal subset of copies to place; no
+    // amount of restoring true profits afterwards, in 'unreduce_solution',
+    // can undo a choice already made on wrong information. So a profit
+    // mismatch there must block the merge outright, not just risk a worse
+    // search guide.
+    if (original_instance_->objective() == Objective::Knapsack
+            && original_item_type_1.profit != original_item_type_2.profit)
+        return false;
+    if (original_item_type_1.oriented != original_item_type_2.oriented
+            || original_item_type_1.weight != original_item_type_2.weight
+            || original_item_type_1.group_id != original_item_type_2.group_id
+            || original_item_type_1.eligibility_id != original_item_type_2.eligibility_id)
+        return false;
+
+    static const std::vector<double> empty_schedule;
+    for (BinTypeId bin_type_id = 0;
+            bin_type_id < original_instance_->number_of_bin_types();
+            ++bin_type_id) {
+        const BinType& bin_type = original_instance_->bin_type(bin_type_id);
+        for (ResourceId resource_id = 0;
+                resource_id < bin_type.number_of_resources();
+                ++resource_id) {
+            const std::vector<std::vector<double>>& item_consumptions
+                = bin_type.resource(resource_id).item_consumptions;
+            const std::vector<double>& schedule_1
+                = (item_type_id_1 < (ItemTypeId)item_consumptions.size())?
+                    item_consumptions[item_type_id_1]: empty_schedule;
+            const std::vector<double>& schedule_2
+                = (item_type_id_2 < (ItemTypeId)item_consumptions.size())?
+                    item_consumptions[item_type_id_2]: empty_schedule;
+            if (schedule_1 != schedule_2)
+                return false;
+        }
+    }
+
+    // Each candidate's own current copies must be either entirely
+    // mandatory or entirely optional, and both candidates must agree on
+    // which - see this method's own doc comment in 'reduction.hpp' for
+    // the general argument. Concrete counterexample for why a mix is
+    // unsound: item type A, 3 copies, 'copies_min' 3 (fully mandatory -
+    // only possible for 'Knapsack'), merged with identical-footprint item
+    // type B, 5 copies, 'copies_min' 0 (fully optional). The merged
+    // survivor would get 8 copies with a combined 'copies_min' of 3 (see
+    // 'reduction_to_instance'), which only forces *some* 3 of the 8
+    // copies to be placed - nothing ties those specific 3 back to A's own
+    // copies, since 'reduction_to_instance''s per-copy origin list (see
+    // 'CopyOrigin') assigns origins in a fixed, arbitrary order (survivor
+    // first, then each merged-in type), unrelated to which copies a
+    // downstream 'Knapsack' solve actually chooses to place. A solution
+    // that places 3 copies drawn entirely from B's share (fully
+    // satisfying the reduced instance's own 'copies_min' of 3) would
+    // 'unreduce_solution' into leaving all 3 of A's genuinely mandatory
+    // copies unplaced - violating A's true requirement, even though the
+    // reduced-instance solve was itself entirely valid. Both-mandatory or
+    // both-optional merges do not have this problem: a combined
+    // 'copies_min' equal to the full merged copies count (both
+    // mandatory) forces every copy to be placed regardless of origin,
+    // and a combined 'copies_min' of zero (both optional) forces nothing
+    // regardless of origin either way.
+    ItemPos effective_copies_min_1 = effective_copies_min(reduction_item_types, item_type_id_1);
+    ItemPos effective_copies_min_2 = effective_copies_min(reduction_item_types, item_type_id_2);
+    bool item_1_fully_mandatory = (effective_copies_min_1 == item_1.copies);
+    bool item_2_fully_mandatory = (effective_copies_min_2 == item_2.copies);
+    bool item_1_fully_optional = (effective_copies_min_1 == 0);
+    bool item_2_fully_optional = (effective_copies_min_2 == 0);
+    if (!(item_1_fully_mandatory || item_1_fully_optional)
+            || !(item_2_fully_mandatory || item_2_fully_optional))
+        return false;
+    if (item_1_fully_mandatory != item_2_fully_mandatory)
+        return false;
+
+    return true;
+}
+
+ItemPos Reduction::effective_copies_min(
+        const std::vector<ReductionItemType>& reduction_item_types,
+        ItemTypeId item_type_id) const
+{
+    const ItemType& original_item_type = original_instance_->item_type(item_type_id);
+    ItemPos consumed = original_item_type.copies - reduction_item_types[item_type_id].copies;
+    return std::max((ItemPos)0, original_item_type.copies_min - consumed);
+}
+
+bool Reduction::merge_identical_items(
+        std::vector<ReductionItemType>& reduction_item_types)
+{
+    bool found = false;
+    for (ItemTypeId item_type_id_1 = 0;
+            item_type_id_1 < (ItemTypeId)reduction_item_types.size();
+            ++item_type_id_1) {
+        if (reduction_item_types[item_type_id_1].removed)
+            continue;
+        for (ItemTypeId item_type_id_2 = item_type_id_1 + 1;
+                item_type_id_2 < (ItemTypeId)reduction_item_types.size();
+                ++item_type_id_2) {
+            if (reduction_item_types[item_type_id_2].removed)
+                continue;
+            if (!items_mergeable(reduction_item_types, item_type_id_1, item_type_id_2))
+                continue;
+            reduction_item_types[item_type_id_2].removed = true;
+            reduction_item_types[item_type_id_2].merged_into = item_type_id_1;
+            found = true;
+        }
+    }
+    return found;
+}
+
 Instance Reduction::reduction_to_instance(
         const std::vector<ReductionItemType>& reduction_item_types)
 {
@@ -1079,7 +1216,14 @@ Instance Reduction::reduction_to_instance(
     for (ItemTypeId item_type_id = 0;
             item_type_id < (ItemTypeId)reduction_item_types.size();
             ++item_type_id) {
-        if (!reduction_item_types[item_type_id].removed)
+        // A merged-away item type (see 'merge_identical_items') is
+        // 'removed' too, but its copies still need bin capacity in the
+        // reduced instance - just folded into its survivor's own count
+        // below - unlike every other reason an item type can be 'removed'
+        // (absorbed as a companion, or consumed into a dedicated bin),
+        // which genuinely need none.
+        if (!reduction_item_types[item_type_id].removed
+                || reduction_item_types[item_type_id].merged_into != -1)
             remaining_items += original_instance_->item_type(item_type_id).copies;
     }
 
@@ -1139,18 +1283,46 @@ Instance Reduction::reduction_to_instance(
     // survivor or not.
     final_item_types_ = reduction_item_types;
 
-    reduced_to_original_item_type_ids_.clear();
+    reduced_copy_origins_.clear();
     for (ItemTypeId item_type_id = 0;
             item_type_id < (ItemTypeId)reduction_item_types.size();
             ++item_type_id) {
         const ReductionItemType& item = reduction_item_types[item_type_id];
         if (item.removed)
             continue;
+
+        // Per-copy origin list for this survivor: its own copies, then, in
+        // discovery order, every item type merged into it (see
+        // 'merge_identical_items') - any consistent order works, since
+        // merged item types are interchangeable by construction (see
+        // 'items_mergeable').
+        std::vector<CopyOrigin> copy_origins;
+        // Combined minimum copies requirement: the sum of the survivor's
+        // own 'effective_copies_min' and every merged-in constituent's -
+        // sound (regardless of origin order) only because 'items_mergeable'
+        // already restricts every merge to same-category (fully mandatory
+        // with fully mandatory, fully optional with fully optional) pairs -
+        // see 'items_mergeable''s own doc comment.
+        ItemPos total_copies_min = effective_copies_min(reduction_item_types, item_type_id);
+        for (ItemPos copy_index = 0; copy_index < item.copies; ++copy_index)
+            copy_origins.push_back({item_type_id, copy_index});
+        for (ItemTypeId other_item_type_id = 0;
+                other_item_type_id < (ItemTypeId)reduction_item_types.size();
+                ++other_item_type_id) {
+            if (reduction_item_types[other_item_type_id].merged_into != item_type_id)
+                continue;
+            ItemPos merged_copies = reduction_item_types[other_item_type_id].copies;
+            total_copies_min += effective_copies_min(reduction_item_types, other_item_type_id);
+            for (ItemPos copy_index = 0; copy_index < merged_copies; ++copy_index)
+                copy_origins.push_back({other_item_type_id, copy_index});
+        }
+
         const ItemType& original_item_type = original_instance_->item_type(item_type_id);
         ItemTypeId new_item_type_id = instance_builder.add_item_type(
                 item.rect.x, item.rect.y, original_item_type.oriented);
         instance_builder.set_item_type_profit(new_item_type_id, original_item_type.profit);
-        instance_builder.set_item_type_copies(new_item_type_id, item.copies);
+        instance_builder.set_item_type_copies(new_item_type_id, (ItemPos)copy_origins.size());
+        instance_builder.set_item_type_copies_min(new_item_type_id, total_copies_min);
         instance_builder.set_item_type_group(new_item_type_id, original_item_type.group_id);
         instance_builder.set_item_type_weight(new_item_type_id, original_item_type.weight);
         instance_builder.set_item_type_eligibility(new_item_type_id, original_item_type.eligibility_id);
@@ -1182,26 +1354,15 @@ Instance Reduction::reduction_to_instance(
                 }
             }
         }
-        reduced_to_original_item_type_ids_.push_back(item_type_id);
+        reduced_copy_origins_.push_back(std::move(copy_origins));
     }
 
     return instance_builder.build();
 }
 
-namespace
-{
-
-/**
- * Maximum achievable combination of item widths (or heights) not
- * exceeding 'capacity' - the inner multiple-choice subset-sum
- * maximization of equation (7) - via 'multiplechoicesubsetsumsolver': one
- * group per item copy, containing one candidate value per orientation
- * that copy is allowed to present on this axis (see
- * 'Reduction::compute_shrunk_bin_sizes''s own doc comment for why this is
- * sound for non-oriented items too).
- */
-Length max_achievable_dimension_sum(
-        const Instance& instance,
+Length Reduction::max_achievable_dimension_sum(
+        const std::vector<ReductionItemType>& reduction_item_types,
+        const Instance& original_instance,
         Length capacity,
         bool width_axis)
 {
@@ -1209,14 +1370,17 @@ Length max_achievable_dimension_sum(
     mcss_instance_builder.set_capacity(capacity);
     multiplechoicesubsetsumsolver::GroupId mcss_group_id = 0;
     for (ItemTypeId item_type_id = 0;
-            item_type_id < instance.number_of_item_types();
+            item_type_id < (ItemTypeId)reduction_item_types.size();
             ++item_type_id) {
-        const ItemType& item_type = instance.item_type(item_type_id);
-        Length value = (width_axis)? item_type.rect.x: item_type.rect.y;
-        Length rotated_value = (width_axis)? item_type.rect.y: item_type.rect.x;
-        for (ItemPos copy = 0; copy < item_type.copies; ++copy) {
+        const ReductionItemType& item = reduction_item_types[item_type_id];
+        if (item.removed)
+            continue;
+        bool oriented = original_instance.item_type(item_type_id).oriented;
+        Length value = (width_axis)? item.rect.x: item.rect.y;
+        Length rotated_value = (width_axis)? item.rect.y: item.rect.x;
+        for (ItemPos copy = 0; copy < item.copies; ++copy) {
             mcss_instance_builder.add_item(mcss_group_id, value);
-            if (!item_type.oriented && rotated_value != value)
+            if (!oriented && rotated_value != value)
                 mcss_instance_builder.add_item(mcss_group_id, rotated_value);
             ++mcss_group_id;
         }
@@ -1230,50 +1394,51 @@ Length max_achievable_dimension_sum(
     return mcss_output.bound;
 }
 
-}
-
-Reduction::ShrunkBinSizes Reduction::compute_shrunk_bin_sizes(
-        const Instance& instance)
+bool Reduction::compute_shrunk_bin_sizes(
+        const std::vector<ReductionItemType>& reduction_item_types,
+        ShrunkBinSizes& shrunk_bin_sizes) const
 {
-    ShrunkBinSizes result;
-
-    if (instance.number_of_bin_types() != 1) {
-        result.bin_width = 0;
-        result.bin_height = 0;
-        return result;
+    if (original_instance_->number_of_bin_types() != 1) {
+        shrunk_bin_sizes.bin_width = 0;
+        shrunk_bin_sizes.bin_height = 0;
+        return false;
     }
-    const BinType& bin_type = instance.bin_type(0);
-    result.bin_width = bin_type.rect.x;
-    result.bin_height = bin_type.rect.y;
+    const BinType& bin_type = original_instance_->bin_type(0);
+    shrunk_bin_sizes.bin_width = bin_type.rect.x;
+    shrunk_bin_sizes.bin_height = bin_type.rect.y;
 
-    // Infinite item copies can't be flattened into individual groups; the
-    // technique isn't meaningful there anyway (an infinite-copies item
-    // type can already saturate any capacity on its own), so skip it and
-    // return the bin's own, unshrunk dimensions.
     for (ItemTypeId item_type_id = 0;
-            item_type_id < instance.number_of_item_types();
+            item_type_id < (ItemTypeId)reduction_item_types.size();
             ++item_type_id) {
-        if (instance.item_type(item_type_id).copies < 0)
-            return result;
+        if (!reduction_item_types[item_type_id].removed
+                && reduction_item_types[item_type_id].copies < 0)
+            return false;
     }
 
     // Equation (7): shrink the bin width/height to the largest achievable
     // combination of item widths/heights.
-    result.bin_width = max_achievable_dimension_sum(instance, bin_type.rect.x, /* width_axis */ true);
-    result.bin_height = max_achievable_dimension_sum(instance, bin_type.rect.y, /* width_axis */ false);
+    shrunk_bin_sizes.bin_width = max_achievable_dimension_sum(
+            reduction_item_types, *original_instance_, bin_type.rect.x, /* width_axis */ true);
+    shrunk_bin_sizes.bin_height = max_achievable_dimension_sum(
+            reduction_item_types, *original_instance_, bin_type.rect.y, /* width_axis */ false);
 
-    return result;
+    return true;
 }
 
-bool Reduction::applies(
-        const Instance& instance,
-        const ReductionParameters& parameters)
+bool Reduction::companion_absorption_applies(const Instance& instance)
 {
-    // Every check this class performs (the wide/tall/both companion-bin
-    // feasibility solves in 'try_reduce_group', and the direct
-    // dimension-only matches in 'reduce_full_bin_items'/
+    // Only sound for these three objectives - see the class-level doc
+    // comment's "Companion absorption" paragraph.
+    if (instance.objective() != Objective::BinPacking
+            && instance.objective() != Objective::VariableSizedBinPacking
+            && instance.objective() != Objective::Feasibility)
+        return false;
+
+    // Every check companion absorption performs (the wide/tall/both
+    // companion-bin feasibility solves in 'try_reduce_group', and the
+    // direct dimension-only matches in 'reduce_full_bin_items'/
     // 'reduce_perfect_pairs') reasons purely about geometry: whether a set
-    // of item footprints fits together inside an empty rectangle. Three
+    // of item footprints fits together inside an empty rectangle. Four
     // instance features break that:
     //
     // - Defects: the companion-bin sub-instances built in
@@ -1309,15 +1474,14 @@ bool Reduction::applies(
     //   itself only ever see the validated-enlarged item's own
     //   consumption, never its companions', so it could not correctly
     //   enforce the resource's capacity across the bin either.
-    return (instance.objective() == Objective::BinPacking
-                || instance.objective() == Objective::VariableSizedBinPacking
-                || instance.objective() == Objective::Feasibility)
-            && instance.number_of_bin_types() == 1
+    //
+    // Also only for instances with a single bin type - see the class-level
+    // doc comment's "Companion absorption" paragraph.
+    return instance.number_of_bin_types() == 1
             && instance.number_of_defects() == 0
             && instance.unloading_constraint() == UnloadingConstraint::None
             && !instance.weight_matters()
-            && !instance.resources_matter()
-            && parameters.reduce;
+            && !instance.resources_matter();
 }
 
 Reduction::Reduction(
@@ -1328,17 +1492,16 @@ Reduction::Reduction(
 {
     // Working representation: a stable 1:1 copy of the original instance's
     // item types (see 'ReductionItemType'). Always built and compacted
-    // back via 'reduction_to_instance' at the end (even when the
-    // reduction doesn't apply below, in which case it is an identity
-    // rebuild): this keeps 'final_item_types_'/
-    // 'reduced_to_original_item_type_ids_' always populated, so
-    // 'unreduce_solution' never needs a separate no-op code path. Callers
-    // that already know 'applies()' is 'false' are better off not
-    // constructing a 'Reduction' at all (see 'applies''s own doc comment)
-    // - but the constructor still handles that case correctly, both for
-    // simplicity (one code path regardless of caller diligence) and
-    // because 'applies()' and the constructor could otherwise silently
-    // drift out of sync.
+    // back via 'reduction_to_instance' at the end (even when
+    // 'parameters.reduce' is 'false' below, in which case it is an
+    // identity rebuild): this keeps 'final_item_types_'/
+    // 'reduced_copy_origins_' always populated, so 'unreduce_solution'
+    // never needs a separate no-op code path. Callers that already know
+    // 'parameters.reduce' is 'false' are better off not constructing a
+    // 'Reduction' at all - but the constructor still handles that case
+    // correctly, both for simplicity (one code path regardless of caller
+    // diligence) and to avoid a second, redundant place that would need
+    // to stay in sync with it.
     std::vector<ReductionItemType> reduction_item_types(instance.number_of_item_types());
     for (ItemTypeId item_type_id = 0;
             item_type_id < instance.number_of_item_types();
@@ -1347,64 +1510,82 @@ Reduction::Reduction(
         reduction_item_types[item_type_id].copies = instance.item_type(item_type_id).copies;
     }
 
-    if (!applies(instance, parameters)) {
+    if (!parameters.reduce) {
         instance_ = reduction_to_instance(reduction_item_types);
         return;
     }
 
-    // Shrunk bin dimensions (equation (7), "shrinking the bins": see
-    // 'compute_shrunk_bin_sizes'), computed once from the *original*,
-    // never-reduced instance's full item set - not per round. This stays
-    // sound throughout every round despite items later being removed: the
-    // bound proves "no item in the original full set is small enough to
-    // extend this achieved sum", and every item ever considered in a later
-    // round is a subset of that same original full set, so the bound only
-    // ever remains valid (if anything, recomputing it from a shrinking
-    // remaining set could tighten it further, but that is a possible
-    // future improvement, not a soundness requirement).
-    //
-    // Used as the effective bin dimensions throughout this whole class
-    // ('is_big', 'could_fit', 'companion_bin_dimensions', enlargement
-    // targets, 'reduce_full_bin_items', 'reduce_perfect_pairs'): any
-    // multi-item combination that fits within the *true* bin capacity is,
-    // by definition of 'shrunk_bin_w'/'shrunk_bin_h' as the maximum
-    // achievable subset-sum from the full original item set, already
-    // bounded by it - so substituting it for the true dimensions never
-    // discards a genuinely achievable candidate, and the true bin's
-    // remaining margin beyond it is provably unusable by any combination
-    // of the actual items.
-    ShrunkBinSizes shrunk_bin_sizes = compute_shrunk_bin_sizes(instance);
-    Length bin_w = shrunk_bin_sizes.bin_width;
-    Length bin_h = shrunk_bin_sizes.bin_height;
+    // Every sub-operation below is independently gated by its own
+    // 'parameters' flag - see 'ReductionParameters''s own doc comments -
+    // on top of 'companion_absorption_applies' for the four companion-
+    // absorption ones (wide/tall, both, full-bin items, perfect pairs;
+    // see 'companion_absorption_applies''s own doc comment for why those
+    // four specifically share one precondition that 'merge_identical_items'
+    // does not).
+    bool companion_absorption_ok = companion_absorption_applies(instance);
+    bool run_wide_tall = companion_absorption_ok && parameters.enlarge_wide_tall_items;
+    bool run_both = companion_absorption_ok && parameters.enlarge_both_items;
+    bool run_full_bin_items = companion_absorption_ok && parameters.reduce_full_bin_items;
+    bool run_perfect_pairs = companion_absorption_ok && parameters.reduce_perfect_pairs;
 
-    // Outer fixpoint loop: repeat {wide, tall, both, full-bin items,
+    // Main reduction loop: repeat {wide, tall, both, full-bin items,
     // perfect pairs} until a full pass finds nothing new (a later case's
     // success can free up items that make an earlier case worth
-    // retrying).
+    // retrying). Runs unconditionally, even when every 'run_*' flag above
+    // is 'false': the first round then finds nothing (every sub-operation
+    // below is skipped) and the loop exits immediately after it, same end
+    // result as skipping the loop outright, without needing a separate
+    // guard here to special-case it.
     for (Counter round_number = 0;
             round_number < parameters.maximum_number_of_rounds;
             ++round_number) {
         if (parameters.timer.needs_to_end())
             break;
+
+        // Shrunk bin dimensions (equation (7), "shrinking the bins": see
+        // 'compute_shrunk_bin_sizes'), recomputed every round from
+        // 'reduction_item_types''s then-current, still-remaining item set
+        // - see 'compute_shrunk_bin_sizes''s own doc comment for why
+        // excluding already-'removed' item types only ever tightens this
+        // bound, never understates it: once an item type is the only one
+        // left, the bound correctly collapses to exactly its own current
+        // dimensions, letting 'reduce_full_bin_items' below claim it as a
+        // dedicated bin even when its dimensions never matched the
+        // *true* bin - a sound, more aggressive equivalent encoding of
+        // the same physical solution, not a different one, since nothing
+        // else remains that could ever share a bin with it anyway.
+        ShrunkBinSizes shrunk_bin_sizes;
+        compute_shrunk_bin_sizes(reduction_item_types, shrunk_bin_sizes);
+        Length bin_w = shrunk_bin_sizes.bin_width;
+        Length bin_h = shrunk_bin_sizes.bin_height;
+
         bool found = false;
-        found |= reduce_group(reduction_item_types, parameters, EnlargementCase::Wide, bin_w, bin_h);
+        if (run_wide_tall)
+            found |= reduce_group(reduction_item_types, parameters, EnlargementCase::Wide, bin_w, bin_h);
         if (parameters.timer.needs_to_end())
             break;
-        found |= reduce_group(reduction_item_types, parameters, EnlargementCase::Tall, bin_w, bin_h);
+        if (run_wide_tall)
+            found |= reduce_group(reduction_item_types, parameters, EnlargementCase::Tall, bin_w, bin_h);
         if (parameters.timer.needs_to_end())
             break;
-        found |= reduce_both_groups(reduction_item_types, parameters, bin_w, bin_h);
+        if (run_both)
+            found |= reduce_both_groups(reduction_item_types, parameters, bin_w, bin_h);
         if (parameters.timer.needs_to_end())
             break;
-        found |= reduce_full_bin_items(
-                reduction_item_types, bin_w, bin_h);
+        if (run_full_bin_items)
+            found |= reduce_full_bin_items(
+                    reduction_item_types, bin_w, bin_h);
         if (parameters.timer.needs_to_end())
             break;
-        found |= reduce_perfect_pairs(
-                reduction_item_types, bin_w, bin_h);
+        if (run_perfect_pairs)
+            found |= reduce_perfect_pairs(
+                    reduction_item_types, bin_w, bin_h);
         if (!found)
             break;
     }
+
+    if (!parameters.timer.needs_to_end() && parameters.merge_identical_items)
+        merge_identical_items(reduction_item_types);
 
     instance_ = reduction_to_instance(reduction_item_types);
 }
@@ -1438,9 +1619,13 @@ Solution Reduction::unreduce_solution(
     SolutionBuilder solution_builder(*original_instance_);
 
     // For each reduced item type, how many of its placements have been
-    // encountered so far while scanning 'solution' (used to pick the right
-    // entry of 'companions_by_copy' - any consistent order works, since
-    // companion-bin instances of the same type are interchangeable).
+    // encountered so far while scanning 'solution' - indexes both
+    // 'reduced_copy_origins_' (to resolve which original item type/copy a
+    // given placement actually is - see 'merge_identical_items') and, once
+    // resolved, that original item type's own 'companions_by_copy' (any
+    // consistent order works for either, since a reduced item type's
+    // copies are interchangeable by construction, whether from companion
+    // enlargement or from a merge).
     std::vector<ItemPos> next_copy_index(instance_.number_of_item_types(), 0);
 
     for (BinPos bin_pos = 0;
@@ -1450,16 +1635,16 @@ Solution Reduction::unreduce_solution(
         for (BinPos copy = 0; copy < solution_bin.copies; ++copy) {
             BinPos new_bin_pos = solution_builder.add_bin(solution_bin.bin_type_id, 1);
             for (const SolutionItem& solution_item: solution_bin.items) {
-                ItemTypeId original_item_type_id =
-                    reduced_to_original_item_type_ids_[solution_item.item_type_id];
+                ItemPos reduced_copy_index = next_copy_index[solution_item.item_type_id]++;
+                const CopyOrigin& origin
+                    = reduced_copy_origins_[solution_item.item_type_id][reduced_copy_index];
+                ItemTypeId original_item_type_id = origin.item_type_id;
                 const ReductionItemType& item_type = final_item_types_[original_item_type_id];
 
                 std::vector<CompanionItem> no_companions;
                 const std::vector<CompanionItem>* companions = &no_companions;
-                if (!item_type.companions_by_copy.empty()) {
-                    ItemPos copy_index = next_copy_index[solution_item.item_type_id]++;
-                    companions = &item_type.companions_by_copy[copy_index];
-                }
+                if (!item_type.companions_by_copy.empty())
+                    companions = &item_type.companions_by_copy[origin.copy_index];
                 place_item_and_companions(
                         solution_builder,
                         new_bin_pos,

--- a/test/rectangle/reduction_test.cpp
+++ b/test/rectangle/reduction_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <map>
 #include <sstream>
 
@@ -96,7 +97,17 @@ TEST(RectangleReduction, TallItemWithNarrowCompanionsExactFit)
     // Bin 10x10. Item 0 (4x8) is tall (8 > 10/2) but not wide (4 <= 5):
     // its companion strip is (4, 2). Items 1 (1x2) and 2 (3x2) - neither
     // wide nor tall themselves - exactly tile that strip side by side
-    // (1 + 3 = 4).
+    // (1 + 3 = 4). Item 0 is validated-tall-enlarged to (4, 10), consuming
+    // both companions - at which point it is the *only* item type left in
+    // the working representation, so 'compute_shrunk_bin_sizes' (now
+    // recomputed every round from the then-current, still-remaining item
+    // set - see the constructor's own comment) finds nothing left that
+    // could ever share a bin with it: the recomputed shrunk bin exactly
+    // equals item 0's own (4, 10), so 'reduce_full_bin_items' claims it
+    // as a dedicated bin instead of leaving it as an ordinary item type in
+    // the reduced instance - an equivalent, more aggressive encoding of
+    // the exact same physical solution (one bin holding item 0 and its
+    // two companions), not a different one.
     InstanceBuilder instance_builder;
     instance_builder.set_objective(Objective::BinPacking);
     BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
@@ -110,13 +121,10 @@ TEST(RectangleReduction, TallItemWithNarrowCompanionsExactFit)
     Instance instance = instance_builder.build();
 
     Reduction reduction(instance);
-    ASSERT_EQ(reduction.instance().number_of_item_types(), 1);
-    EXPECT_EQ(reduction.instance().item_type(0).rect.x, 4);
-    EXPECT_EQ(reduction.instance().item_type(0).rect.y, 10);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
 
     SolutionBuilder reduced_solution_builder(reduction.instance());
-    BinPos bin_pos = reduced_solution_builder.add_bin(0, 1);
-    reduced_solution_builder.add_item(bin_pos, 0, Point{0, 0}, false);
     Solution reduced_solution = reduced_solution_builder.build();
 
     Solution solution = reduction.unreduce_solution(reduced_solution);
@@ -370,10 +378,17 @@ TEST(RectangleReduction, PerfectPairLimitedByFiniteBinCopies)
     // Bin 10x10 with only 1 copy available (Feasibility objective). Items 0
     // and 1 (5x10 each, 2 copies each) would tile the bin exactly, twice
     // over (needing 2 dedicated bins), but only 1 bin copy exists in total:
-    // the reduction must not reserve more dedicated bins than the bin type
-    // actually has copies for, leaving both item types for the underlying
-    // solver instead (which, with only 1 bin available for 2 copies of
-    // each item, correctly proves the instance infeasible).
+    // 'reduce_perfect_pairs' must not reserve more dedicated bins than the
+    // bin type actually has copies for, leaving both item types present
+    // (which, with only 1 bin available for 2 copies of each item, lets
+    // the underlying solver correctly prove the instance infeasible).
+    //
+    // Items 0 and 1 are also literally identical (same size, oriented, no
+    // resources), so once 'reduce_perfect_pairs' leaves both untouched,
+    // 'merge_identical_items' consolidates them into a single item type
+    // with 4 copies - a second, independent reduction exercised by this
+    // same instance, not a contradiction of the "must not over-reserve"
+    // point above.
     InstanceBuilder instance_builder;
     instance_builder.set_objective(Objective::Feasibility);
     BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
@@ -386,7 +401,8 @@ TEST(RectangleReduction, PerfectPairLimitedByFiniteBinCopies)
 
     Reduction reduction(instance);
     EXPECT_EQ(reduction.number_of_dedicated_bins(), 0);
-    EXPECT_EQ(reduction.instance().number_of_item_types(), 2);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 1);
+    EXPECT_EQ(reduction.instance().item_type(0).copies, 4);
     EXPECT_EQ(reduction.instance().bin_type(0).copies, 1);
 }
 
@@ -732,8 +748,19 @@ TEST(RectangleReduction, TallCompanionlessEnlargementIndependentOfBlockedWideStr
     // strip's own, otherwise-conclusive, empty-margin proof - item 0 must
     // still get tall-companionless-enlarged to (6x10) independently of
     // the wide strip's outcome, at which point it exactly matches item 1
-    // (4x10) as a 'PerfectPair' (6+4=10), leaving item 2 untouched in the
-    // reduced instance.
+    // (4x10) as a 'PerfectPair' (6+4=10), leaving item 2 alone in the
+    // working representation afterwards. At that point item 2 is the
+    // *only* item type left, so the next round's recomputed
+    // 'compute_shrunk_bin_sizes' (now recomputed every round from the
+    // then-current, still-remaining item set - see the constructor's own
+    // comment) finds nothing left that could ever share a bin with it:
+    // the recomputed shrunk bin exactly equals item 2's own (4, 2), so
+    // 'reduce_full_bin_items' claims it as a second dedicated bin too,
+    // instead of leaving it as an ordinary item type in the (now empty)
+    // reduced instance - an equivalent, more aggressive encoding of the
+    // exact same physical solution (item 2 was always going to end up
+    // alone in its own second bin regardless, since the perfect pair's
+    // own dedicated bin already has no room left for it).
     InstanceBuilder instance_builder;
     instance_builder.set_objective(Objective::BinPacking);
     BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
@@ -747,14 +774,10 @@ TEST(RectangleReduction, TallCompanionlessEnlargementIndependentOfBlockedWideStr
     Instance instance = instance_builder.build();
 
     Reduction reduction(instance);
-    ASSERT_EQ(reduction.instance().number_of_item_types(), 1);
-    EXPECT_EQ(reduction.instance().item_type(0).rect.x, 4);
-    EXPECT_EQ(reduction.instance().item_type(0).rect.y, 2);
-    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 2);
 
     SolutionBuilder reduced_solution_builder(reduction.instance());
-    BinPos bin_pos = reduced_solution_builder.add_bin(0, 1);
-    reduced_solution_builder.add_item(bin_pos, 0, Point{0, 0}, false);
     Solution reduced_solution = reduced_solution_builder.build();
 
     Solution solution = reduction.unreduce_solution(reduced_solution);
@@ -908,7 +931,19 @@ TEST(RectangleReduction, ShrunkBinViaMultipleCopiesOfSameItem)
     // - the target height (9) is unreachable from any smaller number of
     // copies. Item 0 gets validated-tall-enlarged to 5x9 with all three
     // copies of item 1 as its real companions, rather than to the bin's
-    // true height (10).
+    // true height (10). At that point item 0 is the *only* item type left
+    // in the working representation, so the next round's recomputed
+    // 'compute_shrunk_bin_sizes' (now recomputed every round from the
+    // then-current, still-remaining item set - see the constructor's own
+    // comment) finds nothing left that could ever share a bin with it:
+    // the recomputed shrunk width collapses to item 0's own width (5, its
+    // only remaining candidate on that axis, well short of the bin's true
+    // 20), which together with the unchanged shrunk height (9) exactly
+    // equals item 0's own (5, 9) - so 'reduce_full_bin_items' claims it as
+    // a dedicated bin instead of leaving it as an ordinary item type in
+    // the reduced instance, an equivalent, more aggressive encoding of
+    // the exact same physical solution (one bin holding item 0 and its
+    // three companions).
     InstanceBuilder instance_builder;
     instance_builder.set_objective(Objective::BinPacking);
     BinTypeId bin_type_id = instance_builder.add_bin_type(20, 10);
@@ -920,14 +955,10 @@ TEST(RectangleReduction, ShrunkBinViaMultipleCopiesOfSameItem)
     Instance instance = instance_builder.build();
 
     Reduction reduction(instance);
-    ASSERT_EQ(reduction.instance().number_of_item_types(), 1);
-    EXPECT_EQ(reduction.instance().item_type(0).rect.x, 5);
-    EXPECT_EQ(reduction.instance().item_type(0).rect.y, 9);
-    EXPECT_EQ(reduction.number_of_dedicated_bins(), 0);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 0);
+    EXPECT_EQ(reduction.number_of_dedicated_bins(), 1);
 
     SolutionBuilder reduced_solution_builder(reduction.instance());
-    BinPos bin_pos = reduced_solution_builder.add_bin(0, 1);
-    reduced_solution_builder.add_item(bin_pos, 0, Point{0, 0}, false);
     Solution reduced_solution = reduced_solution_builder.build();
 
     Solution solution = reduction.unreduce_solution(reduced_solution);
@@ -1081,4 +1112,218 @@ TEST(RectangleReduction, ReductionStillAppliesWithFiniteWeightButZeroItemWeights
     Reduction reduction(instance);
     EXPECT_EQ(reduction.instance().number_of_item_types(), 0);
     EXPECT_EQ(reduction.number_of_dedicated_bins(), 2);
+}
+
+TEST(RectangleReduction, MergeIdenticalItems)
+{
+    // Bin 100x100 (much larger than either item, so no wide/tall/both/
+    // full-bin/perfect-pair reduction ever triggers - this exercises
+    // 'merge_identical_items' in isolation). Two item types, both 4x4,
+    // oriented, no profit/weight/group/eligibility/resources set (so
+    // identical on every property 'items_mergeable' checks): they merge
+    // into a single item type with the combined copies.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(100, 100);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(4, 4, true);
+    instance_builder.set_item_type_copies(0, 3);
+    instance_builder.add_item_type(4, 4, true);
+    instance_builder.set_item_type_copies(1, 2);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 1);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.x, 4);
+    EXPECT_EQ(reduction.instance().item_type(0).rect.y, 4);
+    EXPECT_EQ(reduction.instance().item_type(0).copies, 5);
+}
+
+TEST(RectangleReduction, MergeIdenticalItemsDifferentProfitStillMerges)
+{
+    // Same as 'MergeIdenticalItems', but the two item types have different
+    // profit - not compared by 'items_mergeable' for this ('BinPacking')
+    // objective (see its own doc comment: profit is never the actual
+    // objective here, and 'unreduce_solution' always restores each placed
+    // copy's own true original profit regardless of merging - unlike for
+    // 'Knapsack', see 'MergeIdenticalItemsKnapsackRequiresMatchingProfit'),
+    // so these two still merge. This is exactly what happens in practice
+    // on real instances: companion absorption enlarges a "wide"/"tall"
+    // item's 'rect' without touching its profit, so two originally
+    // different-sized (and so different-profit) item types can end up with
+    // the same footprint after enlargement, and should still merge.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(100, 100);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(4, 4, true);
+    instance_builder.set_item_type_copies(0, 3);
+    instance_builder.set_item_type_profit(0, 5);
+    instance_builder.add_item_type(4, 4, true);
+    instance_builder.set_item_type_copies(1, 2);
+    instance_builder.set_item_type_profit(1, 10);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 1);
+    EXPECT_EQ(reduction.instance().item_type(0).copies, 5);
+
+    // Confirm 'unreduce_solution' still restores each copy's own true
+    // original profit: build a reduced solution using all 5 copies, then
+    // check the unreduced solution's total profit is the original
+    // per-type total (3 * 5 + 2 * 10 = 35), not 5 times either single
+    // merged profit value (25 or 50).
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    BinPos bin_pos = reduced_solution_builder.add_bin(0, 1);
+    for (ItemPos copy = 0; copy < 5; ++copy)
+        reduced_solution_builder.add_item(bin_pos, 0, Point{4 * (Length)copy, 0}, false);
+    Solution reduced_solution = reduced_solution_builder.build();
+
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    EXPECT_EQ(solution.profit(), 35);
+}
+
+TEST(RectangleReduction, MergeIdenticalItemsKnapsackRequiresMatchingProfit)
+{
+    // Bin 100x100 (large enough that no other reduction ever triggers - see
+    // 'MergeIdenticalItems''s own comment), 'Knapsack' objective. Item
+    // types 0 and 1 (both 4x4, oriented, same profit 5) are identical
+    // including profit and merge; item type 2 (also 4x4, oriented, but
+    // profit 10) is identical on every *other* property but must stay
+    // separate: unlike every other objective this class handles (see
+    // 'MergeIdenticalItemsDifferentProfitStillMerges'), 'Knapsack'
+    // optimizes profit directly over a solve that may legitimately leave
+    // copies unplaced, so merging different-profit item types would report
+    // one uniform profit for every copy and let the solve choose a
+    // suboptimal subset on wrong information.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::Knapsack);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(100, 100);
+    instance_builder.set_bin_type_copies(bin_type_id, 1);
+    instance_builder.add_item_type(4, 4, true);
+    instance_builder.set_item_type_copies(0, 3);
+    instance_builder.set_item_type_profit(0, 5);
+    instance_builder.add_item_type(4, 4, true);
+    instance_builder.set_item_type_copies(1, 2);
+    instance_builder.set_item_type_profit(1, 5);
+    instance_builder.add_item_type(4, 4, true);
+    instance_builder.set_item_type_copies(2, 1);
+    instance_builder.set_item_type_profit(2, 10);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 2);
+    // Whichever survivor absorbed the other has 5 copies (3+2); the one
+    // with the different profit stays alone with 1.
+    ItemPos copies_0 = reduction.instance().item_type(0).copies;
+    ItemPos copies_1 = reduction.instance().item_type(1).copies;
+    EXPECT_EQ(std::min(copies_0, copies_1), 1);
+    EXPECT_EQ(std::max(copies_0, copies_1), 5);
+}
+
+TEST(RectangleReduction, MergeIdenticalItemsWithDefects)
+{
+    // Bin 100x100 with a defect: 'companion_absorption_applies' is 'false'
+    // (defects break every companion-bin geometric check), but
+    // 'merge_identical_items' does not care about defects at all - it
+    // merges two identical, defect-independent item types regardless.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(100, 100);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_defect(bin_type_id, 50, 50, 1, 1);
+    instance_builder.add_item_type(4, 4, true);
+    instance_builder.set_item_type_copies(0, 2);
+    instance_builder.add_item_type(4, 4, true);
+    instance_builder.set_item_type_copies(1, 2);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 1);
+    EXPECT_EQ(reduction.instance().item_type(0).copies, 4);
+}
+
+TEST(RectangleReduction, MergeIdenticalItemsRespectsResources)
+{
+    // Bin 100x100 with one resource. Item types 0 and 1 (both 4x4,
+    // oriented) have the exact same per-copy consumption schedule and
+    // merge; item type 2 (also 4x4, oriented) has a different schedule and
+    // must stay separate - 'resources_matter()' makes
+    // 'companion_absorption_applies' 'false' here too, but
+    // 'merge_identical_items' still runs, now actually checking resource
+    // schedules for equality instead of being blocked outright.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(100, 100);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    ResourceId resource_id = instance_builder.add_bin_type_resource(bin_type_id, 1000);
+    instance_builder.add_item_type(4, 4, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_resource_consumption(bin_type_id, resource_id, 0, 0, 1);
+    instance_builder.add_item_type(4, 4, true);
+    instance_builder.set_item_type_copies(1, 1);
+    instance_builder.add_resource_consumption(bin_type_id, resource_id, 1, 0, 1);
+    instance_builder.add_item_type(4, 4, true);
+    instance_builder.set_item_type_copies(2, 1);
+    instance_builder.add_resource_consumption(bin_type_id, resource_id, 2, 0, 2);
+    Instance instance = instance_builder.build();
+
+    ASSERT_TRUE(instance.resources_matter());
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 2);
+    // Whichever survivor absorbed the other has 2 copies; the one with the
+    // different schedule stays alone with 1.
+    ItemPos copies_0 = reduction.instance().item_type(0).copies;
+    ItemPos copies_1 = reduction.instance().item_type(1).copies;
+    EXPECT_EQ(std::min(copies_0, copies_1), 1);
+    EXPECT_EQ(std::max(copies_0, copies_1), 2);
+}
+
+TEST(RectangleReduction, MergeIdenticalItemsUnreduceSolutionRoundTrip)
+{
+    // Bin 20x20 (taller than the items, unlike the bin's true width -
+    // deliberately, so neither the wide/tall/both companion checks nor
+    // 'reduce_perfect_pairs' find anything: with only these two items in
+    // the whole instance, the "shrunk" bin - see 'compute_shrunk_bin_sizes'
+    // - would collapse to exactly 10x20 (the max achievable combination),
+    // at which point a 20x10 bin's two 5x10 items would look like a
+    // "perfect pair" reaching the shrunk width with each item's height
+    // already matching the shrunk height, consuming them into a dedicated
+    // bin before 'merge_identical_items' ever got a chance to run - not
+    // what this test means to exercise). Item types 0 and 1 (both 5x10,
+    // oriented, 1 copy each) are identical and merge into a single reduced
+    // item type with 2 copies. Placing both reduced copies side by side
+    // and unreducing must recover a valid solution using original item
+    // type ids 0 and 1, each exactly once, at the same positions.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(20, 20);
+    instance_builder.set_bin_type_copies(bin_type_id, -1);
+    instance_builder.add_item_type(5, 10, true);
+    instance_builder.set_item_type_copies(0, 1);
+    instance_builder.add_item_type(5, 10, true);
+    instance_builder.set_item_type_copies(1, 1);
+    Instance instance = instance_builder.build();
+
+    Reduction reduction(instance);
+    ASSERT_EQ(reduction.instance().number_of_item_types(), 1);
+    ASSERT_EQ(reduction.instance().item_type(0).copies, 2);
+
+    SolutionBuilder reduced_solution_builder(reduction.instance());
+    BinPos bin_pos = reduced_solution_builder.add_bin(0, 1);
+    reduced_solution_builder.add_item(bin_pos, 0, Point{0, 0}, false);
+    reduced_solution_builder.add_item(bin_pos, 0, Point{5, 0}, false);
+    Solution reduced_solution = reduced_solution_builder.build();
+
+    Solution solution = reduction.unreduce_solution(reduced_solution);
+    EXPECT_TRUE(solution.full());
+    ASSERT_EQ(solution.bin(0).items.size(), 2);
+    expect_geometrically_valid(solution);
+
+    std::vector<ItemTypeId> used_original_ids;
+    for (const SolutionItem& item: solution.bin(0).items)
+        used_original_ids.push_back(item.item_type_id);
+    std::sort(used_original_ids.begin(), used_original_ids.end());
+    EXPECT_EQ(used_original_ids, std::vector<ItemTypeId>({0, 1}));
 }


### PR DESCRIPTION
## Summary
- Removes `Reduction::applies()`; the reduction now runs whenever `parameters.reduce` is set, with each sub-operation independently gated: companion absorption (wide/tall, both, full-bin items, perfect pairs) still requires `companion_absorption_applies` (its own, narrower objective/instance precondition - `BinPacking`/`VariableSizedBinPacking`/`Feasibility`, single bin type, no defects/unloading constraint/weight/resources), while the new `merge_identical_items` operation runs for any objective.
- Adds `merge_identical_items`: folds interchangeable item types (same footprint, orientation, weight, group, eligibility, resource consumption schedule, and mandatory/optional copies status) into a single item type with combined copies - a merged item's copies stay fully visible and independently placed in the reduced instance, so it doesn't need companion absorption's stricter preconditions.
- Adds per-sub-operation enable/disable flags to `ReductionParameters` (`enlarge_wide_tall_items`, `enlarge_both_items`, `reduce_full_bin_items`, `reduce_perfect_pairs`, `merge_identical_items`).
- Recomputes the "shrinking the bins" (equation (7)) bound every round from the then-current, still-remaining item set instead of once upfront - excluding already-absorbed item types only ever tightens the bound, correctly letting the last remaining item type in a group be recognized as needing its own dedicated bin even when its own dimensions never matched the bin's true ones.

## Test plan
- [x] `cmake --build build_debug_claude --target PackingSolver_rectangle_main PackingSolver_rectangle_test`
- [x] `./build_debug_claude/test/rectangle/PackingSolver_rectangle_test` - 88/88 tests pass