### PR TITLE
column_generation: generalize subset-row cuts to cardinality 5 and 7

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -110,7 +110,7 @@ set(COLUMNGENERATIONSOLVER_BUILD_EXAMPLES OFF)
 FetchContent_Declare(
     columngenerationsolver
     GIT_REPOSITORY https://github.com/fontanf/columngenerationsolver.git
-    GIT_TAG b9b2761203531ca26edabddc47116c50b865775b
+    GIT_TAG f1e1f101b411c586f34b5dec6e4e0b83cb7fc6b9
     #SOURCE_DIR "${PROJECT_SOURCE_DIR}/../columngenerationsolver/"
     EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(columngenerationsolver)

--- a/src/algorithms/column_generation.hpp
+++ b/src/algorithms/column_generation.hpp
@@ -54,6 +54,7 @@
 #include <set>
 #include <sstream>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace packingsolver
 {
@@ -65,30 +66,39 @@ using CutIdx = columngenerationsolver::CutIdx;
 using PricingOutput = columngenerationsolver::PricingSolver::PricingOutput;
 
 /**
- * Data specific to a subset-row cut of cardinality three (Jepsen, Petersen,
- * Spoorendonk & Pisinger 2008; used for the SR cuts of wang2025_bin_packing):
- * given three item types, at most one generated column/pattern may contain
- * two or more of them, i.e. sum_{p: pattern p contains >= 2 of the triplet}
- * xi_p <= 1.
+ * Data specific to a subset-row cut of generalized cardinality (Jepsen,
+ * Petersen, Spoorendonk & Pisinger 2008 introduce the cardinality-three case,
+ * used for the SR cuts of wang2025_bin_packing; the same multiplier-1/2
+ * Chvatal-Gomory rounding argument generalizes to any larger subset, as in
+ * the "extended" subset-row cuts used in VRP branch-cut-and-price): given a
+ * subset of item types, summing their demand-exactly-1 row equalities with
+ * multiplier 1/2 each and rounding down gives
+ * sum_{p: pattern p contains >= 2 of the subset} floor(|subset ∩ p| / 2) xi_p
+ *     <= floor(|item_type_ids.size()| / 2).
+ * The cardinality-three case is the special case where the right-hand side
+ * is 1 and the left-hand side coefficient is 0/1 valued ("at most one
+ * pattern contains >= 2 of the triplet").
  *
  * Stored in 'Cut::extra' (tagged by 'Cut::name == subset_row_cut_name'):
  * 'columngenerationsolver::Cut' is a concrete, uniform type - cut families
  * are told apart by 'extra', not by subclassing (see 'Cut' in
  * columngenerationsolver). 'item_type_ids' is always kept sorted (by
- * 'build_subset_row_cut' below), so two cuts over the same triple compare
- * equal by simple array comparison - see 'ColumnGenerationPricingSolver::
+ * 'build_subset_row_cut' below), so two cuts over the same subset compare
+ * equal by simple vector comparison - see 'ColumnGenerationPricingSolver::
  * equal' below.
  */
 struct SubsetRowCutExtra
 {
-    std::array<ItemTypeId, 3> item_type_ids;
+    std::vector<ItemTypeId> item_type_ids;
 };
 
 /** Tag used to recognize a subset-row cut among 'Cut::extra' payloads. */
 const std::string subset_row_cut_name = "subset_row";
 
 /**
- * Build a subset-row cut over the given item type triple.
+ * Build a subset-row cut over the given item type subset (cardinality >= 3
+ * - see 'SubsetRowCutExtra' above for the general formula; cardinality 3 is
+ * the original Jepsen et al. triple).
  *
  * Coefficient computation is not attached to the cut itself (see 'Cut' in
  * columngenerationsolver): 'ColumnGenerationPricingSolver::coefficient'
@@ -103,17 +113,16 @@ const std::string subset_row_cut_name = "subset_row";
  * for domains whose 'InstanceBuilder' supports resources.
  */
 inline std::shared_ptr<Cut> build_subset_row_cut(
-        ItemTypeId item_type_id_1,
-        ItemTypeId item_type_id_2,
-        ItemTypeId item_type_id_3)
+        std::vector<ItemTypeId> item_type_ids)
 {
+    std::sort(item_type_ids.begin(), item_type_ids.end());
+
     auto extra = std::make_shared<SubsetRowCutExtra>();
-    extra->item_type_ids = {item_type_id_1, item_type_id_2, item_type_id_3};
-    std::sort(extra->item_type_ids.begin(), extra->item_type_ids.end());
+    extra->item_type_ids = item_type_ids;
 
     auto cut = std::make_shared<Cut>();
     cut->name = subset_row_cut_name;
-    cut->upper_bound = 1.0;
+    cut->upper_bound = (Value)(item_type_ids.size() / 2);
     cut->extra = extra;
     return cut;
 }
@@ -133,19 +142,14 @@ public:
             const ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, Output>& pricing_function):
         instance_(instance),
         output_(output),
-        pricing_function_(pricing_function),
-        fixed_bin_types_(instance.number_of_bin_types()),
-        filled_demands_(instance.number_of_item_types()),
-        filled_fixed_demands_(instance.number_of_item_types())
+        pricing_function_(pricing_function)
     { }
-
-    virtual std::vector<std::shared_ptr<const Column>> initialize_pricing(
-            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>& fixed_columns,
-            const std::vector<std::shared_ptr<const columngenerationsolver::Cut>>&,
-            const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&) override;
 
     virtual PricingOutput solve_pricing(
             bool solve_feasibility,
+            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>& fixed_columns,
+            const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&,
+            const std::unordered_set<std::shared_ptr<const columngenerationsolver::Column>>& tabu,
             const std::vector<columngenerationsolver::Value>& duals,
             const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>& cut_duals,
             columngenerationsolver::Counter pricing_level) override;
@@ -159,13 +163,22 @@ public:
      * for every domain that uses this column generation template, not just
      * rectangle.
      *
-     * Candidate triples are restricted to those built from a pair of item
-     * types directly co-occurring in some positive-valued column of
-     * 'solution', extended by a third item type that co-occurs with either
-     * one of the pair in some (possibly different) column: a triple with
-     * no such pairwise evidence anywhere contributes nothing to any cut's
-     * violation yet, so this is a sound (if not exhaustive) pruning of the
-     * full O(n^3) triple search space.
+     * Two passes:
+     * - Cardinality 3: candidate triples are restricted to those built from
+     *   a pair of item types directly co-occurring in some positive-valued
+     *   column of 'solution', extended by a third item type that co-occurs
+     *   with either one of the pair in some (possibly different) column: a
+     *   triple with no such pairwise evidence anywhere contributes nothing
+     *   to any cut's violation yet, so this is a sound (if not exhaustive)
+     *   pruning of the full O(n^3) triple search space.
+     * - Cardinality 5, then 7 (see 'generalized_subset_row_cardinalities'
+     *   below): every co-occurring pair (seeded from pairs rather than
+     *   triples - see this pass's own comment in 'separate_cuts' for why
+     *   ranking by triple weight would miss some violated larger subsets)
+     *   is greedily grown, one item type at a time, up through cardinality
+     *   5 and then 7, checking for a violation at each cardinality along
+     *   the way - picking at each growth step whichever candidate
+     *   maximizes the resulting subset's violation.
      */
     virtual std::vector<std::shared_ptr<const Cut>> separate_cuts(
             const columngenerationsolver::Solution& solution) override;
