### PR TITLE
rectangle: force benders decomposition for dual pricing, add benders master problem parameters

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -110,7 +110,7 @@ set(COLUMNGENERATIONSOLVER_BUILD_EXAMPLES OFF)
 FetchContent_Declare(
     columngenerationsolver
     GIT_REPOSITORY https://github.com/fontanf/columngenerationsolver.git
-    GIT_TAG 4e0987c76c3e1abad841cc3f8ceccccf7903d132
+    GIT_TAG 04874aaecea7a78984ccab85a1f37bbb3998ca47
     #SOURCE_DIR "${PROJECT_SOURCE_DIR}/../columngenerationsolver/"
     EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(columngenerationsolver)

--- a/src/algorithms/column_generation.hpp
+++ b/src/algorithms/column_generation.hpp
@@ -64,6 +64,7 @@ using Column = columngenerationsolver::Column;
 using Cut = columngenerationsolver::Cut;
 using CutIdx = columngenerationsolver::CutIdx;
 using PricingOutput = columngenerationsolver::PricingSolver::PricingOutput;
+using PricingType = columngenerationsolver::PricingSolver::PricingType;
 
 /**
  * Data specific to a subset-row cut of generalized cardinality (Jepsen,
@@ -128,7 +129,7 @@ inline std::shared_ptr<Cut> build_subset_row_cut(
 }
 
 template <typename Instance, typename InstanceBuilder, typename Solution, typename Output = packingsolver::Output<Instance, Solution>>
-using ColumnGenerationPricingFunction = std::function<Output(const Instance&)>;
+using ColumnGenerationPricingFunction = std::function<Output(const Instance&, PricingType)>;
 
 template <typename Instance, typename InstanceBuilder, typename Solution, typename Output = packingsolver::Output<Instance, Solution>>
 class ColumnGenerationPricingSolver: public columngenerationsolver::PricingSolver
@@ -139,10 +140,12 @@ public:
     ColumnGenerationPricingSolver(
             const Instance& instance,
             const Output& output,
-            const ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, Output>& pricing_function):
+            const ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, Output>& pricing_function,
+            bool has_pricing_bound = false):
         instance_(instance),
         output_(output),
-        pricing_function_(pricing_function)
+        pricing_function_(pricing_function),
+        has_pricing_bound_(has_pricing_bound)
     { }
 
     virtual PricingOutput solve_pricing(
@@ -152,7 +155,22 @@ public:
             const std::unordered_set<std::shared_ptr<const columngenerationsolver::Column>>& tabu,
             const std::vector<columngenerationsolver::Value>& duals,
             const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>& cut_duals,
-            columngenerationsolver::Counter pricing_level) override;
+            PricingType pricing_type) override;
+
+    /**
+     * Whether 'pricing_function_' has something genuinely useful to offer
+     * for 'PricingType::Dual' calls - set from the constructor's
+     * 'has_pricing_bound' argument, which only a domain whose
+     * 'pricing_function' actually branches on 'PricingType::Dual' (e.g.
+     * rectangle, forcing an exact Benders-decomposition solve - see
+     * 'rectangle::optimize_column_generation') should pass as 'true'. See
+     * 'columngenerationsolver::PricingSolver::has_pricing_bound' for what
+     * this gates.
+     */
+    virtual bool has_pricing_bound() const override
+    {
+        return has_pricing_bound_;
+    }
 
     /**
      * Subset-row cut (Jepsen et al. 2008) separation - see
@@ -209,6 +227,9 @@ private:
 
     ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, Output> pricing_function_;
 
+    /** See 'has_pricing_bound' above. */
+    bool has_pricing_bound_ = false;
+
     /**
      * Cache for the 'VariableSizedBinPacking' 'maximum_number_of_bins'
      * computation below: 'true' once it has been computed at least once,
@@ -229,7 +250,8 @@ template <typename Instance, typename InstanceBuilder, typename Solution, typena
 columngenerationsolver::Model get_model(
         const Instance& instance,
         const Output& output,
-        const ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, Output>& pricing_function)
+        const ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, Output>& pricing_function,
+        bool pricing_function_has_dual_bound = false)
 {
     columngenerationsolver::Model model;
 
@@ -270,7 +292,8 @@ columngenerationsolver::Model get_model(
 
     // Pricing solver.
     model.pricing_solver = std::unique_ptr<columngenerationsolver::PricingSolver>(
-            new ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>(instance, output, pricing_function));
+            new ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>(
+                instance, output, pricing_function, pricing_function_has_dual_bound));
     return model;
 }
 
@@ -333,7 +356,7 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution,
         const std::unordered_set<std::shared_ptr<const columngenerationsolver::Column>>& tabu,
         const std::vector<Value>& duals,
         const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, Value>>& cut_duals,
-        columngenerationsolver::Counter)
+        PricingType pricing_type)
 {
     double multiplier_cost = largest_power_of_two_lesser_or_equal(instance_.largest_bin_cost());
     double multiplier_profit = largest_power_of_two_lesser_or_equal(instance_.largest_item_profit());
@@ -634,7 +657,7 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution,
 
         // Solve knapsack instance.
         //std::cout << "pricing_function" << std::endl;
-        auto kp_output = pricing_function_(kp_instance);
+        auto kp_output = pricing_function_(kp_instance, pricing_type);
         //std::cout << "pricing_function end" << std::endl;
 
         // Retrieve column.
@@ -1328,6 +1351,21 @@ struct ColumnGenerationParameters: packingsolver::Parameters<Instance, Solution,
      * comparatively little benefit.
      */
     int use_cutting_planes = 0;
+
+    /**
+     * Whether 'pricing_function' has something genuinely useful to offer
+     * for 'columngenerationsolver::PricingSolver::PricingType::Dual' calls
+     * - i.e. whether it actually branches on the 'PricingType' it is given
+     * to run a more expensive, exact algorithm there instead of its
+     * regular cheap search (e.g. rectangle forcing a Benders-decomposition
+     * solve - see 'rectangle::optimize_column_generation'). Off by
+     * default: passed straight through to 'get_model', which only grants
+     * the pricing solver a genuine 'has_pricing_bound' when this is set,
+     * so 'columngenerationsolver::column_generation' never wastes a
+     * 'PricingType::Dual' call on a 'pricing_function' that would just
+     * redo its regular search.
+     */
+    bool pricing_function_has_dual_bound = false;
 };
 
 /**
@@ -1496,6 +1534,7 @@ Output column_generation(
             sub_parameters.internal_diving = parameters.internal_diving;
             sub_parameters.use_cutting_planes = parameters.use_cutting_planes;
             sub_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
+            sub_parameters.pricing_function_has_dual_bound = parameters.pricing_function_has_dual_bound;
             Output sub_output = column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter, Output>(
                     sub_instance, pricing_function, sub_parameters, 0,
                     &sequential_feasibility_column_pool,
@@ -1539,7 +1578,8 @@ Output column_generation(
     }
 
     columngenerationsolver::Model cgs_model
-        = get_model<Instance, InstanceBuilder, Solution, Output>(instance, output, pricing_function);
+        = get_model<Instance, InstanceBuilder, Solution, Output>(
+                instance, output, pricing_function, parameters.pricing_function_has_dual_bound);
     columngenerationsolver::LimitedDiscrepancySearchParameters cgslds_parameters;
     cgslds_parameters.verbosity_level = 0;
     cgslds_parameters.timer = parameters.timer;

--- a/src/box/optimize.cpp
+++ b/src/box/optimize.cpp
@@ -484,7 +484,7 @@ void optimize_column_generation(
         box::Output* local_output)
 {
     ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, box::Output> pricing_function
-        = [&algorithm_formatter, &parameters](const Instance& kp_instance)
+        = [&algorithm_formatter, &parameters](const Instance& kp_instance, PricingType)
         {
             OptimizeParameters kp_parameters;
             kp_parameters.verbosity_level = 0;

--- a/src/irregular/optimize.cpp
+++ b/src/irregular/optimize.cpp
@@ -589,7 +589,7 @@ void optimize_column_generation(
         irregular::Output* local_output)
 {
     ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, irregular::Output> pricing_function
-        = [&algorithm_formatter, &parameters](const Instance& kp_instance)
+        = [&algorithm_formatter, &parameters](const Instance& kp_instance, PricingType)
         {
             OptimizeParameters kp_parameters;
             kp_parameters.verbosity_level = 0;

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -491,7 +491,7 @@ void optimize_column_generation(
         onedimensional::Output* local_output)
 {
     ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, onedimensional::Output> pricing_function
-        = [&parameters](const Instance& kp_instance)
+        = [&parameters](const Instance& kp_instance, PricingType)
         {
             OptimizeParameters kp_parameters;
             kp_parameters.verbosity_level = 0;

--- a/src/rectangle/bar_relaxation.cpp
+++ b/src/rectangle/bar_relaxation.cpp
@@ -64,7 +64,7 @@ public:
             const std::unordered_set<std::shared_ptr<const columngenerationsolver::Column>>&,
             const std::vector<columngenerationsolver::Value>& duals,
             const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&,
-            columngenerationsolver::Counter pricing_level) override;
+            columngenerationsolver::PricingSolver::PricingType) override;
 
 private:
 
@@ -232,7 +232,7 @@ columngenerationsolver::PricingSolver::PricingOutput BarRelaxationPricingSolver:
         const std::unordered_set<std::shared_ptr<const columngenerationsolver::Column>>&,
         const std::vector<columngenerationsolver::Value>& duals,
         const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&,
-        columngenerationsolver::Counter)
+        columngenerationsolver::PricingSolver::PricingType)
 {
     columngenerationsolver::PricingSolver::PricingOutput output;
     double overcost = 0.0;

--- a/src/rectangle/benders_decomposition.cpp
+++ b/src/rectangle/benders_decomposition.cpp
@@ -871,6 +871,11 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
     // genuinely feasible (and possibly optimal) region.
     bool all_cuts_proven_infeasible = true;
 
+    // Number of iterations that actually solved at least one feasibility
+    // subproblem so far - see
+    // 'BendersDecompositionParameters::not_anytime_maximum_number_of_subproblem_solves'.
+    Counter number_of_subproblem_solves = 0;
+
     for (output.number_of_iterations = 0;
             ;
             ++output.number_of_iterations) {
@@ -894,6 +899,9 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
             = (parameters.optimization_mode == OptimizationMode::NotAnytimeSequential)?
             OptimizationMode::NotAnytimeSequential:
             OptimizationMode::NotAnytimeDeterministic;
+        master_parameters.use_tree_search = parameters.master_problem_use_tree_search;
+        master_parameters.use_milp_assignment = parameters.master_problem_use_milp_assignment;
+        master_parameters.optimization_mode = OptimizationMode::Anytime;
         onedimensional::Output master_output = onedimensional::optimize(
                 master_instance, master_parameters);
 
@@ -978,6 +986,19 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
             //std::cout << "dff_violation_found" << std::endl;
             continue;
         }
+
+        // Check maximum number of subproblem solves. Checked here, not at
+        // the top of the loop alongside
+        // 'not_anytime_maximum_number_of_iterations', since only past this
+        // point is it known that this iteration will actually solve at
+        // least one subproblem below (the 'continue' above skips it
+        // otherwise).
+        if (parameters.optimization_mode != OptimizationMode::Anytime
+                && parameters.not_anytime_maximum_number_of_subproblem_solves >= 0
+                && number_of_subproblem_solves >= parameters.not_anytime_maximum_number_of_subproblem_solves) {
+            break;
+        }
+        number_of_subproblem_solves++;
 
         // Pass 2: no bin had a dual-feasible-function violation; run the
         // actual geometric feasibility subproblem for every bin, adding one

--- a/src/rectangle/benders_decomposition.hpp
+++ b/src/rectangle/benders_decomposition.hpp
@@ -27,6 +27,12 @@ struct BendersDecompositionParameters: packingsolver::Parameters<Instance, Solut
     /** Optimization mode. */
     OptimizationMode optimization_mode = OptimizationMode::Anytime;
 
