### PR TITLE
column_generation: fix subset-row cut resource consumption for item copies

### DIFF
--- a/src/algorithms/column_generation.hpp
+++ b/src/algorithms/column_generation.hpp
@@ -475,10 +475,12 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution,
                 // = cut_dual * multiplier_profit', scaled the same way the
                 // item duals just above are).
                 // The cut's coefficient on a generated column is
-                // floor(count / 2), where 'count' is how many of
-                // 'item_type_ids' the column contains (see 'coefficient'
-                // below) - reproduced here as one soft resource per unit of
-                // that coefficient: resource i (capacities 1, 3, 5, ...)
+                // floor(count / 2), where 'count' is how many *distinct*
+                // item types of 'item_type_ids' the column contains - not
+                // how many copies (see 'coefficient' below, which counts
+                // presence, not copies) - reproduced here as one soft
+                // resource per unit of that coefficient: resource i
+                // (capacities 1, 3, 5, ...)
                 // is the first to cross its capacity exactly when 'count'
                 // reaches 2*(i+1), so the number of resources that end up
                 // crossed equals floor(count / 2) exactly, each
@@ -523,12 +525,27 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution,
                             /* penalize */ true,
                             /* penalty */ penalty);
                     for (ItemTypeId kp_item_type_id: present_kp_item_type_ids) {
+                        // Consumption schedule '[1.0, 0.0]': the item
+                        // type's first copy consumes 1.0 (counts as
+                        // "present"), every further copy consumes 0.0 (see
+                        // 'Resource::item_consumption' - a copy past the
+                        // end of the schedule repeats its last entry, so
+                        // without this trailing 0 every extra copy would
+                        // keep adding 1.0, making the resource count total
+                        // copies instead of distinct present item types,
+                        // unlike 'coefficient' above).
                         kp_instance_builder.add_resource_consumption(
                                 kp_bin_type_id,
                                 resource_id,
                                 kp_item_type_id,
                                 0,
                                 1.0);
+                        kp_instance_builder.add_resource_consumption(
+                                kp_bin_type_id,
+                                resource_id,
+                                kp_item_type_id,
+                                1,
+                                0.0);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- The pricing-side resource enforcing a subset-row cut set only the first-copy consumption (`item_copy` 0) to 1.0, leaving a length-1 schedule.
- Per `Resource::item_consumption`, a copy past the end of the schedule repeats the last entry, so every further copy of that item type also added 1.0 to the resource — the resource ended up counting total item copies packed instead of distinct item types present.
- This mismatched `coefficient()`, which charges the cut on the resulting column based on presence (0/1 per item type), not copies — so the pricing search could over-penalize/over-restrict columns containing several copies of a single subset item type relative to what the cut actually charges in the master problem.
- Fix: add a trailing `item_copy` 1 consumption of 0.0, so the schedule becomes `[1.0, 0.0]` and the resource caps at 1.0 per item type regardless of copy count, matching `coefficient()`.

## Test plan
- [x] `cmake --build build_debug_claude --target PackingSolver_rectangle_main` builds cleanly.