@@ -195,13 +208,6 @@ private:
     const Output& output_;
 
     ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, Output> pricing_function_;
-
-    std::vector<BinPos> fixed_bin_types_;
-
-    std::vector<double> filled_demands_;
-
-    /** Fixed copies already covered by selected LP columns (per item type). */
-    std::vector<double> filled_fixed_demands_;
 
     /**
      * Cache for the 'VariableSizedBinPacking' 'maximum_number_of_bins'
@@ -268,36 +274,6 @@ columngenerationsolver::Model get_model(
     return model;
 }
 
-template <typename Instance, typename InstanceBuilder, typename Solution, typename Output>
-std::vector<std::shared_ptr<const Column>> ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>::initialize_pricing(
-        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>& fixed_columns,
-        const std::vector<std::shared_ptr<const columngenerationsolver::Cut>>&,
-        const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&)
-{
-    //std::cout << "initialize_pricing " << fixed_columns.size() << std::endl;
-    std::fill(fixed_bin_types_.begin(), fixed_bin_types_.end(), 0);
-    std::fill(filled_demands_.begin(), filled_demands_.end(), 0);
-    std::fill(filled_fixed_demands_.begin(), filled_fixed_demands_.end(), 0);
-    for (auto p: fixed_columns) {
-        const Column& column = *(p.first);
-        Value value = p.second;
-        if (value < 0.5)
-            continue;
-        for (const columngenerationsolver::LinearTerm& element: column.elements) {
-            if (element.row < instance_.number_of_bin_types()) {
-                BinTypeId bin_type_id = element.row;
-                fixed_bin_types_[bin_type_id] += value;
-                for (const auto& fixed_item: instance_.bin_type(bin_type_id).fixed_items)
-                    filled_fixed_demands_[fixed_item.item_type_id] += value;
-            } else {
-                filled_demands_[element.row - instance_.number_of_bin_types()] += value * element.coefficient;
-            }
-        }
-    }
-    //std::cout << "initialize_pricing end" << std::endl;
-    return {};
-}
-
 template <typename Solution>
 std::vector<std::shared_ptr<const Column>> solution_to_columns(
         const Solution& solution)
@@ -352,12 +328,42 @@ std::vector<std::shared_ptr<const Column>> solution_to_columns(
 template <typename Instance, typename InstanceBuilder, typename Solution, typename Output>
 PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>::solve_pricing(
         bool solve_feasibility,
+        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>& fixed_columns,
+        const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&,
+        const std::unordered_set<std::shared_ptr<const columngenerationsolver::Column>>& tabu,
         const std::vector<Value>& duals,
         const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, Value>>& cut_duals,
         columngenerationsolver::Counter)
 {
     double multiplier_cost = largest_power_of_two_lesser_or_equal(instance_.largest_bin_cost());
     double multiplier_profit = largest_power_of_two_lesser_or_equal(instance_.largest_item_profit());
+
+    // 'fixed_columns' and 'tabu' are the same on every call within one
+    // column generation attempt (see 'columngenerationsolver::PricingSolver
+    // ::solve_pricing''s own doc comment on why they're passed here rather
+    // than via a separate one-time setup call), but cheap enough to derive
+    // from unconditionally on every call anyway - no need to cache them
+    // across calls.
+    std::vector<BinPos> fixed_bin_types(instance_.number_of_bin_types(), 0);
+    std::vector<double> filled_demands(instance_.number_of_item_types(), 0);
+    // Fixed copies already covered by selected LP columns (per item type).
+    std::vector<double> filled_fixed_demands(instance_.number_of_item_types(), 0);
+    for (const auto& p: fixed_columns) {
+        const Column& column = *(p.first);
+        Value value = p.second;
+        if (value < 0.5)
+            continue;
+        for (const columngenerationsolver::LinearTerm& element: column.elements) {
+            if (element.row < instance_.number_of_bin_types()) {
+                BinTypeId bin_type_id = element.row;
+                fixed_bin_types[bin_type_id] += value;
+                for (const auto& fixed_item: instance_.bin_type(bin_type_id).fixed_items)
+                    filled_fixed_demands[fixed_item.item_type_id] += value;
+            } else {
+                filled_demands[element.row - instance_.number_of_bin_types()] += value * element.coefficient;
+            }
+        }
+    }
 
     //std::cout << "solve_pricing" << std::endl;
     PricingOutput output;
@@ -368,7 +374,7 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution,
             bin_type_id < instance_.number_of_bin_types();
             ++bin_type_id) {
         const auto& bin_type = instance_.bin_type(bin_type_id);
-        if (fixed_bin_types_[bin_type_id] == bin_type.copies)
+        if (fixed_bin_types[bin_type_id] == bin_type.copies)
             continue;
 
         for (const auto& fixed_item: bin_type.fixed_items)
@@ -415,7 +421,7 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution,
             } else {
                 copies = item_type.copies
                     - item_type.copies_fixed
-                    - (filled_demands_[item_type_id] - filled_fixed_demands_[item_type_id])
+                    - (filled_demands[item_type_id] - filled_fixed_demands[item_type_id])
                     + bin_fixed_copies[item_type_id];
             }
             //std::cout << "item_type_id " << item_type_id << " profit " << profit << std::endl;
@@ -426,18 +432,27 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution,
             kp_instance_builder.set_item_type_copies(kp_item_type_id, copies);
             kp2vbpp.push_back(item_type_id);
         }
+        // Map from vbpp item type id to this round's kp item type id ('-1'
+        // for a vbpp item type excluded from this round's kp instance -
+        // see the 'copies <= 0' skip above). Built once, shared by the
+        // subset-row cut resources below and the tabu no-good cut
+        // resources further down.
+        std::vector<ItemTypeId> vbpp2kp;
+        if (!cut_duals.empty() || !tabu.empty()) {
+            vbpp2kp.assign(instance_.number_of_item_types(), -1);
+            for (ItemTypeId kp_item_type_id = 0;
+                    kp_item_type_id < (ItemTypeId)kp2vbpp.size();
+                    ++kp_item_type_id) {
+                vbpp2kp[kp2vbpp[kp_item_type_id]] = kp_item_type_id;
+            }
+        }
+
         // Apply active subset-row cuts as penalizing resources on the
         // pricing sub-instance's bin type (see 'Resource' in
         // 'packingsolver/algorithms/common.hpp'), so that the tree search
         // actually searches for the best *reduced-cost* pattern instead of
         // just the best raw-profit one.
         if (!cut_duals.empty()) {
-            std::vector<ItemTypeId> vbpp2kp(instance_.number_of_item_types(), -1);
-            for (ItemTypeId kp_item_type_id = 0;
-                    kp_item_type_id < (ItemTypeId)kp2vbpp.size();
-                    ++kp_item_type_id) {
-                vbpp2kp[kp2vbpp[kp_item_type_id]] = kp_item_type_id;
-            }
             for (const auto& cut_dual: cut_duals) {
                 if (cut_dual.first->name != subset_row_cut_name)
                     continue;
@@ -459,14 +474,32 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution,
                 // 'profit -= cut_dual * multiplier_profit' (i.e. 'penalty
                 // = cut_dual * multiplier_profit', scaled the same way the
                 // item duals just above are).
-                // The penalty can only ever trigger once 2 of the 3 item
-                // types are simultaneously present in a generated column
-                // (see 'coefficient' above), so if this bin type's pricing
-                // sub-instance excludes 2 or more of them already (e.g.
-                // because their remaining demand is 0 this round - see the
+                // The cut's coefficient on a generated column is
+                // floor(count / 2), where 'count' is how many of
+                // 'item_type_ids' the column contains (see 'coefficient'
+                // below) - reproduced here as one soft resource per unit of
+                // that coefficient: resource i (capacities 1, 3, 5, ...)
+                // is the first to cross its capacity exactly when 'count'
+                // reaches 2*(i+1), so the number of resources that end up
+                // crossed equals floor(count / 2) exactly, each
+                // independently contributing one 'penalty' ('Resource'
+                // triggers its penalty only once per bin, the first time
+                // consumption crosses its own capacity - see its own doc
+                // comment). This is why the cardinality-3 case (a single
+                // resource of capacity 1) is enough to cap its coefficient
+                // at 1: floor(3 / 2) is still 1, so a second resource would
+                // never be reachable there anyway.
+                //
+                // If this bin type's pricing sub-instance excludes 2 or
+                // more of the subset's item types already (e.g. because
+                // their remaining demand is 0 this round - see the
                 // 'copies <= 0' skip above), no column from it could ever
-                // reach that count and the resource would be a dead weight
-                // in the tree search state for no benefit.
+                // reach count 2, so no resource here could ever be crossed
+                // and building any would be dead weight in the tree search
+                // state for no benefit - same reasoning caps the number of
+                // resources built at 'present_kp_item_type_ids.size() / 2':
+                // no column could ever reach a count high enough to cross
+                // any resource beyond that.
                 std::vector<ItemTypeId> present_kp_item_type_ids;
                 for (ItemTypeId item_type_id: extra.item_type_ids) {
                     if (item_type_id < 0 || item_type_id >= (ItemTypeId)vbpp2kp.size())
@@ -482,19 +515,101 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution,
                 double penalty = (instance_.objective() == Objective::Knapsack)?
                     cut_dual.second * multiplier_profit:
                     -cut_dual.second;
-                ResourceId resource_id = kp_instance_builder.add_bin_type_resource(
-                        kp_bin_type_id,
-                        /* capacity */ 1.0,
-                        /* penalize */ true,
-                        /* penalty */ penalty);
-                for (ItemTypeId kp_item_type_id: present_kp_item_type_ids) {
+                ItemPos number_of_thresholds = (ItemPos)present_kp_item_type_ids.size() / 2;
+                for (ItemPos threshold = 0; threshold < number_of_thresholds; ++threshold) {
+                    ResourceId resource_id = kp_instance_builder.add_bin_type_resource(
+                            kp_bin_type_id,
+                            /* capacity */ 2.0 * threshold + 1.0,
+                            /* penalize */ true,
+                            /* penalty */ penalty);
+                    for (ItemTypeId kp_item_type_id: present_kp_item_type_ids) {
+                        kp_instance_builder.add_resource_consumption(
+                                kp_bin_type_id,
+                                resource_id,
+                                kp_item_type_id,
+                                0,
+                                1.0);
+                    }
+                }
+            }
+        }
+
+        // Forbid regenerating any tabu column's pattern for this bin type,
+        // via a no-good cut expressed as a hard resource (see 'Resource'
+        // in 'packingsolver/algorithms/common.hpp', and the identical
+        // technique - 'threshold_schedule'/'ResourceCut' - already used by
+        // 'rectangle::benders_decomposition' for the same purpose on its
+        // own master problem): a per-item-type schedule capping that item
+        // type's contribution at its copy count in the tabu pattern (a run
+        // of 1's the length of that copy count, followed by a trailing 0
+        // so it stops growing there), with the resource's capacity set to
+        // one less than the sum of all the pattern's item copies, forbids
+        // exactly that pattern - and any pattern using at least as many
+        // copies of every item type in it - without excluding anything
+        // else. Unlike the subset-row resources above, this is a hard
+        // exclusion ('penalize' left at its default 'false'): a tabu
+        // column isn't a priced-in cut with a dual value to trade off
+        // against, it is a pattern the search has already branched away
+        // from and must never regenerate.
+        for (const auto& tabu_column: tabu) {
+            // Identify the bin type this tabu column was generated for -
+            // every column built by this template has exactly one bin
+            // type element, with coefficient 1 (see 'solution_to_columns'
+            // and this function's own column-building loop below).
+            BinTypeId tabu_bin_type_id = -1;
+            for (const columngenerationsolver::LinearTerm& element: tabu_column->elements) {
+                if (element.row < instance_.number_of_bin_types()) {
+                    tabu_bin_type_id = element.row;
+                    break;
+                }
+            }
+            if (tabu_bin_type_id != bin_type_id)
+                continue;
+
+            std::vector<std::pair<ItemTypeId, ItemPos>> present_kp_item_thresholds;
+            double capacity = -1.0;
+            for (const columngenerationsolver::LinearTerm& element: tabu_column->elements) {
+                if (element.row < instance_.number_of_bin_types())
+                    continue;
+                ItemTypeId item_type_id = element.row - instance_.number_of_bin_types();
+                ItemPos threshold = (ItemPos)std::round(element.coefficient);
+                if (threshold <= 0)
+                    continue;
+                capacity += threshold;
+                ItemTypeId kp_item_type_id = vbpp2kp[item_type_id];
+                if (kp_item_type_id == -1)
+                    continue;
+                present_kp_item_thresholds.push_back({kp_item_type_id, threshold});
+            }
+            // If none of the tabu pattern's item types survived into this
+            // round's kp instance, the pattern can't be regenerated this
+            // round regardless (see the 'copies <= 0' skip above), so the
+            // cut would be a dead weight in the tree search state for no
+            // benefit - same reasoning as the subset-row cut's own
+            // '< 2 present' skip above.
+            if (present_kp_item_thresholds.empty())
+                continue;
+
+            ResourceId resource_id = kp_instance_builder.add_bin_type_resource(
+                    kp_bin_type_id,
+                    /* capacity */ capacity);
+            for (const auto& present_kp_item_threshold: present_kp_item_thresholds) {
+                ItemTypeId kp_item_type_id = present_kp_item_threshold.first;
+                ItemPos threshold = present_kp_item_threshold.second;
+                for (ItemPos copy = 0; copy < threshold; ++copy) {
                     kp_instance_builder.add_resource_consumption(
                             kp_bin_type_id,
                             resource_id,
                             kp_item_type_id,
-                            0,
+                            copy,
                             1.0);
                 }
+                kp_instance_builder.add_resource_consumption(
+                        kp_bin_type_id,
+                        resource_id,
+                        kp_item_type_id,
+                        threshold,
+                        0.0);
             }
         }
 