+    /** Use the tree search algorithm to solve the master problem. */
+    bool master_problem_use_tree_search = false;
+
+    /** Use the MILP assignment algorithm to solve the master problem. */
+    bool master_problem_use_milp_assignment = true;
+
     /**
      * Maximum number of iterations, in non-'Anytime' optimization modes
      * only (-1: unlimited). 'Anytime' mode instead relies on the timer (or
@@ -34,7 +40,19 @@ struct BendersDecompositionParameters: packingsolver::Parameters<Instance, Solut
      * geometrically feasible) to stop, since it is expected to keep
      * improving for as long as it is given to run.
      */
-    Counter not_anytime_maximum_number_of_iterations = 10;
+    Counter not_anytime_maximum_number_of_iterations = -1;
+
+    /**
+     * Maximum number of iterations that actually solve at least one
+     * feasibility subproblem, in non-'Anytime' optimization modes only
+     * (-1: unlimited). Unlike 'not_anytime_maximum_number_of_iterations',
+     * an iteration whose master candidate is cut by a dual-feasible-
+     * function inequality before any subproblem is solved (see
+     * 'find_most_violated_dual_feasible_function_cut' in
+     * 'benders_decomposition.cpp') doesn't count towards this limit, since
+     * it never actually pays for a subproblem solve.
+     */
+    Counter not_anytime_maximum_number_of_subproblem_solves = 0;
 
     /** Size of the queue for the knapsack subproblem. */
     NodeId subproblem_queue_size = 512;

