### PR TITLE
column_generation: adapt to columngenerationsolver removal of cut_pool

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -110,7 +110,7 @@ set(COLUMNGENERATIONSOLVER_BUILD_EXAMPLES OFF)
 FetchContent_Declare(
     columngenerationsolver
     GIT_REPOSITORY https://github.com/fontanf/columngenerationsolver.git
-    GIT_TAG 04874aaecea7a78984ccab85a1f37bbb3998ca47
+    GIT_TAG f057b78387c29abc736ea7fea7d48ee37e6b1047
     #SOURCE_DIR "${PROJECT_SOURCE_DIR}/../columngenerationsolver/"
     EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(columngenerationsolver)

--- a/src/algorithms/column_generation.hpp
+++ b/src/algorithms/column_generation.hpp
@@ -206,11 +206,6 @@ public:
             const Cut& cut,
             const Column& column) const override;
 
-    /** Recognize two 'Cut' instances built over the same item type triple - see 'Cut' in columngenerationsolver. */
-    virtual bool equal(
-            const Cut& cut_1,
-            const Cut& cut_2) const override;
-
 private:
 
     /**
@@ -1319,19 +1314,6 @@ Value ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>
     return (Value)coefficient;
 }
 
-template <typename Instance, typename InstanceBuilder, typename Solution, typename Output>
-bool ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution, Output>::equal(
-        const Cut& cut_1,
-        const Cut& cut_2) const
-{
-    // Both cuts are always subset-row cuts - see 'build_subset_row_cut'
-    // above - and 'item_type_ids' is always kept sorted, so a plain vector
-    // comparison recognizes two cuts built over the same subset.
-    const SubsetRowCutExtra& extra_1 = *std::static_pointer_cast<SubsetRowCutExtra>(cut_1.extra);
-    const SubsetRowCutExtra& extra_2 = *std::static_pointer_cast<SubsetRowCutExtra>(cut_2.extra);
-    return extra_1.item_type_ids == extra_2.item_type_ids;
-}
-
 template <typename Instance, typename Solution, typename Output = packingsolver::Output<Instance, Solution>>
 struct ColumnGenerationParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
@@ -1474,33 +1456,26 @@ Instance build_sequential_feasibility_sub_instance(
  * one pick up where the previous one left off instead of starting its
  * pricing from scratch.
  *
- * 'cut_pool': the cut analogue of 'column_pool' above - every subset-row
- * cut only ever references item type ids, so, just like a column, it stays
- * valid across every candidate of the sequential feasibility scheme. If
- * non-null, seeded with '*cut_pool' before solving; on return, every cut
- * newly confirmed violated by this call (see 'columngenerationsolver::
- * Output::new_cuts') is appended to it - appended, not replaced, since
- * 'new_cuts' deliberately excludes cuts already reactivated from the
- * seeded pool, unlike 'column_pool' which is simply overwritten with
- * 'columngenerationsolver::Output::columns' above.
- *
- * 'initial_columns'/'initial_cuts': unlike 'column_pool'/'cut_pool' above
- * (checked lazily, only once the master LP actually needs a new entry),
- * these seed the root master LP and root active cut set directly from the
- * start. If non-null, seeded with '*initial_columns'/'*initial_cuts'
- * before solving; on return, overwritten (not appended - there is only
- * ever one root relaxation per call) with the columns of this call's own
- * root node relaxation solution and its own root active cuts (see
- * 'columngenerationsolver::LimitedDiscrepancySearchOutput::
- * root_relaxation_solution'/'root_cuts'). Passing the same pointers to a
- * sequence of calls (as the sequential feasibility scheme does) thus
- * warm-starts each candidate's root relaxation with what was already
- * (near-)optimal one bin fewer, the same way 'column_pool' lets pricing
- * pick up where the previous call left off. Left untouched when this call
- * takes the sequential feasibility branch itself instead of actually
- * solving a single master LP - only a call that reaches
- * 'columngenerationsolver::limited_discrepancy_search' below has a root
- * relaxation of its own to report.
+ * 'initial_columns'/'initial_cuts': unlike 'column_pool' above (checked
+ * lazily, only once the master LP actually needs a new entry), these seed
+ * the root master LP and root active cut set directly from the start (no
+ * analogous cross-call pool exists for cuts on its own - a cut is either
+ * currently active or forgotten, never kept around inactive on the chance
+ * it is needed again later; see 'columngenerationsolver::Parameters::
+ * initial_cuts''s own doc comment). If non-null, seeded with
+ * '*initial_columns'/'*initial_cuts' before solving; on return, overwritten
+ * (not appended - there is only ever one root relaxation per call) with the
+ * columns of this call's own root node relaxation solution and its own
+ * root active cuts (see 'columngenerationsolver::
+ * LimitedDiscrepancySearchOutput::root_relaxation_solution'/'root_cuts').
+ * Passing the same pointers to a sequence of calls (as the sequential
+ * feasibility scheme does) thus warm-starts each candidate's root
+ * relaxation with what was already (near-)optimal one bin fewer, the same
+ * way 'column_pool' lets pricing pick up where the previous call left off.
+ * Left untouched when this call takes the sequential feasibility branch
+ * itself instead of actually solving a single master LP - only a call that
+ * reaches 'columngenerationsolver::limited_discrepancy_search' below has a
+ * root relaxation of its own to report.
  */
 template <typename Instance, typename InstanceBuilder, typename Solution, typename AlgorithmFormatter, typename Output = packingsolver::Output<Instance, Solution>>
 Output column_generation(
@@ -1509,7 +1484,6 @@ Output column_generation(
         const ColumnGenerationParameters<Instance, Solution, Output>& parameters = {},
         BinPos lower_bound = 0,
         std::vector<std::shared_ptr<const Column>>* column_pool = nullptr,
-        std::vector<std::shared_ptr<const Cut>>* cut_pool = nullptr,
         std::vector<std::shared_ptr<const Column>>* initial_columns = nullptr,
         std::vector<std::shared_ptr<const Cut>>* initial_cuts = nullptr)
 {
@@ -1543,10 +1517,10 @@ Output column_generation(
                 ++bin_type_id) {
             sequential_feasibility_bins_available += instance.bin_type(bin_type_id).copies;
         }
-        // Columns and cuts are reused from one candidate bin count to the
-        // next (see 'column_pool'/'cut_pool''s own doc comments above):
-        // every candidate shares the same bin and item types, only the
-        // number of bins available of each type changes. Likewise,
+        // Columns are reused from one candidate bin count to the next (see
+        // 'column_pool''s own doc comment above): every candidate shares
+        // the same bin and item types, only the number of bins available
+        // of each type changes. Likewise,
         // 'sequential_feasibility_initial_columns'/'..._initial_cuts' carry
         // each candidate's own root relaxation solution and root active
         // cuts forward as the *next* candidate's own seed (see
@@ -1556,7 +1530,6 @@ Output column_generation(
         // passing the same two vectors through the whole loop is enough -
         // no per-iteration assignment needed.
         std::vector<std::shared_ptr<const Column>> sequential_feasibility_column_pool;
-        std::vector<std::shared_ptr<const Cut>> sequential_feasibility_cut_pool;
         std::vector<std::shared_ptr<const Column>> sequential_feasibility_initial_columns;
         std::vector<std::shared_ptr<const Cut>> sequential_feasibility_initial_cuts;
         for (BinPos number_of_bins = sequential_feasibility_lower_bound;
@@ -1580,7 +1553,6 @@ Output column_generation(
             Output sub_output = column_generation<Instance, InstanceBuilder, Solution, AlgorithmFormatter, Output>(
                     sub_instance, pricing_function, sub_parameters, 0,
                     &sequential_feasibility_column_pool,
-                    &sequential_feasibility_cut_pool,
                     &sequential_feasibility_initial_columns,
                     &sequential_feasibility_initial_cuts);
 
@@ -1623,7 +1595,7 @@ Output column_generation(
         = get_model<Instance, InstanceBuilder, Solution, Output>(
                 instance, output, pricing_function, parameters.pricing_function_has_dual_bound);
     columngenerationsolver::LimitedDiscrepancySearchParameters cgslds_parameters;
-    cgslds_parameters.verbosity_level = 0;
+    cgslds_parameters.verbosity_level = 1;
     cgslds_parameters.timer = parameters.timer;
     cgslds_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     cgslds_parameters.internal_diving = parameters.internal_diving;
@@ -1694,8 +1666,6 @@ Output column_generation(
     cgslds_parameters.cutting_planes = parameters.use_cutting_planes;
     if (column_pool != nullptr)
         cgslds_parameters.column_pool = *column_pool;
-    if (cut_pool != nullptr)
-        cgslds_parameters.cut_pool = *cut_pool;
     if (initial_columns != nullptr)
         cgslds_parameters.initial_columns = *initial_columns;
     if (initial_cuts != nullptr)
@@ -1704,16 +1674,6 @@ Output column_generation(
         = columngenerationsolver::limited_discrepancy_search(cgs_model, cgslds_parameters);
     if (column_pool != nullptr)
         *column_pool = cgslds_search_output.columns;
-    if (cut_pool != nullptr) {
-        // Append, not replace: unlike 'cgslds_search_output.columns' above
-        // (already self-contained), 'new_cuts' deliberately excludes cuts
-        // reactivated from the seeded 'cut_pool' - see 'cut_pool''s own doc
-        // comment above.
-        cut_pool->insert(
-                cut_pool->end(),
-                cgslds_search_output.new_cuts.begin(),
-                cgslds_search_output.new_cuts.end());
-    }
     if (initial_columns != nullptr) {
         initial_columns->clear();
         for (const auto& p: cgslds_search_output.root_relaxation_solution.columns())


### PR DESCRIPTION
## Summary
- Bump the `columngenerationsolver` dependency to `f057b78387c29abc736ea7fea7d48ee37e6b1047`, which removes `Parameters::cut_pool`, `Output::new_cuts`, and `PricingSolver::equal` - the cross-call cut pool mechanism has been dropped upstream in favor of always regenerating cuts from scratch each call.
- Drop packingsolver's own `cut_pool` parameter and wiring in `column_generation()` accordingly, and the now-dangling `equal()` override that only ever served to recognize a cut reactivated from that pool.
- `initial_cuts` (backed by `root_cuts`, unaffected by the removal) still warm-starts the sequential feasibility scheme's root cut set across candidates.

## Test plan
- [x] `PackingSolver_rectangle_test` (138 tests) passes, built in Release mode against the newly pinned `columngenerationsolver` dependency