@@ -871,12 +986,12 @@ std::vector<std::shared_ptr<const Cut>> ColumnGenerationPricingSolver<Instance, 
         return (it == pair_columns.end())? empty_columns: it->second;
     };
 
-    struct ViolatedTriple
+    struct ViolatedSubset
     {
-        std::array<ItemTypeId, 3> item_type_ids;
+        std::vector<ItemTypeId> item_type_ids;
         Value violation;
     };
-    std::vector<ViolatedTriple> violated_triples;
+    std::vector<ViolatedSubset> violated_subsets;
     for (const std::array<ItemTypeId, 3>& triple: candidate_triples) {
         ItemTypeId item_type_id_a = triple[0];
         ItemTypeId item_type_id_b = triple[1];
@@ -919,26 +1034,161 @@ std::vector<std::shared_ptr<const Cut>> ColumnGenerationPricingSolver<Instance, 
             + pair_weight_of(item_type_id_b, item_type_id_c)
             - 2.0 * triple_weight
             - 1.0;
-        if (violation > 1e-6)
-            violated_triples.push_back({triple, violation});
+        if (violation > 1e-6) {
+            violated_subsets.push_back({
+                    {item_type_id_a, item_type_id_b, item_type_id_c},
+                    violation});
+        }
+    }
+
+    // Cardinality-5/7 passes (see 'generalized_subset_row_cardinalities'
+    // and the class-level doc comment on this function): grow every
+    // co-occurring pair, one item type at a time, into a subset of the
+    // target cardinality, always adding whichever co-occurrence neighbor
+    // of the current subset maximizes its resulting violation. Evaluated
+    // by direct column scan ('subset_violation' below) rather than the
+    // pairwise inclusion-exclusion trick above: that trick is specific to
+    // counting "exactly 2 vs exactly 3" of a *triple*, it does not
+    // generalize to distinguishing the coefficient 0/1/2/3 bands of a
+    // larger subset.
+    //
+    // Seeded from pairs, not from the strongest candidate triples: ranking
+    // triples by their own combined pairwise weight is biased toward
+    // "triangles" (all 3 pairs co-occurring), but a violated larger subset
+    // need not contain any triangle at all - e.g. a cycle of item types
+    // where only consecutive pairs co-occur has every one of its own
+    // triples scoring worse than an unrelated triangle elsewhere, even
+    // though the full subset is the one that is actually violated. Seeding
+    // from every co-occurring pair instead (there are typically far fewer
+    // distinct pairs than triples, so this stays cheap) avoids that bias:
+    // every edge of such a cycle is its own seed.
+    const std::array<ItemPos, 2> generalized_subset_row_cardinalities = {5, 7};
+    const ItemPos maximum_number_of_extension_seeds = 200;
+    auto subset_violation = [&column_items](const std::vector<ItemTypeId>& subset) -> Value
+    {
+        Value lhs = 0.0;
+        for (const ColumnItems& entry: column_items) {
+            // Both 'subset' and 'entry.item_type_ids' are sorted - count
+            // their intersection via a merge instead of a hash lookup per
+            // element.
+            int count = 0;
+            std::size_t pos_subset = 0;
+            std::size_t pos_entry = 0;
+            while (pos_subset < subset.size() && pos_entry < entry.item_type_ids.size()) {
+                if (subset[pos_subset] == entry.item_type_ids[pos_entry]) {
+                    ++count;
+                    ++pos_subset;
+                    ++pos_entry;
+                } else if (subset[pos_subset] < entry.item_type_ids[pos_entry]) {
+                    ++pos_subset;
+                } else {
+                    ++pos_entry;
+                }
+            }
+            if (count >= 2)
+                lhs += (Value)(count / 2) * entry.value;
+        }
+        return lhs - (Value)(subset.size() / 2);
+    };
+    struct PairScore
+    {
+        ItemTypeId item_type_id_1;
+        ItemTypeId item_type_id_2;
+        Value weight;
+    };
+    std::vector<PairScore> pair_scores;
+    pair_scores.reserve(pair_weight.size());
+    for (const auto& p: pair_weight)
+        pair_scores.push_back({p.first.first, p.first.second, p.second});
+    std::sort(
+            pair_scores.begin(),
+            pair_scores.end(),
+            [](const PairScore& pair_score_1, const PairScore& pair_score_2)
+            {
+                return pair_score_1.weight > pair_score_2.weight;
+            });
+    if ((ItemPos)pair_scores.size() > maximum_number_of_extension_seeds)
+        pair_scores.resize(maximum_number_of_extension_seeds);
+    // Beam width for the growth itself: pure greedy (width 1) reliably gets
+    // trapped on a tie among several "clique-like" candidates (e.g. three
+    // item types that all pairwise co-occur with the seed, none of them
+    // pairwise with each other) that score equally well one step ahead but
+    // lead nowhere, while the extension actually needed to reach a violated
+    // quintuple scores no better at that same first step - a real example
+    // from the fractional point this cardinality-5 extension targets. A
+    // small beam recovers this: even if the needed extension is one of
+    // several tied candidates, it survives into the next step instead of
+    // being discarded for not going first in the tie.
+    const ItemPos extension_beam_width = 10;
+    for (const PairScore& seed: pair_scores) {
+        std::vector<std::vector<ItemTypeId>> beam = {{seed.item_type_id_1, seed.item_type_id_2}};
+        // Grow the same beam through every target cardinality in increasing
+        // order (5, then 7), checking for violations at each checkpoint
+        // along the way: the first 3 growth steps (2 -> 5) are shared work
+        // for both, no need to restart from the pair for cardinality 7.
+        for (ItemPos target_cardinality: generalized_subset_row_cardinalities) {
+            while ((ItemPos)beam.front().size() < target_cardinality) {
+                std::vector<std::pair<std::vector<ItemTypeId>, Value>> candidates;
+                std::set<std::vector<ItemTypeId>> seen;
+                for (const std::vector<ItemTypeId>& partial: beam) {
+                    std::set<ItemTypeId> candidate_pool;
+                    for (ItemTypeId item_type_id: partial) {
+                        for (ItemTypeId neighbor: neighbors[item_type_id])
+                            candidate_pool.insert(neighbor);
+                    }
+                    for (ItemTypeId item_type_id: partial)
+                        candidate_pool.erase(item_type_id);
+                    for (ItemTypeId candidate: candidate_pool) {
+                        std::vector<ItemTypeId> trial = partial;
+                        trial.push_back(candidate);
+                        std::sort(trial.begin(), trial.end());
+                        if (!seen.insert(trial).second)
+                            continue;
+                        candidates.push_back({trial, subset_violation(trial)});
+                    }
+                }
+                // No co-occurrence neighbor left to grow into from any
+                // subset in the beam: stop here, this seed will be
+                // discarded below (and skipped for any larger target
+                // cardinality still to come) for not reaching this one.
+                if (candidates.empty())
+                    break;
+                std::sort(
+                        candidates.begin(),
+                        candidates.end(),
+                        [](const std::pair<std::vector<ItemTypeId>, Value>& candidate_1, const std::pair<std::vector<ItemTypeId>, Value>& candidate_2)
+                        {
+                            return candidate_1.second > candidate_2.second;
+                        });
+                if ((ItemPos)candidates.size() > extension_beam_width)
+                    candidates.resize(extension_beam_width);
+                beam.clear();
+                for (auto& candidate: candidates)
+                    beam.push_back(std::move(candidate.first));
+            }
+            if ((ItemPos)beam.front().size() != target_cardinality)
+                break;
+            for (const std::vector<ItemTypeId>& subset: beam) {
+                Value violation = subset_violation(subset);
+                if (violation > 1e-6)
+                    violated_subsets.push_back({subset, violation});
+            }
+        }
     }
 
     std::sort(
-            violated_triples.begin(),
-            violated_triples.end(),
-            [](const ViolatedTriple& violated_triple_1, const ViolatedTriple& violated_triple_2)
+            violated_subsets.begin(),
+            violated_subsets.end(),
+            [](const ViolatedSubset& violated_subset_1, const ViolatedSubset& violated_subset_2)
             {
-                return violated_triple_1.violation > violated_triple_2.violation;
+                return violated_subset_1.violation > violated_subset_2.violation;
             });
 
     std::vector<std::shared_ptr<const Cut>> new_cuts;
