### PR TITLE
rectangle: lower default SSK maximal-spaces queue size

### DIFF
--- a/include/packingsolver/rectangle/optimize.hpp
+++ b/include/packingsolver/rectangle/optimize.hpp
@@ -290,7 +290,7 @@ struct OptimizeParameters: packingsolver::Parameters<Instance, Solution, Output>
      * Size of the queue in the tree search maximal spaces algorithm for the single knapsack
      * subproblem of the sequential single knapsack algorithm.
      */
-    NodeId not_anytime_sequential_single_knapsack_subproblem_tree_search_maximal_spaces_queue_size = 1024;
+    NodeId not_anytime_sequential_single_knapsack_subproblem_tree_search_maximal_spaces_queue_size = 64;
 
     /** Number of iterations of the sequential value correction algorithm. */
     Counter not_anytime_sequential_value_correction_number_of_iterations = 32;


### PR DESCRIPTION
## Summary
- `not_anytime_sequential_single_knapsack_subproblem_tree_search_maximal_spaces_queue_size` defaulted to 1024.
- Swept the 150 oriented bin-packing benchmark instances where sequential-single-knapsack (SSK) auto-triggers (`data_bin_packing_oriented.csv`, berkey1987 classes 02/04/06, all dispatching to `tree_search_maximal_spaces`): only one of them (`Class_04.2bp_80_9`) actually needs SSK to reach the best known solution rather than tree_search alone, and for that instance the smallest power-of-two queue size that still reaches it is 64 (1, 2, 4, ..., 32 all fall one bin short).
- Confirmed no other instance regresses at queue size 64 via a full spot-check against the tree-search-alone baseline across all 150 instances.
- Lowered the default from 1024 to 64: cuts `Class_04.2bp_80_9`'s solve time from ~470-700s to ~5s with no loss of solution quality across the swept set.

## Test plan
- [x] Full existing `PackingSolver_rectangle_test` suite passes (138/138), no regressions.
- [x] `packingsolver_rectangle --items data/rectangle/berkey1987/Class_04.2bp_80_9 --bin-infinite-copies --no-item-rotation --objective bin-packing --optimization-mode not-anytime` now finishes in ~6.6s (down from ~470-700s) and still proves the same 3-bin optimum.
- [x] Ascending queue-size sweep (1, 2, 4, 8, 16, 32, 64) confirms 64 is the minimal power of two that reaches the optimum for this instance; 32 and below fall short (4 bins instead of 3).
- [x] Spot-checked queue size 64 against tree-search-alone results across all 150 SSK-triggering instances in the oriented benchmark set: no regression found.