--- a/src/rectangle/benders_decomposition_contiguity.cpp
+++ b/src/rectangle/benders_decomposition_contiguity.cpp
@@ -1294,8 +1294,8 @@ BendersDecompositionContiguityOutput packingsolver::rectangle::benders_decomposi
     for (output.number_of_iterations = 0;
             ;
             ++output.number_of_iterations) {
-        if (parameters.maximum_number_of_iterations >= 0
-                && output.number_of_iterations >= parameters.maximum_number_of_iterations) {
+        if (parameters.not_anytime_maximum_number_of_iterations >= 0
+                && output.number_of_iterations >= parameters.not_anytime_maximum_number_of_iterations) {
             break;
         }
         if (parameters.timer.needs_to_end())

--- a/src/rectangle/benders_decomposition_contiguity.hpp
+++ b/src/rectangle/benders_decomposition_contiguity.hpp
@@ -185,8 +185,8 @@ struct BendersDecompositionContiguityParameters: packingsolver::Parameters<Insta
      */
     NodeId master_problem_tree_search_not_anytime_queue_size = 1024;
 
-    /** Maximum number of iterations. */
-    Counter maximum_number_of_iterations = -1;
+    /** Maximum number of iterations (-1: unlimited). */
+    Counter not_anytime_maximum_number_of_iterations = -1;
 
     /**
      * Seed for the random unit-removal orderings of the no-good cut

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -510,7 +510,7 @@ void optimize_column_generation(
         BinPos lower_bound)
 {
     ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, rectangle::Output> pricing_function
-        = [&parameters](const Instance& kp_instance)
+        = [&parameters](const Instance& kp_instance, PricingType pricing_type)
         {
             OptimizeParameters kp_parameters;
             kp_parameters.verbosity_level = 0;
@@ -524,6 +524,19 @@ void optimize_column_generation(
             kp_parameters.not_anytime_tree_search_maximal_spaces_queue_size
                 = parameters.column_generation_subproblem_tree_search_maximal_spaces_queue_size;
             kp_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
+            // 'PricingType::Dual' calls are rare (at most twice per column
+            // generation attempt) and exist specifically to *prove* a bound
+            // cheaply enough to justify the cost - see
+            // 'columngenerationsolver::PricingSolver::solve_pricing''s own
+            // doc comment. 'benders_decomposition' is the one algorithm here
+            // that converges to a proven-exact answer (or bound) rather than
+            // an incomplete search cut short by a queue size, so force it
+            // alone, bypassing the regular (heuristic) automatic algorithm
+            // selection entirely.
+            if (pricing_type == PricingType::Dual) {
+                //kp_parameters.verbosity_level = 1;
+                kp_parameters.use_benders_decomposition = true;
+            }
             return optimize(kp_instance, kp_parameters);
         };
 
@@ -534,6 +547,7 @@ void optimize_column_generation(
     cg_parameters.optimization_mode = parameters.optimization_mode;
     cg_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
     cg_parameters.use_cutting_planes = 2;
+    cg_parameters.pricing_function_has_dual_bound = true;
     cg_parameters.new_solution_callback = [&algorithm_formatter, local_output](
             const rectangle::Output& ps_output)
     {
@@ -620,7 +634,7 @@ void optimize_benders_decomposition_contiguity(
     bdc_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     bdc_parameters.optimization_mode = parameters.optimization_mode;
     if (parameters.optimization_mode != OptimizationMode::Anytime)
-        bdc_parameters.maximum_number_of_iterations = parameters.not_anytime_benders_decomposition_contiguity_number_of_iterations;
+        bdc_parameters.not_anytime_maximum_number_of_iterations = parameters.not_anytime_benders_decomposition_contiguity_number_of_iterations;
     bdc_parameters.new_solution_callback = [&algorithm_formatter, local_output](
             const rectangle::Output& ps_output)
     {

--- a/src/rectangleguillotine/column_generation_strips.cpp
+++ b/src/rectangleguillotine/column_generation_strips.cpp
@@ -47,7 +47,7 @@ public:
             const std::unordered_set<std::shared_ptr<const columngenerationsolver::Column>>&,
             const std::vector<columngenerationsolver::Value>& duals,
             const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&,
-            columngenerationsolver::Counter pricing_level) override;
+            columngenerationsolver::PricingSolver::PricingType) override;
 
     void set_all_columns_2e_patterns_generated() { all_columns_2e_patterns_generated_ = true; }
 
@@ -1934,7 +1934,7 @@ PricingOutput ColumnGenerationPricingSolver::solve_pricing(
         const std::unordered_set<std::shared_ptr<const columngenerationsolver::Column>>&,
         const std::vector<columngenerationsolver::Value>& duals,
         const std::vector<std::pair<std::shared_ptr<const columngenerationsolver::Cut>, columngenerationsolver::Value>>&,
-        columngenerationsolver::Counter)
+        columngenerationsolver::PricingSolver::PricingType)
 {
     //std::cout << "solve_pricing" << std::endl;
 

--- a/src/rectangleguillotine/optimize.cpp
+++ b/src/rectangleguillotine/optimize.cpp
@@ -626,7 +626,7 @@ void optimize_column_generation(
         rectangleguillotine::Output* local_output)
 {
     ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, rectangleguillotine::Output> pricing_function
-        = [&algorithm_formatter, &parameters](const Instance& kp_instance)
+        = [&algorithm_formatter, &parameters](const Instance& kp_instance, PricingType)
         {
             OptimizeParameters kp_parameters;
             kp_parameters.verbosity_level = 0;

--- a/test/rectangle/column_generation_test.cpp
+++ b/test/rectangle/column_generation_test.cpp
@@ -215,7 +215,7 @@ TEST(RectangleSubsetRowCardinality5Test, SeparatesCardinality5Cut)
     Instance instance = instance_builder.build();
     rectangle::Output output(instance);
     ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, rectangle::Output> pricing_function
-        = [](const Instance&) -> rectangle::Output
+        = [](const Instance&, PricingType) -> rectangle::Output
         {
             throw std::logic_error("not used by this test");
         };
@@ -319,7 +319,7 @@ TEST(RectangleSubsetRowCardinality7Test, SeparatesCardinality7Cut)
     Instance instance = instance_builder.build();
     rectangle::Output output(instance);
     ColumnGenerationPricingFunction<Instance, InstanceBuilder, Solution, rectangle::Output> pricing_function
-        = [](const Instance&) -> rectangle::Output
+        = [](const Instance&, PricingType) -> rectangle::Output
         {
             throw std::logic_error("not used by this test");
         };


### PR DESCRIPTION
## Summary
- Bumps `columngenerationsolver` to the commit that replaces `PricingSolver`'s `pricing_level` escalation with an explicit `PricingType` (`Primal`/`Dual`): `Dual` is a rare, expensive call reserved for actually proving a bound once `Primal` pricing alone has converged, only made at all when the pricing solver reports `has_pricing_bound()`.
- Updates every `ColumnGenerationPricingSolver` subclass's `solve_pricing` signature accordingly (`column_generation.hpp`, shared by all domains; rectangle's `bar_relaxation.cpp`; rectangleguillotine's `column_generation_strips.cpp`; and the corresponding test file).
- Threads `PricingType` through `ColumnGenerationPricingFunction` so each domain's pricing lambda can see it; adds `ColumnGenerationParameters::pricing_function_has_dual_bound` (and propagates it into the sequential-feasibility recursion, which otherwise silently reset it to `false` on a fresh `sub_parameters`).
- For rectangle, forces `use_benders_decomposition` alone (bypassing automatic algorithm selection) when `pricing_type == Dual`: unlike the regular tree search, Benders decomposition converges to a proven-exact answer, which is what a `Dual` pricing call needs to actually prove anything.
- Adds `BendersDecompositionParameters::master_problem_use_tree_search` and `master_problem_use_milp_assignment` (replacing a hardcoded `use_milp_assignment = true`), and `not_anytime_maximum_number_of_subproblem_solves` (default `0`): by default, in non-`Anytime` mode, Benders decomposition now stops as soon as the master's candidate passes every dual-feasible-function cut, without ever paying for a geometric subproblem solve - a fast bound only, rather than a full solve.
- Also renames `BendersDecompositionContiguityParameters::maximum_number_of_iterations` to `not_anytime_maximum_number_of_iterations`, for consistency with the equivalent parameter everywhere else.

## Test plan
- [x] Full build succeeds (Release).
- [x] `PackingSolver_rectangle_test` (138 tests) passes.
- [x] `PackingSolver_rectangleguillotine_test` (285 tests) passes.
- [x] `PackingSolver_onedimensional_test` (37 tests) passes.