-    for (const ViolatedTriple& violated_triple: violated_triples) {
+    for (const ViolatedSubset& violated_subset: violated_subsets) {
         if ((CutIdx)new_cuts.size() >= maximum_number_of_cuts)
             break;
-        new_cuts.push_back(build_subset_row_cut(
-                violated_triple.item_type_ids[0],
-                violated_triple.item_type_ids[1],
-                violated_triple.item_type_ids[2]));
+        new_cuts.push_back(build_subset_row_cut(violated_subset.item_type_ids));
     }
     return new_cuts;
 }
@@ -956,7 +1206,7 @@ Value ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>
         if (extra_solution.item_copies(item_type_id) > 0)
             number_of_items_present++;
     }
-    return (number_of_items_present >= 2)? 1.0: 0.0;
+    return (Value)(number_of_items_present / 2);
 }
 
 template <typename Instance, typename InstanceBuilder, typename Solution, typename Output>
@@ -965,8 +1215,8 @@ bool ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>:
         const Cut& cut_2) const
 {
     // Both cuts are always subset-row cuts - see 'build_subset_row_cut'
-    // above - and 'item_type_ids' is always kept sorted, so a plain array
-    // comparison recognizes two cuts built over the same triple.
+    // above - and 'item_type_ids' is always kept sorted, so a plain vector
+    // comparison recognizes two cuts built over the same subset.
     const SubsetRowCutExtra& extra_1 = *std::static_pointer_cast<SubsetRowCutExtra>(cut_1.extra);
     const SubsetRowCutExtra& extra_2 = *std::static_pointer_cast<SubsetRowCutExtra>(cut_2.extra);
     return extra_1.item_type_ids == extra_2.item_type_ids;

--- a/src/rectangle/bar_relaxation.cpp
+++ b/src/rectangle/bar_relaxation.cpp
@@ -49,21 +49,19 @@ public:
         link2_row_(link2_row)
     { }
 
-    std::vector<std::shared_ptr<const columngenerationsolver::Column>> initialize_pricing(
-            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>&,
-            const std::vector<std::shared_ptr<const columngenerationsolver::Cut>>&,
-            const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&) override
-    {
-        return {};
-    }
-
     // 'solve_feasibility' unused: every dynamically priced column here
     // already carries a fixed 'objective_coefficient' of 0 (see
     // 'price_bars' below - only the static 'n_{i,t}'/'k_t' columns carry
     // the real objective), so this pricing search's own reduced cost is
     // identical in both phases and needs no phase-specific adjustment.
+    // 'fixed_columns'/'branching_decisions'/'tabu' unused: this pricing
+    // solver has neither fixed/tabu column bookkeeping nor
+    // branching-decision-sensitive behavior of its own.
     columngenerationsolver::PricingSolver::PricingOutput solve_pricing(
             bool solve_feasibility,
+            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>&,
+            const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&,
+            const std::unordered_set<std::shared_ptr<const columngenerationsolver::Column>>&,
             const std::vector<columngenerationsolver::Value>& duals,
             const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&,
             columngenerationsolver::Counter pricing_level) override;
@@ -229,6 +227,9 @@ double BarRelaxationPricingSolver::price_bars(
 
 columngenerationsolver::PricingSolver::PricingOutput BarRelaxationPricingSolver::solve_pricing(
         bool,
+        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>&,
+        const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&,
+        const std::unordered_set<std::shared_ptr<const columngenerationsolver::Column>>&,
         const std::vector<columngenerationsolver::Value>& duals,
         const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&,
         columngenerationsolver::Counter)

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -532,6 +532,7 @@ void optimize_column_generation(
     cg_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     cg_parameters.optimization_mode = parameters.optimization_mode;
     cg_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
+    cg_parameters.use_cutting_planes = 2;
     cg_parameters.new_solution_callback = [&algorithm_formatter, local_output](
             const rectangle::Output& ps_output)
     {

--- a/src/rectangleguillotine/column_generation_strips.cpp
+++ b/src/rectangleguillotine/column_generation_strips.cpp
@@ -40,13 +40,11 @@ public:
         filled_demands_(instance.number_of_item_types())
     { }
 
-    virtual std::vector<std::shared_ptr<const Column>> initialize_pricing(
-            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>& fixed_columns,
-            const std::vector<std::shared_ptr<const columngenerationsolver::Cut>>&,
-            const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&) override;
-
     virtual PricingOutput solve_pricing(
             bool solve_feasibility,
+            const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>& fixed_columns,
+            const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&,
+            const std::unordered_set<std::shared_ptr<const columngenerationsolver::Column>>&,
             const std::vector<columngenerationsolver::Value>& duals,
             const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&,
             columngenerationsolver::Counter pricing_level) override;
@@ -131,17 +129,42 @@ private:
     bool all_columns_3h_patterns_generated_ = false;
 
     /**
-     * True from 'initialize_pricing' until the first 'solve_pricing' call has
-     * generated columns using zero duals (i.e. real profit instead of
-     * reduced profit). This guarantees that, for every diving branch, the
-     * best real-profit column (in particular a single-strip solution, since
-     * every generated strip is also considered as a candidate solution) is
-     * always found regardless of where the master problem's dual values
-     * happen to be, since real-profit-optimal columns do not always become
-     * reduced-cost-optimal at the dual values actually visited by the
-     * search.
+     * True from the start of a column generation attempt (see
+     * 'fixed_columns_signature_' below for how that start is detected, now
+     * that there is no dedicated per-attempt setup call) until the first
+     * 'solve_pricing' call of that attempt has generated columns using zero
+     * duals (i.e. real profit instead of reduced profit). This guarantees
+     * that, for every diving branch, the best real-profit column (in
+     * particular a single-strip solution, since every generated strip is
+     * also considered as a candidate solution) is always found regardless
+     * of where the master problem's dual values happen to be, since real-
+     * profit-optimal columns do not always become reduced-cost-optimal at
+     * the dual values actually visited by the search.
      */
     bool first_pricing_ = true;
+
+    /**
+     * '(column, fixed value)' pairs of 'fixed_columns' as of the last
+     * 'solve_pricing' call, used to detect the start of a new column
+     * generation attempt: per 'columngenerationsolver::PricingSolver::
+     * solve_pricing''s own doc comment, 'fixed_columns' (and the branching
+     * decisions it reflects) are the same on every call within one
+     * attempt, changing only when a new attempt (a different search node)
+     * begins. This one solver instance is reused across the whole limited
+     * discrepancy search tree (see its construction in
+     * 'column_generation_strips' below), so 'filled_demands_'/
+     * 'filled_width_'/'first_pricing_' need this signal to know when to
+     * recompute/reset rather than keep reusing the previous attempt's
+     * values. Compares both the column and its value, not just the column:
+     * a descendant node can re-fix the very same column (same pointer) at
+     * a different value as branching bounds tighten deeper in the tree, so
+     * pointer identity alone is not enough to recognize "still the same
+     * attempt".
+     */
+    std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>> fixed_columns_signature_;
+
+    /** 'false' only before the very first 'solve_pricing' call ever. */
+    bool fixed_columns_signature_initialized_ = false;
 
 };
 
@@ -662,40 +685,6 @@ GetModelOutput get_model(
     }
 
     return output;
-}
-
-std::vector<std::shared_ptr<const Column>> ColumnGenerationPricingSolver::initialize_pricing(
-        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>& fixed_columns,
-        const std::vector<std::shared_ptr<const columngenerationsolver::Cut>>&,
-        const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&)
-{
-    const BinType& bin_type = instance_.bin_type(0);
-    double multiplier_length = largest_power_of_two_lesser_or_equal(bin_type.rect.w);
-    std::fill(filled_demands_.begin(), filled_demands_.end(), 0);
-    filled_width_ = 0;
-    first_pricing_ = true;
-    for (auto p: fixed_columns) {
-        const Column& column = *(p.first);
-        Value value = p.second;
-        for (const columngenerationsolver::LinearTerm& element: column.elements) {
-            if (element.row < instance_.number_of_item_types()) {
-                ItemTypeId item_type_id = element.row;
-                ItemPos copies = instance_.item_type(item_type_id).copies;
-                filled_demands_[item_type_id] += std::round(value) * std::round(element.coefficient);
-                if (filled_demands_[item_type_id] > copies) {
-                    throw std::logic_error(
-                            FUNC_SIGNATURE + "; "
-                            "item_type_id: " + std::to_string(item_type_id) + "; "
-                            "copies: " + std::to_string(copies) + "; "
-                            "filled_demands: " + std::to_string(filled_demands_[item_type_id]) + ".");
-                }
-            } else {
-                filled_width_ += std::round(value) * multiplier_length * element.coefficient;
-            }
-        }
-    }
-    //std::cout << "initialize_pricing end" << std::endl;
-    return {};
 }
 
 void ColumnGenerationPricingSolver::generate_1e_patterns(
@@ -1940,11 +1929,61 @@ void ColumnGenerationPricingSolver::generate_duals_zero(
 
 PricingOutput ColumnGenerationPricingSolver::solve_pricing(
         bool solve_feasibility,
+        const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Column>, columngenerationsolver::Value>>& fixed_columns,
+        const std::vector<std::shared_ptr<const columngenerationsolver::BranchingDecision>>&,
+        const std::unordered_set<std::shared_ptr<const columngenerationsolver::Column>>&,
         const std::vector<columngenerationsolver::Value>& duals,
         const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&,
         columngenerationsolver::Counter)
 {
     //std::cout << "solve_pricing" << std::endl;
+
+    // Detect the start of a new column generation attempt (a different
+    // search node) via 'fixed_columns_signature_' - see its own doc
+    // comment - and (re)do what used to happen once per attempt in
+    // 'initialize_pricing', now folded in here since the framework no
+    // longer calls a separate per-attempt setup hook.
+    bool new_attempt = !fixed_columns_signature_initialized_
+        || fixed_columns.size() != fixed_columns_signature_.size();
+    if (!new_attempt) {
+        for (std::size_t pos = 0; pos < fixed_columns.size(); ++pos) {
+            if (fixed_columns[pos].first != fixed_columns_signature_[pos].first
+                    || fixed_columns[pos].second != fixed_columns_signature_[pos].second) {
+                new_attempt = true;
+                break;
+            }
+        }
+    }
+    if (new_attempt) {
+        fixed_columns_signature_initialized_ = true;
+        fixed_columns_signature_ = fixed_columns;
+
+        const BinType& fixed_bin_type = instance_.bin_type(0);
+        double multiplier_length = largest_power_of_two_lesser_or_equal(fixed_bin_type.rect.w);
+        std::fill(filled_demands_.begin(), filled_demands_.end(), 0);
+        filled_width_ = 0;
+        for (const auto& p: fixed_columns) {
+            const Column& column = *(p.first);
+            Value value = p.second;
+            for (const columngenerationsolver::LinearTerm& element: column.elements) {
+                if (element.row < instance_.number_of_item_types()) {
+                    ItemTypeId item_type_id = element.row;
+                    ItemPos copies = instance_.item_type(item_type_id).copies;
+                    filled_demands_[item_type_id] += std::round(value) * std::round(element.coefficient);
+                    if (filled_demands_[item_type_id] > copies) {
+                        throw std::logic_error(
+                                FUNC_SIGNATURE + "; "
+                                "item_type_id: " + std::to_string(item_type_id) + "; "
+                                "copies: " + std::to_string(copies) + "; "
+                                "filled_demands: " + std::to_string(filled_demands_[item_type_id]) + ".");
+                    }
+                } else {
+                    filled_width_ += std::round(value) * multiplier_length * element.coefficient;
+                }
+            }
+        }
+        first_pricing_ = true;
+    }
 
     const BinType& bin_type = instance_.bin_type(0);
 

--- a/test/rectangle/column_generation_test.cpp
+++ b/test/rectangle/column_generation_test.cpp
@@ -1,8 +1,11 @@
+#include "algorithms/column_generation.hpp"
 #include "packingsolver/rectangle/instance_builder.hpp"
 #include "packingsolver/rectangle/optimize.hpp"
 
 #include <gtest/gtest.h>
 #include <boost/filesystem.hpp>
+
+#include <unordered_set>
 
 using namespace packingsolver;
 using namespace packingsolver::rectangle;
@@ -164,3 +167,243 @@ INSTANTIATE_TEST_SUITE_P(
                 fs::path("data") / "rectangle" / "tests" / "variable_sized_bin_packing" / "parameters.csv",
                 1,
             }}));
+
+////////////////////////////////////////////////////////////////////////////////
+///////////////////// RectangleSubsetRowCardinality5Test /////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+using CgsColumn = columngenerationsolver::Column;
+using CgsModel = columngenerationsolver::Model;
+using CgsSolution = columngenerationsolver::Solution;
+using CgsSolutionBuilder = columngenerationsolver::SolutionBuilder;
+
+std::shared_ptr<const CgsColumn> make_column(
+        BinTypeId bin_type_id,
+        const std::vector<ItemTypeId>& item_type_ids,
+        BinTypeId number_of_bin_types)
+{
+    auto column = std::make_shared<CgsColumn>();
+    column->elements.push_back({bin_type_id, 1.0});
+    for (ItemTypeId item_type_id: item_type_ids)
+        column->elements.push_back({number_of_bin_types + item_type_id, 1.0});
+    return column;
+}
+
+}
+
+TEST(RectangleSubsetRowCardinality5Test, SeparatesCardinality5Cut)
+{
+    // Reproduces, item-type-id for item-type-id, a fractional LP node from
+    // a real run: 18 item types (mapped here to item type ids 0..17, in the
+    // same order as the original row ids
+    // 12,14,16,19,22,24,27,32,38,40,42,45,51,53,57,58,60,62), 16 fractional
+    // columns. Several candidate triples over these columns are violated
+    // (confirmed independently by exhaustive search over the raw numbers),
+    // the strongest by 0.384615 - but several 5-item-type subsets are
+    // violated by a full 0.5, more than any triple, so the single cut
+    // 'separate_cuts' returns (capped at 1 per round) should be one of
+    // those quintuples, not the best triple. This checks that ranking
+    // actually happens, not just that the math works out on paper.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    for (int item = 0; item < 18; ++item)
+        instance_builder.add_item_type(1, 1, true);
+    Instance instance = instance_builder.build();
+    rectangle::Output output(instance);
+    ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, rectangle::Output> pricing_function
+        = [](const Instance&) -> rectangle::Output
+        {
+            throw std::logic_error("not used by this test");
+        };
+    ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, rectangle::Output> pricing_solver(
+            instance, output, pricing_function);
+
+    CgsModel model;
+    model.rows.resize(instance.number_of_bin_types() + instance.number_of_item_types());
+
+    struct ColumnSpec
+    {
+        std::vector<ItemTypeId> item_type_ids;
+        Value value;
+    };
+    std::vector<ColumnSpec> column_specs = {
+        {{2, 6, 8, 9, 15}, 0.5},
+        {{9, 12, 14}, 3.0 / 13.0},
+        {{11, 14, 16}, 0.5},
+        {{1, 7, 17}, 9.0 / 26.0},
+        {{0, 4, 9, 14}, 3.0 / 13.0},
+        {{1, 5, 7}, 3.0 / 26.0},
+        {{11, 13, 16}, 0.5},
+        {{0, 3, 5, 7}, 7.0 / 26.0},
+        {{5, 7, 10, 17}, 3.0 / 13.0},
+        {{3, 4, 10, 12}, 7.0 / 26.0},
+        {{2, 6, 8, 13, 15}, 0.5},
+        {{3, 4, 5, 17}, 5.0 / 13.0},
+        {{0, 4, 7, 12, 17}, 1.0 / 26.0},
+        {{0, 1, 10, 12}, 6.0 / 13.0},
+        {{1, 3, 4}, 1.0 / 13.0},
+        {{9, 10, 14}, 1.0 / 26.0},
+    };
+    CgsSolutionBuilder solution_builder;
+    solution_builder.set_model(model);
+    for (const ColumnSpec& column_spec: column_specs) {
+        solution_builder.add_column(
+                make_column(bin_type_id, column_spec.item_type_ids, instance.number_of_bin_types()),
+                column_spec.value);
+    }
+    CgsSolution solution = solution_builder.build();
+
+    std::vector<std::shared_ptr<const columngenerationsolver::Cut>> cuts
+        = pricing_solver.separate_cuts(solution);
+
+    ASSERT_FALSE(cuts.empty());
+    const SubsetRowCutExtra& extra
+        = *std::static_pointer_cast<SubsetRowCutExtra>(cuts[0]->extra);
+    // The best triple over these columns is violated by only 0.384615 (by
+    // exhaustive search over the raw numbers, independent of this
+    // template's own heuristics), less than the 0.5 several quintuples -
+    // and, tied with them, several 7-item-type subsets too - reach, so the
+    // single returned cut should be cardinality 5 or 7, never 3.
+    ASSERT_TRUE(extra.item_type_ids.size() == 5U || extra.item_type_ids.size() == 7U)
+        << "size: " << extra.item_type_ids.size();
+    EXPECT_EQ(cuts[0]->upper_bound, (Value)(extra.item_type_ids.size() / 2));
+
+    // Recompute the cut's violation directly against 'column_specs' (not
+    // relying on any of 'separate_cuts''s own machinery) as the real
+    // correctness check: several subsets of this particular fractional
+    // point tie at the maximum violation of 0.5 across both cardinalities
+    // (confirmed by exhaustive search), so this checks the *magnitude*
+    // 'separate_cuts' actually found rather than pinning down which of the
+    // tied subsets its greedy search happened to land on.
+    std::unordered_set<ItemTypeId> subset(extra.item_type_ids.begin(), extra.item_type_ids.end());
+    Value lhs = 0.0;
+    for (const ColumnSpec& column_spec: column_specs) {
+        int count = 0;
+        for (ItemTypeId item_type_id: column_spec.item_type_ids) {
+            if (subset.count(item_type_id) > 0)
+                ++count;
+        }
+        lhs += (Value)(count / 2) * column_spec.value;
+    }
+    EXPECT_NEAR(lhs - (Value)(extra.item_type_ids.size() / 2), 0.5, 1e-6);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///////////////////// RectangleSubsetRowCardinality7Test /////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(RectangleSubsetRowCardinality7Test, SeparatesCardinality7Cut)
+{
+    // 'column_items' below (item type ids and LP values) of a real
+    // fractional node from 'martello1998/Class_07.2bp_80_7' (BinPacking,
+    // no rotation, infinite bin copies), captured with cutting planes
+    // enabled at every search node: neither the cardinality-3 nor the
+    // cardinality-5 pass finds any violated cut here (confirmed
+    // independently by exhaustive search over the raw numbers), but
+    // several 7-item-type subsets are violated by a full 0.5 - e.g.
+    // {26, 39, 44, 46, 52, 55, 56}: seven columns each contain exactly 2 of
+    // the 7 ({44,56,59}, {39,50,56}, {26,37,46,57}, {15,26,37,52,57},
+    // {39,55,60}, {46,55,60}, {44,52,59}, each valued 0.5), so
+    // floor(2/2) = 1 per column, summing to 3.5 > floor(7/2) = 3. This
+    // checks 'separate_cuts' actually reaches cardinality 7, not just that
+    // the math works out on paper.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::BinPacking);
+    BinTypeId bin_type_id = instance_builder.add_bin_type(10, 10);
+    for (int item = 0; item < 61; ++item)
+        instance_builder.add_item_type(1, 1, true);
+    Instance instance = instance_builder.build();
+    rectangle::Output output(instance);
+    ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, rectangle::Output> pricing_function
+        = [](const Instance&) -> rectangle::Output
+        {
+            throw std::logic_error("not used by this test");
+        };
+    ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, rectangle::Output> pricing_solver(
+            instance, output, pricing_function);
+
+    CgsModel model;
+    model.rows.resize(instance.number_of_bin_types() + instance.number_of_item_types());
+
+    struct ColumnSpec
+    {
+        std::vector<ItemTypeId> item_type_ids;
+        Value value;
+    };
+    std::vector<ColumnSpec> column_specs = {
+        {{3, 22}, 0.286667},
+        {{1, 49}, 0.166667},
+        {{2, 40}, 0.113333},
+        {{44, 56, 59}, 0.5},
+        {{39, 50, 56}, 0.5},
+        {{25, 50, 53}, 0.113333},
+        {{31, 47, 53}, 0.16},
+        {{1, 43, 47, 49}, 0.413333},
+        {{26, 37, 46, 57}, 0.5},
+        {{3, 11, 22}, 0.26},
+        {{0, 12}, 0.5},
+        {{49, 50}, 0.306667},
+        {{12, 15, 22, 40}, 0.34},
+        {{2, 11, 41, 47}, 0.24},
+        {{11, 47}, 0.0266667},
+        {{1, 3, 40, 43}, 0.0733333},
+        {{15, 26, 37, 52, 57}, 0.5},
+        {{39, 55, 60}, 0.5},
+        {{2, 25}, 0.3},
+        {{3, 53}, 0.0266667},
+        {{31, 41, 53}, 0.413333},
+        {{46, 55, 60}, 0.5},
+        {{3, 43}, 0.273333},
+        {{41}, 0.3},
+        {{11, 53}, 0.286667},
+        {{1, 2, 31}, 0.346667},
+        {{44, 52, 59}, 0.5},
+        {{0}, 0.5},
+        {{12, 15, 25, 40, 43, 47}, 0.16},
+        {{11, 25, 40}, 0.14},
+        {{22, 25, 49}, 0.113333},
+        {{25, 40}, 0.173333},
+        {{11, 41}, 0.0466667},
+        {{3, 31, 43, 50}, 0.08},
+    };
+    CgsSolutionBuilder solution_builder;
+    solution_builder.set_model(model);
+    for (const ColumnSpec& column_spec: column_specs) {
+        solution_builder.add_column(
+                make_column(bin_type_id, column_spec.item_type_ids, instance.number_of_bin_types()),
+                column_spec.value);
+    }
+    CgsSolution solution = solution_builder.build();
+
+    std::vector<std::shared_ptr<const columngenerationsolver::Cut>> cuts
+        = pricing_solver.separate_cuts(solution);
+
+    ASSERT_FALSE(cuts.empty());
+    const SubsetRowCutExtra& extra
+        = *std::static_pointer_cast<SubsetRowCutExtra>(cuts[0]->extra);
+    // Neither cardinality 3 nor 5 has any violated candidate here, so the
+    // cut found can only come from the cardinality-7 extension.
+    ASSERT_EQ(extra.item_type_ids.size(), 7U);
+    EXPECT_EQ(cuts[0]->upper_bound, 3.0);
+
+    // Recompute the cut's violation directly against 'column_specs', the
+    // real correctness check (same reasoning as the cardinality-5 test
+    // above): several 7-item-type subsets tie at the maximum violation of
+    // 0.5, so this checks the magnitude found rather than pinning down
+    // which tied subset the beam search happened to land on.
+    std::unordered_set<ItemTypeId> subset(extra.item_type_ids.begin(), extra.item_type_ids.end());
+    Value lhs = 0.0;
+    for (const ColumnSpec& column_spec: column_specs) {
+        int count = 0;
+        for (ItemTypeId item_type_id: column_spec.item_type_ids) {
+            if (subset.count(item_type_id) > 0)
+                ++count;
+        }
+        lhs += (Value)(count / 2) * column_spec.value;
+    }
+    EXPECT_NEAR(lhs - 3.0, 0.5, 1e-6);
+}


### PR DESCRIPTION
## Summary
- Generalizes the subset-row cut mechanism from a hardcoded cardinality-3 triple (Jepsen et al. 2008) to arbitrary cardinality: `SubsetRowCutExtra` holds a `vector<ItemTypeId>` instead of `array<3>`, the coefficient is `floor(count/2)`, and pricing-side enforcement uses `ceil(cardinality/2)` stacked soft resources (capacities 1, 3, 5, ...) instead of one.
- Adds a cardinality-5/7 separation pass alongside the existing cardinality-3 one: seeded from every co-occurring item-type pair (not from the strongest triples, which are biased toward "triangle" structures and can miss a violated larger subset built from a weakly-connected cycle), a small beam search grows each pair through cardinality 5 and then 7, checking for a violation at each checkpoint.
- Bumps the vendored `columngenerationsolver` commit, which consolidated `PricingSolver::initialize_pricing` into `solve_pricing` (fixed columns/branching decisions/tabu are now passed on every call instead of once via a separate setup hook). Updates every `PricingSolver` implementation in this repo (`algorithms/column_generation.hpp`, `rectangle/bar_relaxation.cpp`, `rectangleguillotine/column_generation_strips.cpp`) accordingly.
- `column_generation_strips`'s own per-attempt state (filled demands/width, first-pricing tracking) now detects the start of a new attempt itself via a fixed-columns-and-their-values signature, since there's no longer a dedicated setup call to reset it from.
- Enables cutting-plane separation at every search node for rectangle's column generation (`use_cutting_planes = 2`), not just the root. Root-only separation left later nodes unable to cut a fractional point that only becomes violated after branching reshapes the LP - exactly the pattern that motivated the cardinality-5/7 extension, and confirmed against a real `martello1998` instance where cardinality 3 and 5 were both clean at a node but a cardinality-7 cut applied.

This is a real (if modest) performance cost: cutting-plane separation plus its master LP re-solve now runs at every node instead of just the root.

## Test plan
- [x] `PackingSolver_rectangle_test`: 114/114 passed (includes two new regression tests, `RectangleSubsetRowCardinality5Test` and `RectangleSubsetRowCardinality7Test`, reproducing real fractional LP nodes - including the `martello1998/Class_07.2bp_80_7` node that motivated the cardinality-7 extension - and checking `separate_cuts` finds the expected cut).
- [x] `PackingSolver_rectangleguillotine_test`: 285/285 passed.
- [x] Verified `packingsolver_rectangle --items martello1998/Class_07.2bp_80_7 --bin-infinite-copies --no-item-rotation --objective bin-packing`: the limited discrepancy search now reaches the optimal solution on this instance.