### PR TITLE
column_generation: adapt to columngenerationsolver's new Activation enum

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -110,7 +110,7 @@ set(COLUMNGENERATIONSOLVER_BUILD_EXAMPLES OFF)
 FetchContent_Declare(
     columngenerationsolver
     GIT_REPOSITORY https://github.com/fontanf/columngenerationsolver.git
-    GIT_TAG f057b78387c29abc736ea7fea7d48ee37e6b1047
+    GIT_TAG 1274df41234709ab3d62f1b3e6dd2a88d3799710
     #SOURCE_DIR "${PROJECT_SOURCE_DIR}/../columngenerationsolver/"
     EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(columngenerationsolver)

--- a/src/algorithms/column_generation.hpp
+++ b/src/algorithms/column_generation.hpp
@@ -1318,7 +1318,7 @@ template <typename Instance, typename Solution, typename Output = packingsolver:
 struct ColumnGenerationParameters: packingsolver::Parameters<Instance, Solution, Output>
 {
     OptimizationMode optimization_mode = OptimizationMode::Anytime;
-    int internal_diving = 1;
+    columngenerationsolver::Activation internal_diving = columngenerationsolver::Activation::Initial;
     columngenerationsolver::SolverName linear_programming_solver_name
         = columngenerationsolver::SolverName::CLP;
 
@@ -1374,7 +1374,7 @@ struct ColumnGenerationParameters: packingsolver::Parameters<Instance, Solution,
      * during search, otherwise they only add master LP overhead for
      * comparatively little benefit.
      */
-    int use_cutting_planes = 0;
+    columngenerationsolver::Activation use_cutting_planes = columngenerationsolver::Activation::Never;
 
     /**
      * Whether 'pricing_function' has something genuinely useful to offer
@@ -1595,11 +1595,11 @@ Output column_generation(
         = get_model<Instance, InstanceBuilder, Solution, Output>(
                 instance, output, pricing_function, parameters.pricing_function_has_dual_bound);
     columngenerationsolver::LimitedDiscrepancySearchParameters cgslds_parameters;
-    cgslds_parameters.verbosity_level = 1;
+    cgslds_parameters.verbosity_level = 0;
     cgslds_parameters.timer = parameters.timer;
     cgslds_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     cgslds_parameters.internal_diving = parameters.internal_diving;
-    cgslds_parameters.rounding_heuristic = true;
+    cgslds_parameters.rounding_heuristic = columngenerationsolver::Activation::Initial;
     if (parameters.optimization_mode != OptimizationMode::Anytime)
         cgslds_parameters.automatic_stop = true;
     cgslds_parameters.new_solution_callback = [&instance, &algorithm_formatter](
@@ -1661,8 +1661,6 @@ Output column_generation(
     };
     cgslds_parameters.column_generation_parameters.solver_name
         = parameters.linear_programming_solver_name;
-    // '1': enabled at the root node only (see 'ColumnGenerationParameters::
-    // use_cutting_planes' above).
     cgslds_parameters.cutting_planes = parameters.use_cutting_planes;
     if (column_pool != nullptr)
         cgslds_parameters.column_pool = *column_pool;

--- a/src/onedimensional/optimize.cpp
+++ b/src/onedimensional/optimize.cpp
@@ -511,7 +511,7 @@ void optimize_column_generation(
     cg_parameters.timer = parameters.timer;
     cg_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     cg_parameters.optimization_mode = parameters.optimization_mode;
-    cg_parameters.internal_diving = 0;
+    cg_parameters.internal_diving = columngenerationsolver::Activation::Never;
     cg_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
     // Unlike the other domains, this one already has its own dedicated,
     // purpose-built sequential feasibility scheme for 'BinPacking' (see

--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -546,7 +546,7 @@ void optimize_column_generation(
     cg_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
     cg_parameters.optimization_mode = parameters.optimization_mode;
     cg_parameters.linear_programming_solver_name = parameters.linear_programming_solver_name;
-    cg_parameters.use_cutting_planes = 2;
+    cg_parameters.use_cutting_planes = columngenerationsolver::Activation::Always;
     cg_parameters.pricing_function_has_dual_bound = true;
     cg_parameters.new_solution_callback = [&algorithm_formatter, local_output](
             const rectangle::Output& ps_output)

--- a/src/rectangleguillotine/column_generation_strips.cpp
+++ b/src/rectangleguillotine/column_generation_strips.cpp
@@ -2154,7 +2154,7 @@ void column_generation_strips_vertical(
     cgslds_parameters.verbosity_level = 0;
     cgslds_parameters.timer = parameters.timer;
     cgslds_parameters.timer.add_end_boolean(&algorithm_formatter.end_boolean());
-    cgslds_parameters.internal_diving = 0;
+    cgslds_parameters.internal_diving = columngenerationsolver::Activation::Never;
     cgslds_parameters.automatic_stop = (parameters.optimization_mode != OptimizationMode::Anytime);
     cgslds_parameters.new_solution_callback = [&instance, &algorithm_formatter, local_output](
             const columngenerationsolver::Output& cgs_output)


### PR DESCRIPTION
## Summary
- Bump the `columngenerationsolver` dependency to `1274df41234709ab3d62f1b3e6dd2a88d3799710`, which replaces the ad hoc "0: never, 1: root node, 2: every node" `int` convention on `Parameters::internal_diving`/`cutting_planes`/`rounding_heuristic` with a proper `columngenerationsolver::Activation` enum (`Never`/`Initial`/`Always`).
- Change packingsolver's own `ColumnGenerationParameters::internal_diving`/`use_cutting_planes` fields to the same enum type instead of carrying a parallel `int` convention of their own, and update every call site (rectangle, onedimensional, rectangleguillotine's `column_generation_strips`) accordingly.
- Also fix `cgslds_parameters.verbosity_level`, left at `1` by mistake in the previous columngenerationsolver-adaptation commit (debug instrumentation that should have been reverted before that commit).

## Test plan
- [x] Full project build succeeds
- [x] `PackingSolver_algorithms_test`, `PackingSolver_box_test`, `PackingSolver_boxstacks_test`, `PackingSolver_onedimensional_test`, `PackingSolver_rectangleguillotine_test`, `PackingSolver_rectangle_test` all pass (487 tests total)