### PR TITLE
irregular: cut out bin borders in tree_search_periodic_packing's root

### DIFF
--- a/data/irregular/tests/knapsack_bin_border.json
+++ b/data/irregular/tests/knapsack_bin_border.json
@@ -1,0 +1,26 @@
+{
+    "objective": "Knapsack",
+    "bin_types": [
+        {
+            "type": "polygon",
+            "vertices": [
+                {"x": 0, "y": 0},
+                {"x": 20, "y": 0},
+                {"x": 20, "y": 5},
+                {"x": 10, "y": 5},
+                {"x": 10, "y": 10},
+                {"x": 0, "y": 10}
+            ],
+            "copies": 1
+        }
+    ],
+    "item_types": [
+        {
+            "type": "rectangle",
+            "width": 10,
+            "height": 10,
+            "copies": 2,
+            "profit": 1
+        }
+    ]
+}

--- a/data/irregular/tests/knapsack_bin_border_solution.json
+++ b/data/irregular/tests/knapsack_bin_border_solution.json
@@ -1,0 +1,95 @@
+{
+    "bins": [
+        {
+            "copies": 1,
+            "id": 0,
+            "items": [
+                {
+                    "angle": 0.0,
+                    "id": 0,
+                    "item_shapes": [
+                        {
+                            "shape": [
+                                {
+                                    "type": "LineSegment",
+                                    "xe": 10.0,
+                                    "xs": 0.0,
+                                    "ye": 0.0,
+                                    "ys": 0.0
+                                },
+                                {
+                                    "type": "LineSegment",
+                                    "xe": 10.0,
+                                    "xs": 10.0,
+                                    "ye": 10.0,
+                                    "ys": 0.0
+                                },
+                                {
+                                    "type": "LineSegment",
+                                    "xe": 0.0,
+                                    "xs": 10.0,
+                                    "ye": 10.0,
+                                    "ys": 10.0
+                                },
+                                {
+                                    "type": "LineSegment",
+                                    "xe": 0.0,
+                                    "xs": 0.0,
+                                    "ye": 0.0,
+                                    "ys": 10.0
+                                }
+                            ]
+                        }
+                    ],
+                    "mirror": false,
+                    "x": 0.0,
+                    "y": 0.0
+                }
+            ],
+            "shape": [
+                {
+                    "type": "LineSegment",
+                    "xe": 20.0,
+                    "xs": 0.0,
+                    "ye": 0.0,
+                    "ys": 0.0
+                },
+                {
+                    "type": "LineSegment",
+                    "xe": 20.0,
+                    "xs": 20.0,
+                    "ye": 5.0,
+                    "ys": 0.0
+                },
+                {
+                    "type": "LineSegment",
+                    "xe": 10.0,
+                    "xs": 20.0,
+                    "ye": 5.0,
+                    "ys": 5.0
+                },
+                {
+                    "type": "LineSegment",
+                    "xe": 10.0,
+                    "xs": 10.0,
+                    "ye": 10.0,
+                    "ys": 5.0
+                },
+                {
+                    "type": "LineSegment",
+                    "xe": 0.0,
+                    "xs": 10.0,
+                    "ye": 10.0,
+                    "ys": 10.0
+                },
+                {
+                    "type": "LineSegment",
+                    "xe": 0.0,
+                    "xs": 0.0,
+                    "ye": 0.0,
+                    "ys": 10.0
+                }
+            ]
+        }
+    ]
+}

--- a/src/irregular/tree_search_periodic_packing.cpp
+++ b/src/irregular/tree_search_periodic_packing.cpp
@@ -496,21 +496,29 @@ BranchingSchemePeriodicPacking::root() const
     space.bx = bin_bx();
     space.by = bin_by();
     node->empty_spaces.push_back(space);
-    // Cut out defects (approximated by their inflated AABB) from the initial
-    // empty space.
+    // Cut out defects and borders (approximated by their inflated AABB) from
+    // the initial empty space. 'space' spans the bin's full bounding box
+    // (see usable_bin_bx()/by()'s comment above), which for a non-rectangular
+    // bin shape extends past the shape itself; without cutting out 'borders'
+    // -- the AABB decomposition of that bounding-box-minus-shape area, built
+    // alongside 'defects' in InstanceBuilder::build() -- the search would
+    // treat that area as free space and place items outside the bin.
     const std::vector<Defect>& defects = bin_type().defects;
