### PR TITLE
rectangle: remove stray debug print in optimize()

### DIFF
--- a/src/rectangle/optimize.cpp
+++ b/src/rectangle/optimize.cpp
@@ -980,9 +980,6 @@ packingsolver::rectangle::Output packingsolver::rectangle::optimize(
                 }
             } else {
                 use_tree_search = true;
-                std::cout << "mean_number_of_items_in_bins " << mean_number_of_items_in_bins
-                    << " / " << parameters.many_items_in_bins_threshold
-                    << std::endl;
                 if (mean_number_of_items_in_bins
                         > parameters.many_items_in_bins_threshold) {
                     use_sequential_single_knapsack = true;


### PR DESCRIPTION
## Summary

- `optimize()`'s algorithm-selection logic unconditionally printed `mean_number_of_items_in_bins " " / " " parameters.many_items_in_bins_threshold` to stdout in the `use_tree_search` branch, regardless of verbosity level -- a leftover debug print.

## Changes

**`src/rectangle/optimize.cpp`** -- removed the print. No behavior change; the surrounding branching logic is untouched.

## Test plan

- [x] `PackingSolver_rectangle_test`: 138 tests pass.