-    for (const Defect& defect: defects) {
-        AxisAlignedBoundingBox aabb = defect.shape_inflated.compute_min_max();
-        cut_spaces(
-                node->empty_spaces,
-                {aabb.x_min, aabb.y_min},
-                aabb.x_max - aabb.x_min,
-                aabb.y_max - aabb.y_min);
+    const std::vector<Defect>& borders = bin_type().borders;
+    for (const std::vector<Defect>& obstacles: {defects, borders}) {
+        for (const Defect& obstacle: obstacles) {
+            AxisAlignedBoundingBox aabb = obstacle.shape_inflated.compute_min_max();
+            cut_spaces(
+                    node->empty_spaces,
+                    {aabb.x_min, aabb.y_min},
+                    aabb.x_max - aabb.x_min,
+                    aabb.y_max - aabb.y_min);
+        }
     }
     ItemPos number_of_blocks = (ItemPos)blocks_.size();
     node->valid_block_ids.resize(number_of_blocks);
     std::iota(node->valid_block_ids.begin(), node->valid_block_ids.end(), (ItemPos)0);
-    if (!defects.empty())
+    if (!defects.empty() || !borders.empty())
         remove_unusable_spaces(*node);
     return node;
 }

--- a/test/irregular/tree_search_periodic_packing_test.cpp
+++ b/test/irregular/tree_search_periodic_packing_test.cpp
@@ -128,4 +128,18 @@ INSTANTIATE_TEST_SUITE_P(
                 // overlapping the defect). Only 1 of the 2 copies fits.
                 fs::path("data") / "irregular" / "tests" / "knapsack_defect_blocks_middle.json",
                 fs::path("data") / "irregular" / "tests" / "knapsack_defect_blocks_middle_solution.json"
+            }, {
+                // L-shaped (non-rectangular) bin: a 20x10 bounding box with
+                // its top-right 10x5 corner (x in [10,20), y in [5,10))
+                // missing. root()'s initial empty space spans the bin's full
+                // bounding box, so without cutting out 'bin_type().borders'
+                // -- the AABB decomposition of the bounding-box-minus-shape
+                // area computed alongside 'defects' -- the search would treat
+                // that missing corner as free space. A 10x10 item, 2 copies:
+                // the first fits at (0,0), entirely inside the true L-shape;
+                // a second at (10,0) would need the missing corner, and the
+                // remaining true free space (10x5) is too short for it, so
+                // only 1 of the 2 copies fits.
+                fs::path("data") / "irregular" / "tests" / "knapsack_bin_border.json",
+                fs::path("data") / "irregular" / "tests" / "knapsack_bin_border_solution.json"
             }}));


### PR DESCRIPTION
Fixes #545

## Summary

- `BranchingSchemePeriodicPacking::root()` initializes its single starting empty space as the bin's full bounding box, and only cut out `bin_type().defects` from it, never `bin_type().borders` -- the AABB decomposition of the bounding-box-minus-shape area that `InstanceBuilder::build()` already computes for non-rectangular bins (shared with `milp_raster` and `nonlinear_programming`, which do use it).
- For a rectangular bin `borders` is empty, so this made no difference there. But for a concave/notched bin, the search treated that gap as free space and placed items outside the bin -- this is issue #545's "inefficient bin utilization" report: the reported instance uses an L-shaped (notched) polygon bin, and the solver's own output showed a *negative* `Full waste` (`bin_area() - item_area()` going negative), which is only possible if items overlap or extend outside the bin.

## Changes

**`src/irregular/tree_search_periodic_packing.cpp`** -- `root()` now cuts out `bin_type().borders` the same way it already cuts out `bin_type().defects` (same `Defect` type, same `shape_inflated`/AABB handling), and includes borders in the `remove_unusable_spaces` trigger condition.

**`test/irregular/tree_search_periodic_packing_test.cpp`** -- added a minimal regression test: an L-shaped bin (a 20x10 bounding box with its top-right 10x5 corner missing) with a single 10x10 item type at 2 copies. Only 1 copy fits in the true L-shape; the second would need the missing corner. Confirmed this test fails on `master` (2/2 items placed, negative waste) and passes with this change (1/2 items, positive waste).

## Test plan

- [x] Reproduced the exact instance attached to #545: `Full waste` went from `-164074` (invalid -- items overlapping the bin's missing corner) to `+853993` (a valid packing), with item count actually improving (224 -> 234, since the search is no longer misled by the phantom free space).
- [x] Rendered both the before and after solutions: before, the bin outline shows the notch but items don't respect it; after, the notch is correctly left empty.
- [x] Added regression test fails on `master`, passes with this change (verified both ways).
- [x] Full `irregular` test suite (`irregular_test`, `periodic_packing_test`, `rotations_test`, `linear_programming_test`, `tree_search_periodic_packing_test` -- 110 + 12 tests) passes.