### PR TITLE
algorithms: store Resource::item_consumptions sparsely

### DIFF
--- a/include/packingsolver/algorithms/common.hpp
+++ b/include/packingsolver/algorithms/common.hpp
@@ -9,6 +9,7 @@
 #include "optimizationtools/utils/common.hpp"
 #include "optimizationtools/utils/output.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <set>
 #include <iomanip>
@@ -273,21 +274,41 @@ struct Resource
     double capacity = 0.0;
 
     /**
-     * Resource consumption schedule of each item type, indexed by
-     * [item_type_id][copy]: the consumption charged for the 'copy'-th
-     * (0-indexed) unit of the item type packed in a bin with this resource.
-     * A 'copy' past the end of the schedule repeats its last entry (so a
-     * length-1 schedule means "the same consumption regardless of how many
-     * copies are already packed" - the common case); an 'item_type_id' past
-     * the end of this vector implicitly consumes 0 regardless of 'copy'.
+     * Resource consumption schedule of each item type that has one - each
+     * entry's 'std::vector<double>' gives the consumption charged for the
+     * 'copy'-th (0-indexed) unit of that item type packed in a bin with
+     * this resource. A 'copy' past the end of the schedule repeats its
+     * last entry (so a length-1 schedule means "the same consumption
+     * regardless of how many copies are already packed" - the common
+     * case); an 'item_type_id' absent from this list implicitly consumes 0
+     * regardless of 'copy'.
      *
      * A non-uniform schedule lets a resource express "at least N copies of
      * this item type" as a plain capacity/consumption row: an all-ones
      * schedule of length N followed by a single trailing 0 makes the total
      * consumption equal to 'min(count, N)', which only keeps growing while
      * count < N.
+     *
+     * Sparse rather than a plain [item_type_id]-indexed vector because a
+     * resource generated as a combinatorial cut (see e.g. the rectangle
+     * Benders decomposition's no-good and triplet-incompatibility cuts)
+     * typically only involves a handful of item types, yet every consumer
+     * that used to index a dense vector by 'item_type_id' had to be sized
+     * (and, worse, scanned - see 'onedimensional::milp_assignment.cpp's
+     * constraint builder before this) up to the highest item type id
+     * referenced anywhere in the instance, however large that is.
+     *
+     * At most one entry per 'item_type_id' - 'InstanceBuilder::build'
+     * throws otherwise (see its own doc comment); 'InstanceBuilder::
+     * add_resource_consumption' may therefore be called at most once per
+     * (item type, resource) pair, and simply appends here, no search
+     * needed. No per-item-type lookup method is offered here on purpose -
+     * a one-off search (linear or otherwise) through this list is not
+     * O(1), so a caller that already knows which item type it wants would
+     * pay for one on every query. Look the position up once instead, via
+     * 'ItemType::resources', and index this list directly with it.
      */
-    std::vector<std::vector<double>> item_consumptions;
+    std::vector<std::pair<ItemTypeId, std::vector<double>>> item_consumptions;
 
     /**
      * If 'true', exceeding 'capacity' does not make a bin infeasible;
@@ -298,49 +319,61 @@ struct Resource
 
     /** Penalty subtracted from the solution's profit; only used when 'penalize' is 'true'. */
     double penalty = 0.0;
-
-    /** Get the consumption of the 'copy'-th (0-indexed) unit of an item type. */
-    inline double item_consumption(
-            ItemTypeId item_type_id,
-            ItemPos copy) const
-    {
-        if (item_type_id >= (ItemTypeId)item_consumptions.size())
-            return 0.0;
-        const std::vector<double>& schedule = item_consumptions[item_type_id];
-        if (schedule.empty())
-            return 0.0;
-        return (copy < (ItemPos)schedule.size())?
-            schedule[copy]:
-            schedule.back();
-    }
 };
 
 /**
- * Prefix sums of 'resource''s per-copy consumption schedule for
- * 'item_type_id': result[k] = sum of
- * 'resource.item_consumption(item_type_id, copy)' for 'copy' in [0, k), for
- * k in [0, schedule.size()] - always has at least one entry (result[0] ==
- * 0), even for an item type absent from 'resource.item_consumptions' or
- * with an empty schedule.
+ * One of a bin type's resources a given item type has a non-zero
+ * consumption for, together with the position of that item type's own
+ * entry in the resource's own (sparse) 'Resource::item_consumptions' list
+ * - see 'ItemType::resources' - so that a caller already holding one of
+ * these can jump straight to 'bin_type.resource(resource_id).item_consumptions[consumption_pos].second'
+ * for the schedule, with no search at all.
+ */
+struct ItemResourceConsumption
+{
+    ResourceId resource_id;
+    std::size_t consumption_pos;
+};
+
+/**
+ * Get the consumption of the 'copy'-th (0-indexed) unit of an item type,
+ * given its schedule (see 'Resource::item_consumptions') - O(1), unlike a
+ * per-item-type lookup would be. 'schedule' is typically obtained via
+ * 'ItemType::resources' (see 'ItemResourceConsumption').
+ */
+inline double schedule_consumption(
+        const std::vector<double>& schedule,
+        ItemPos copy)
+{
+    if (schedule.empty())
+        return 0.0;
+    return (copy < (ItemPos)schedule.size())?
+        schedule[copy]:
+        schedule.back();
+}
+
+/**
+ * Prefix sums of 'schedule' (an item type's consumption schedule for some
+ * resource - see 'Resource::item_consumptions', typically obtained in O(1)
+ * via 'ItemType::resources'): result[k] = sum of 'schedule[copy]' (or
+ * 'schedule.back()' past its end) for 'copy' in [0, k), for k in
+ * [0, schedule.size()] - always has at least one entry (result[0] == 0),
+ * even for an empty schedule.
  *
  * Not stored on 'Resource' itself: only a consumer that bundles several
  * copies of an item at once (e.g. rectangle::block.cpp's guillotine blocks)
  * ever needs a *range* sum - every other domain's tree search looks up one
- * copy at a time via 'Resource::item_consumption' directly, so precomputing
- * this unconditionally in every domain's 'InstanceBuilder::build' would pay
- * for something most of them never read. Call this once per (bin type,
- * item type, resource) a block-bundling consumer actually cares about, and
- * pass the result to 'sum_item_consumption' for an O(1) range sum instead
- * of an O(schedule.size()) one - worthwhile whenever the same triple gets
- * queried many times (e.g. once per generated block).
+ * copy at a time via 'schedule_consumption' directly, so precomputing this
+ * unconditionally in every domain's 'InstanceBuilder::build' would pay for
+ * something most of them never read. Call this once per (bin type, item
+ * type, resource) a block-bundling consumer actually cares about, and pass
+ * the result to 'sum_item_consumption' for an O(1) range sum instead of an
+ * O(schedule.size()) one - worthwhile whenever the same triple gets queried
+ * many times (e.g. once per generated block).
  */
 inline std::vector<double> compute_resource_consumption_prefix_sums(
-        const Resource& resource,
-        ItemTypeId item_type_id)
+        const std::vector<double>& schedule)
 {
-    if (item_type_id >= (ItemTypeId)resource.item_consumptions.size())
-        return {0.0};
-    const std::vector<double>& schedule = resource.item_consumptions[item_type_id];
     std::vector<double> prefix_sums(schedule.size() + 1, 0.0);
     for (std::size_t k = 0; k < schedule.size(); ++k)
         prefix_sums[k + 1] = prefix_sums[k] + schedule[k];
@@ -348,14 +381,11 @@ inline std::vector<double> compute_resource_consumption_prefix_sums(
 }
 
 /**
- * Sum of 'resource.item_consumption(item_type_id, copy)' for 'copy' in
- * '[0, count)', in O(1) given 'prefix_sums' (see
- * 'compute_resource_consumption_prefix_sums', called against the same
- * 'resource'/'item_type_id').
+ * Sum of 'schedule_consumption(schedule, copy)' for 'copy' in '[0, count)',
+ * in O(1) given 'prefix_sums' (see 'compute_resource_consumption_prefix_sums',
+ * called against that same 'schedule').
  */
 inline double sum_item_consumption(
-        const Resource& resource,
-        ItemTypeId item_type_id,
         const std::vector<double>& prefix_sums,
         ItemPos count)
 {
@@ -365,8 +395,10 @@ inline double sum_item_consumption(
     ItemPos head_count = (std::min)(count, schedule_length);
     double sum = prefix_sums[head_count];
     ItemPos tail_count = count - head_count;
-    if (tail_count > 0)
-        sum += (double)tail_count * resource.item_consumption(item_type_id, schedule_length - 1);
+    if (tail_count > 0) {
+        double last_schedule_value = prefix_sums[schedule_length] - prefix_sums[schedule_length - 1];
+        sum += (double)tail_count * last_schedule_value;
+    }
     return sum;
 }
 

--- a/include/packingsolver/box/instance.hpp
+++ b/include/packingsolver/box/instance.hpp
@@ -175,13 +175,16 @@ struct ItemType
 
     /**
      * For each bin type (indexed by bin_type_id - a resource's id is only
-     * ever local to one bin type, see 'BinType::resources'), the ids of
-     * that bin type's resources this item type has a non-zero consumption
-     * for. Lets algorithms that need every resource a given item type
-     * (in a given bin type) might affect skip the rest, instead of scanning
-     * every resource of the bin type for every item.
+     * ever local to one bin type, see 'BinType::resources'), the bin
+     * type's resources this item type has a non-zero consumption for,
+     * together with the position of this item type's own entry in each
+     * resource's own 'Resource::item_consumptions' (see
+     * 'ItemResourceConsumption') - so a caller can jump straight to its
+     * schedule with no search. Lets algorithms that need every resource a
+     * given item type (in a given bin type) might affect skip the rest,
+     * instead of scanning every resource of the bin type for every item.
      */
-    std::vector<std::vector<ResourceId>> resource_ids;
+    std::vector<std::vector<ItemResourceConsumption>> resources;
 };
 
 std::ostream& operator<<(

--- a/include/packingsolver/box/instance_builder.hpp
+++ b/include/packingsolver/box/instance_builder.hpp
@@ -81,17 +81,17 @@ public:
             double penalty = 0.0);
 
     /**
-     * Set an item type's consumption of a bin type's resource for the
-     * 'item_copy'-th copy of the item type placed in the bin (0-indexed). See
-     * 'Resource::item_consumptions' for the exact semantics of a
-     * per-copy schedule.
+     * Set an item type's whole per-copy consumption schedule of a bin
+     * type's resource at once - see 'Resource::item_consumptions' for the
+     * exact semantics of a per-copy schedule. May be called at most once
+     * per (item type, resource) pair - 'InstanceBuilder::build' throws
+     * otherwise.
      */
     void add_resource_consumption(
             BinTypeId bin_type_id,
             ResourceId resource_id,
             ItemTypeId item_type_id,
-            ItemPos item_copy,
-            double consumption);
+            const std::vector<double>& schedule);
 
     /**
      * Add a bin type from another bin type.

--- a/include/packingsolver/irregular/instance.hpp
+++ b/include/packingsolver/irregular/instance.hpp
@@ -332,13 +332,16 @@ struct ItemType
 
     /**
      * For each bin type (indexed by bin_type_id - a resource's id is only
-     * ever local to one bin type, see 'BinType::resources'), the ids of
-     * that bin type's resources this item type has a non-zero consumption
-     * for. Lets algorithms that need every resource a given item type
-     * (in a given bin type) might affect skip the rest, instead of scanning
-     * every resource of the bin type for every item.
+     * ever local to one bin type, see 'BinType::resources'), the bin
+     * type's resources this item type has a non-zero consumption for,
+     * together with the position of this item type's own entry in each
+     * resource's own 'Resource::item_consumptions' (see
+     * 'ItemResourceConsumption') - so a caller can jump straight to its
+     * schedule with no search. Lets algorithms that need every resource a
+     * given item type (in a given bin type) might affect skip the rest,
+     * instead of scanning every resource of the bin type for every item.
      */
-    std::vector<std::vector<ResourceId>> resource_ids;
+    std::vector<std::vector<ItemResourceConsumption>> resources;
 
     AreaDbl space() const { return area_orig; }
 

--- a/include/packingsolver/irregular/instance_builder.hpp
+++ b/include/packingsolver/irregular/instance_builder.hpp
@@ -89,17 +89,17 @@ public:
             double penalty = 0.0);
 
     /**
-     * Set an item type's consumption of a bin type's resource for the
-     * 'item_copy'-th copy of the item type placed in the bin (0-indexed). See
-     * 'Resource::item_consumptions' for the exact semantics of a
-     * per-copy schedule.
+     * Set an item type's whole per-copy consumption schedule of a bin
+     * type's resource at once - see 'Resource::item_consumptions' for the
+     * exact semantics of a per-copy schedule. May be called at most once
+     * per (item type, resource) pair - 'InstanceBuilder::build' throws
+     * otherwise.
      */
     void add_resource_consumption(
             BinTypeId bin_type_id,
             ResourceId resource_id,
             ItemTypeId item_type_id,
-            ItemPos item_copy,
-            double consumption);
+            const std::vector<double>& schedule);
 
     /**
      * Add a bin type from another bin type.

--- a/include/packingsolver/onedimensional/instance.hpp
+++ b/include/packingsolver/onedimensional/instance.hpp
@@ -106,13 +106,16 @@ struct ItemType
 
     /**
      * For each bin type (indexed by bin_type_id - a resource's id is only
-     * ever local to one bin type, see 'BinType::resources'), the ids of
-     * that bin type's resources this item type has a non-zero consumption
-     * for. Lets algorithms that need every resource a given item type
-     * (in a given bin type) might affect skip the rest, instead of scanning
-     * every resource of the bin type for every item.
+     * ever local to one bin type, see 'BinType::resources'), the bin
+     * type's resources this item type has a non-zero consumption for,
+     * together with the position of this item type's own entry in each
+     * resource's own 'Resource::item_consumptions' (see
+     * 'ItemResourceConsumption') - so a caller can jump straight to its
+     * schedule with no search. Lets algorithms that need every resource a
+     * given item type (in a given bin type) might affect skip the rest,
+     * instead of scanning every resource of the bin type for every item.
      */
-    std::vector<std::vector<ResourceId>> resource_ids;
+    std::vector<std::vector<ItemResourceConsumption>> resources;
 
 };
 

--- a/include/packingsolver/onedimensional/instance_builder.hpp
+++ b/include/packingsolver/onedimensional/instance_builder.hpp
@@ -84,19 +84,19 @@ public:
             double penalty = 0.0);
 
     /**
-     * Set an item type's consumption of a bin type's resource for the
-     * 'item_copy'-th (0-indexed) copy of the item type; see
-     * 'Resource::item_consumptions' for the exact semantics of a
-     * copy past the last one explicitly set (it repeats the last one set).
-     * Setting only 'item_copy == 0' gives the same, uniform consumption
-     * regardless of how many copies are already packed - the common case.
+     * Set an item type's whole per-copy consumption schedule of a bin
+     * type's resource at once; see 'Resource::item_consumptions' for the
+     * exact semantics of a copy past the last one in the schedule (it
+     * repeats the last one) - a length-1 schedule gives the same, uniform
+     * consumption regardless of how many copies are already packed, the
+     * common case. May be called at most once per (item type, resource)
+     * pair - 'InstanceBuilder::build' throws otherwise.
      */
     void add_resource_consumption(
             BinTypeId bin_type_id,
             ResourceId resource_id,
             ItemTypeId item_type_id,
-            ItemPos item_copy,
-            double consumption);
+            const std::vector<double>& schedule);
 
     /**
      * Add a bin type from another bin type.

--- a/include/packingsolver/rectangle/instance.hpp
+++ b/include/packingsolver/rectangle/instance.hpp
@@ -179,13 +179,16 @@ struct ItemType
 
     /**
      * For each bin type (indexed by bin_type_id - a resource's id is only
-     * ever local to one bin type, see 'BinType::resources'), the ids of
-     * that bin type's resources this item type has a non-zero consumption
-     * for. Lets algorithms that need every resource a given item type
-     * (in a given bin type) might affect skip the rest, instead of scanning
-     * every resource of the bin type for every item.
+     * ever local to one bin type, see 'BinType::resources'), the bin
+     * type's resources this item type has a non-zero consumption for,
+     * together with the position of this item type's own entry in each
+     * resource's own 'Resource::item_consumptions' (see
+     * 'ItemResourceConsumption') - so a caller can jump straight to its
+     * schedule with no search. Lets algorithms that need every resource a
+     * given item type (in a given bin type) might affect skip the rest,
+     * instead of scanning every resource of the bin type for every item.
      */
-    std::vector<std::vector<ResourceId>> resource_ids;
+    std::vector<std::vector<ItemResourceConsumption>> resources;
 };
 
 std::ostream& operator<<(

--- a/include/packingsolver/rectangle/instance_builder.hpp
+++ b/include/packingsolver/rectangle/instance_builder.hpp
@@ -123,17 +123,17 @@ public:
             double penalty = 0.0);
 
     /**
-     * Set an item type's consumption of a bin type's resource for the
-     * 'item_copy'-th copy of the item type placed in the bin (0-indexed). See
-     * 'Resource::item_consumptions' for the exact semantics of a
-     * per-copy schedule.
+     * Set an item type's whole per-copy consumption schedule of a bin
+     * type's resource at once - see 'Resource::item_consumptions' for the
+     * exact semantics of a per-copy schedule. May be called at most once
+     * per (item type, resource) pair - 'InstanceBuilder::build' throws
+     * otherwise.
      */
     void add_resource_consumption(
             BinTypeId bin_type_id,
             ResourceId resource_id,
             ItemTypeId item_type_id,
-            ItemPos item_copy,
-            double consumption);
+            const std::vector<double>& schedule);
 
     /**
      * Add a bin type from another bin type.

--- a/include/packingsolver/rectangleguillotine/instance.hpp
+++ b/include/packingsolver/rectangleguillotine/instance.hpp
@@ -336,13 +336,16 @@ struct ItemType
 
     /**
      * For each bin type (indexed by bin_type_id - a resource's id is only
-     * ever local to one bin type, see 'BinType::resources'), the ids of
-     * that bin type's resources this item type has a non-zero consumption
-     * for. Lets algorithms that need every resource a given item type
-     * (in a given bin type) might affect skip the rest, instead of scanning
-     * every resource of the bin type for every item.
+     * ever local to one bin type, see 'BinType::resources'), the bin
+     * type's resources this item type has a non-zero consumption for,
+     * together with the position of this item type's own entry in each
+     * resource's own 'Resource::item_consumptions' (see
+     * 'ItemResourceConsumption') - so a caller can jump straight to its
+     * schedule with no search. Lets algorithms that need every resource a
+     * given item type (in a given bin type) might affect skip the rest,
+     * instead of scanning every resource of the bin type for every item.
      */
-    std::vector<std::vector<ResourceId>> resource_ids;
+    std::vector<std::vector<ItemResourceConsumption>> resources;
 };
 
 std::ostream& operator<<(

--- a/include/packingsolver/rectangleguillotine/instance_builder.hpp
+++ b/include/packingsolver/rectangleguillotine/instance_builder.hpp
@@ -162,17 +162,17 @@ public:
             double penalty = 0.0);
 
     /**
-     * Set an item type's consumption of a bin type's resource for the
-     * 'item_copy'-th copy of the item type placed in the bin (0-indexed). See
-     * 'Resource::item_consumptions' for the exact semantics of a
-     * per-copy schedule.
+     * Set an item type's whole per-copy consumption schedule of a bin
+     * type's resource at once - see 'Resource::item_consumptions' for the
+     * exact semantics of a per-copy schedule. May be called at most once
+     * per (item type, resource) pair - 'InstanceBuilder::build' throws
+     * otherwise.
      */
     void add_resource_consumption(
             BinTypeId bin_type_id,
             ResourceId resource_id,
             ItemTypeId item_type_id,
-            ItemPos item_copy,
-            double consumption);
+            const std::vector<double>& schedule);
 
     /**
      * Add a bin type from another bin type.

--- a/src/algorithms/column_generation.hpp
+++ b/src/algorithms/column_generation.hpp
@@ -546,7 +546,7 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution,
                         // Consumption schedule '[1.0, 0.0]': the item
                         // type's first copy consumes 1.0 (counts as
                         // "present"), every further copy consumes 0.0 (see
-                        // 'Resource::item_consumption' - a copy past the
+                        // 'Resource::item_consumptions' - a copy past the
                         // end of the schedule repeats its last entry, so
                         // without this trailing 0 every extra copy would
                         // keep adding 1.0, making the resource count total
@@ -556,14 +556,7 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution,
                                 kp_bin_type_id,
                                 resource_id,
                                 kp_item_type_id,
-                                0,
-                                1.0);
-                        kp_instance_builder.add_resource_consumption(
-                                kp_bin_type_id,
-                                resource_id,
-                                kp_item_type_id,
-                                1,
-                                0.0);
+                                {1.0, 0.0});
                     }
                 }
             }
@@ -631,20 +624,13 @@ PricingOutput ColumnGenerationPricingSolver<Instance, InstanceBuilder, Solution,
             for (const auto& present_kp_item_threshold: present_kp_item_thresholds) {
                 ItemTypeId kp_item_type_id = present_kp_item_threshold.first;
                 ItemPos threshold = present_kp_item_threshold.second;
-                for (ItemPos copy = 0; copy < threshold; ++copy) {
-                    kp_instance_builder.add_resource_consumption(
-                            kp_bin_type_id,
-                            resource_id,
-                            kp_item_type_id,
-                            copy,
-                            1.0);
-                }
+                std::vector<double> schedule(threshold, 1.0);
+                schedule.push_back(0.0);
                 kp_instance_builder.add_resource_consumption(
                         kp_bin_type_id,
                         resource_id,
                         kp_item_type_id,
-                        threshold,
-                        0.0);
+                        schedule);
             }
         }
 

--- a/src/box/instance.cpp
+++ b/src/box/instance.cpp
@@ -339,14 +339,12 @@ void Instance::write_json(
                 json_resource["penalize"] = resource.penalize;
                 json_resource["penalty"] = resource.penalty;
                 json_resource["consumptions"] = nlohmann::json::array();
-                for (ItemTypeId item_type_id = 0;
-                        item_type_id < (ItemTypeId)resource.item_consumptions.size();
-                        ++item_type_id) {
-                    const std::vector<double>& schedule = resource.item_consumptions[item_type_id];
+                for (const std::pair<ItemTypeId, std::vector<double>>& entry: resource.item_consumptions) {
+                    const std::vector<double>& schedule = entry.second;
                     if (schedule.empty())
                         continue;
                     nlohmann::json json_consumption;
-                    json_consumption["item_type_id"] = item_type_id;
+                    json_consumption["item_type_id"] = entry.first;
                     if (schedule.size() == 1) {
                         json_consumption["consumption"] = schedule[0];
                     } else {

--- a/src/box/instance_builder.cpp
+++ b/src/box/instance_builder.cpp
@@ -1,6 +1,7 @@
 #include "packingsolver/box/instance_builder.hpp"
 
 #include "optimizationtools/utils/utils.hpp"
+#include "optimizationtools/containers/indexed_set.hpp"
 
 using namespace packingsolver;
 using namespace packingsolver::box;
@@ -113,8 +114,7 @@ void InstanceBuilder::add_resource_consumption(
         BinTypeId bin_type_id,
         ResourceId resource_id,
         ItemTypeId item_type_id,
-        ItemPos item_copy,
-        double consumption)
+        const std::vector<double>& schedule)
 {
     if (bin_type_id < 0 || bin_type_id >= (BinTypeId)instance_.bin_types_.size()) {
         throw std::invalid_argument(
@@ -132,20 +132,11 @@ void InstanceBuilder::add_resource_consumption(
                 "resource_id: " + std::to_string(resource_id) + "; "
                 "bin_type.resources.size(): " + std::to_string(bin_type.resources.size()) + ".");
     }
-    if (item_copy < 0) {
-        throw std::invalid_argument(
-                FUNC_SIGNATURE + ": "
-                "invalid 'item_copy'; "
-                "item_copy: " + std::to_string(item_copy) + ".");
-    }
 
-    std::vector<std::vector<double>>& item_consumptions = bin_type.resources[resource_id].item_consumptions;
-    if (item_type_id >= (ItemTypeId)item_consumptions.size())
-        item_consumptions.resize(item_type_id + 1);
-    std::vector<double>& schedule = item_consumptions[item_type_id];
-    if (item_copy >= (ItemPos)schedule.size())
-        schedule.resize(item_copy + 1, 0.0);
-    schedule[item_copy] = consumption;
+    // May be called at most once per (item type, resource) pair (checked,
+    // and thrown on otherwise, in 'build' below) - no search needed, just
+    // append.
+    bin_type.resources[resource_id].item_consumptions.push_back({item_type_id, schedule});
 }
 
 BinTypeId InstanceBuilder::add_bin_type(
@@ -386,24 +377,15 @@ ItemTypeId InstanceBuilder::add_item_type(
         if (sub_bin_type_id == -1)
             continue;
         const BinType& original_bin_type = original_instance.bin_type(original_bin_type_id);
-        for (ResourceId resource_id = 0;
-                resource_id < original_bin_type.number_of_resources();
-                ++resource_id) {
-            const std::vector<std::vector<double>>& item_consumptions
-                = original_bin_type.resource(resource_id).item_consumptions;
-            if (original_item_type_id >= (ItemTypeId)item_consumptions.size())
-                continue;
-            const std::vector<double>& schedule = item_consumptions[original_item_type_id];
-            for (ItemPos item_copy = 0;
-                    item_copy < (ItemPos)schedule.size();
-                    ++item_copy) {
-                add_resource_consumption(
-                        sub_bin_type_id,
-                        resource_id,
-                        item_type_id,
-                        item_copy,
-                        schedule[item_copy]);
-            }
+        for (const ItemResourceConsumption& consumption: item_type.resources[original_bin_type_id]) {
+            const std::vector<double>& schedule
+                = original_bin_type.resource(consumption.resource_id)
+                    .item_consumptions[consumption.consumption_pos].second;
+            add_resource_consumption(
+                    sub_bin_type_id,
+                    consumption.resource_id,
+                    item_type_id,
+                    schedule);
         }
     }
     return item_type_id;
@@ -815,16 +797,11 @@ void InstanceBuilder::read(
                             // the end of the schedule repeats its last
                             // entry); see 'Resource::item_consumptions'.
                             std::vector<double> schedule = json_consumption["consumption_schedule"];
-                            for (ItemPos item_copy = 0;
-                                    item_copy < (ItemPos)schedule.size();
-                                    ++item_copy) {
-                                add_resource_consumption(
-                                        bin_type_id,
-                                        resource_id,
-                                        item_type_id,
-                                        item_copy,
-                                        schedule[item_copy]);
-                            }
+                            add_resource_consumption(
+                                    bin_type_id,
+                                    resource_id,
+                                    item_type_id,
+                                    schedule);
                         } else {
                             // Uniform consumption, regardless of how many
                             // copies are already packed.
@@ -833,8 +810,7 @@ void InstanceBuilder::read(
                                     bin_type_id,
                                     resource_id,
                                     item_type_id,
-                                    0,
-                                    consumption);
+                                    {consumption});
                         }
                     }
                 }
@@ -1002,12 +978,13 @@ Instance InstanceBuilder::build()
             instance_.item_types_[fixed_item.item_type_id].copies_fixed += bin_type.copies;
     }
 
-    // Compute item_type.resource_ids (see its own doc comment).
+    // Compute item_type.resources (see its own doc comment).
     for (ItemTypeId item_type_id = 0;
             item_type_id < instance_.number_of_item_types();
             ++item_type_id) {
-        instance_.item_types_[item_type_id].resource_ids.resize(instance_.number_of_bin_types());
+        instance_.item_types_[item_type_id].resources.resize(instance_.number_of_bin_types());
     }
+    optimizationtools::IndexedSet seen_item_type_ids(instance_.number_of_item_types());
     for (BinTypeId bin_type_id = 0;
             bin_type_id < instance_.number_of_bin_types();
             ++bin_type_id) {
@@ -1016,12 +993,24 @@ Instance InstanceBuilder::build()
                 resource_id < bin_type.number_of_resources();
                 ++resource_id) {
             const Resource& resource = bin_type.resource(resource_id);
-            for (ItemTypeId item_type_id = 0;
-                    item_type_id < (ItemTypeId)resource.item_consumptions.size();
-                    ++item_type_id) {
-                if (!resource.item_consumptions[item_type_id].empty()) {
-                    instance_.item_types_[item_type_id].resource_ids[bin_type_id]
-                        .push_back(resource_id);
+            seen_item_type_ids.clear();
+            for (std::size_t consumption_pos = 0;
+                    consumption_pos < resource.item_consumptions.size();
+                    ++consumption_pos) {
+                const std::pair<ItemTypeId, std::vector<double>>& entry
+                    = resource.item_consumptions[consumption_pos];
+                if (!seen_item_type_ids.add(entry.first)) {
+                    throw std::invalid_argument(
+                            FUNC_SIGNATURE + ": "
+                            "resource " + std::to_string(resource_id) + " of bin type " +
+                            std::to_string(bin_type_id) + " has more than one consumption "
+                            "entry for item type " + std::to_string(entry.first) + "; "
+                            "'add_resource_consumption' may only be called once per "
+                            "(item type, resource) pair.");
+                }
+                if (!entry.second.empty()) {
+                    instance_.item_types_[entry.first].resources[bin_type_id]
+                        .push_back({resource_id, consumption_pos});
                 }
             }
         }

--- a/src/box/solution.cpp
+++ b/src/box/solution.cpp
@@ -55,12 +55,14 @@ void Solution::update_indicators(
         item_profit_ += bin.copies * item_type.profit;
 
         // Update bin.resource_consumption.
-        for (ResourceId resource_id: item_type.resource_ids[bin.bin_type_id]) {
+        for (const ItemResourceConsumption& consumption: item_type.resources[bin.bin_type_id]) {
+            ResourceId resource_id = consumption.resource_id;
             const Resource& resource = bin_type.resource(resource_id);
+            const std::vector<double>& schedule = resource.item_consumptions[consumption.consumption_pos].second;
             double previous_consumption = bin.resource_consumption[resource_id];
             bin.resource_consumption[resource_id]
-                += resource.item_consumption(
-                        item.item_type_id,
+                += schedule_consumption(
+                        schedule,
                         item_type_copies_in_bin[item.item_type_id]);
             if (bin.resource_consumption[resource_id] > resource.capacity) {
                 if (resource.penalize) {

--- a/src/box/tree_search.cpp
+++ b/src/box/tree_search.cpp
@@ -342,9 +342,12 @@ BranchingScheme::Node BranchingScheme::child_tmp(
         if (insertion.new_bin > 0) {  // New bin.
             node.last_bin_item_number_of_copies.assign(instance.number_of_item_types(), 0);
             node.last_bin_resource_consumption.assign(bin_type.number_of_resources(), 0.0);
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
-                double consumption = resource.item_consumption(insertion.item_type_id, 0);
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
+                double consumption = schedule_consumption(schedule, 0);
                 node.last_bin_resource_consumption[resource_id] = consumption;
                 // The bin is empty before this insertion, so any crossing here
                 // is necessarily the first one.
@@ -356,11 +359,14 @@ BranchingScheme::Node BranchingScheme::child_tmp(
             node.last_bin_item_number_of_copies = parent.last_bin_item_number_of_copies;
             ItemPos item_copy = node.last_bin_item_number_of_copies[insertion.item_type_id];
             node.last_bin_resource_consumption = parent.last_bin_resource_consumption;
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
                 double previous_consumption = node.last_bin_resource_consumption[resource_id];
                 node.last_bin_resource_consumption[resource_id]
-                    += resource.item_consumption(insertion.item_type_id, item_copy);
+                    += schedule_consumption(schedule, item_copy);
                 if (resource.penalize
                         && node.last_bin_resource_consumption[resource_id] > resource.capacity
                         && previous_consumption <= resource.capacity) {
@@ -588,21 +594,27 @@ void BranchingScheme::insertion_item(
     if (bin_type.number_of_resources() > 0) {
         if (new_bin == 0) {  // Same bin.
             ItemPos item_copy = parent->last_bin_item_number_of_copies[item_type_id];
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
                 if (resource.penalize)
                     continue;
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
                 double consumption = parent->last_bin_resource_consumption[resource_id]
-                    + resource.item_consumption(item_type_id, item_copy);
+                    + schedule_consumption(schedule, item_copy);
                 if (consumption > resource.capacity * PSTOL)
                     return;
             }
         } else {  // New bin.
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
                 if (resource.penalize)
                     continue;
-                double consumption = resource.item_consumption(item_type_id, 0);
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
+                double consumption = schedule_consumption(schedule, 0);
                 if (consumption > resource.capacity * PSTOL)
                     return;
             }

--- a/src/irregular/instance_builder.cpp
+++ b/src/irregular/instance_builder.cpp
@@ -7,6 +7,8 @@
 #include "shape/extract_borders.hpp"
 #include "shape/clean.hpp"
 
+#include "optimizationtools/containers/indexed_set.hpp"
+
 #include <sstream>
 
 using namespace packingsolver;
@@ -131,8 +133,7 @@ void InstanceBuilder::add_resource_consumption(
         BinTypeId bin_type_id,
         ResourceId resource_id,
         ItemTypeId item_type_id,
-        ItemPos item_copy,
-        double consumption)
+        const std::vector<double>& schedule)
 {
     if (bin_type_id < 0 || bin_type_id >= (BinTypeId)instance_.bin_types_.size()) {
         throw std::invalid_argument(
@@ -150,20 +151,11 @@ void InstanceBuilder::add_resource_consumption(
                 "resource_id: " + std::to_string(resource_id) + "; "
                 "bin_type.resources.size(): " + std::to_string(bin_type.resources.size()) + ".");
     }
-    if (item_copy < 0) {
-        throw std::invalid_argument(
-                FUNC_SIGNATURE + ": "
-                "invalid 'item_copy'; "
-                "item_copy: " + std::to_string(item_copy) + ".");
-    }
 
-    std::vector<std::vector<double>>& item_consumptions = bin_type.resources[resource_id].item_consumptions;
-    if (item_type_id >= (ItemTypeId)item_consumptions.size())
-        item_consumptions.resize(item_type_id + 1);
-    std::vector<double>& schedule = item_consumptions[item_type_id];
-    if (item_copy >= (ItemPos)schedule.size())
-        schedule.resize(item_copy + 1, 0.0);
-    schedule[item_copy] = consumption;
+    // May be called at most once per (item type, resource) pair (checked,
+    // and thrown on otherwise, in 'build' below) - no search needed, just
+    // append.
+    bin_type.resources[resource_id].item_consumptions.push_back({item_type_id, schedule});
 }
 
 void InstanceBuilder::set_bin_type_cost(
@@ -402,24 +394,15 @@ ItemTypeId InstanceBuilder::add_item_type(
         if (sub_bin_type_id == -1)
             continue;
         const BinType& original_bin_type = original_instance.bin_type(original_bin_type_id);
-        for (ResourceId resource_id = 0;
-                resource_id < original_bin_type.number_of_resources();
-                ++resource_id) {
-            const std::vector<std::vector<double>>& item_consumptions
-                = original_bin_type.resource(resource_id).item_consumptions;
-            if (original_item_type_id >= (ItemTypeId)item_consumptions.size())
-                continue;
-            const std::vector<double>& schedule = item_consumptions[original_item_type_id];
-            for (ItemPos item_copy = 0;
-                    item_copy < (ItemPos)schedule.size();
-                    ++item_copy) {
-                add_resource_consumption(
-                        sub_bin_type_id,
-                        resource_id,
-                        item_type_id,
-                        item_copy,
-                        schedule[item_copy]);
-            }
+        for (const ItemResourceConsumption& consumption: item_type.resources[original_bin_type_id]) {
+            const std::vector<double>& schedule
+                = original_bin_type.resource(consumption.resource_id)
+                    .item_consumptions[consumption.consumption_pos].second;
+            add_resource_consumption(
+                    sub_bin_type_id,
+                    consumption.resource_id,
+                    item_type_id,
+                    schedule);
         }
     }
 
@@ -1084,12 +1067,13 @@ Instance InstanceBuilder::build()
                 "an instance with objective OpenDimensionY must contain exactly one bin.");
     }
 
-    // Compute item_type.resource_ids (see its own doc comment).
+    // Compute item_type.resources (see its own doc comment).
     for (ItemTypeId item_type_id = 0;
             item_type_id < instance_.number_of_item_types();
             ++item_type_id) {
-        instance_.item_types_[item_type_id].resource_ids.resize(instance_.number_of_bin_types());
+        instance_.item_types_[item_type_id].resources.resize(instance_.number_of_bin_types());
     }
+    optimizationtools::IndexedSet seen_item_type_ids(instance_.number_of_item_types());
     for (BinTypeId bin_type_id = 0;
             bin_type_id < instance_.number_of_bin_types();
             ++bin_type_id) {
@@ -1098,12 +1082,24 @@ Instance InstanceBuilder::build()
                 resource_id < bin_type.number_of_resources();
                 ++resource_id) {
             const Resource& resource = bin_type.resource(resource_id);
-            for (ItemTypeId item_type_id = 0;
-                    item_type_id < (ItemTypeId)resource.item_consumptions.size();
-                    ++item_type_id) {
-                if (!resource.item_consumptions[item_type_id].empty()) {
-                    instance_.item_types_[item_type_id].resource_ids[bin_type_id]
-                        .push_back(resource_id);
+            seen_item_type_ids.clear();
+            for (std::size_t consumption_pos = 0;
+                    consumption_pos < resource.item_consumptions.size();
+                    ++consumption_pos) {
+                const std::pair<ItemTypeId, std::vector<double>>& entry
+                    = resource.item_consumptions[consumption_pos];
+                if (!seen_item_type_ids.add(entry.first)) {
+                    throw std::invalid_argument(
+                            FUNC_SIGNATURE + ": "
+                            "resource " + std::to_string(resource_id) + " of bin type " +
+                            std::to_string(bin_type_id) + " has more than one consumption "
+                            "entry for item type " + std::to_string(entry.first) + "; "
+                            "'add_resource_consumption' may only be called once per "
+                            "(item type, resource) pair.");
+                }
+                if (!entry.second.empty()) {
+                    instance_.item_types_[entry.first].resources[bin_type_id]
+                        .push_back({resource_id, consumption_pos});
                 }
             }
         }

--- a/src/irregular/solution.cpp
+++ b/src/irregular/solution.cpp
@@ -60,12 +60,14 @@ void Solution::update_indicators(
         bin.y_max = std::max(bin.y_max, item.bl_corner.y + aabb.y_max);
 
         // Update bin.resource_consumption.
-        for (ResourceId resource_id: item_type.resource_ids[bin.bin_type_id]) {
+        for (const ItemResourceConsumption& consumption: item_type.resources[bin.bin_type_id]) {
+            ResourceId resource_id = consumption.resource_id;
             const Resource& resource = bin_type.resource(resource_id);
+            const std::vector<double>& schedule = resource.item_consumptions[consumption.consumption_pos].second;
             double previous_consumption = bin.resource_consumption[resource_id];
             bin.resource_consumption[resource_id]
-                += resource.item_consumption(
-                        item.item_type_id,
+                += schedule_consumption(
+                        schedule,
                         item_type_copies_in_bin[item.item_type_id]);
             if (bin.resource_consumption[resource_id] > resource.capacity) {
                 if (resource.penalize) {

--- a/src/irregular/tree_search.cpp
+++ b/src/irregular/tree_search.cpp
@@ -1279,9 +1279,12 @@ BranchingScheme::Node BranchingScheme::child_tmp(
         if (insertion.new_bin_direction != Direction::Any) {  // New bin.
             node.last_bin_item_number_of_copies.assign(instance_.number_of_item_types(), 0);
             node.last_bin_resource_consumption.assign(bin_type.number_of_resources(), 0.0);
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
-                double consumption = resource.item_consumption(trapezoid_set.item_type_id, 0);
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
+                double consumption = schedule_consumption(schedule, 0);
                 node.last_bin_resource_consumption[resource_id] = consumption;
                 // The bin is empty before this insertion, so any crossing here
                 // is necessarily the first one.
@@ -1293,11 +1296,14 @@ BranchingScheme::Node BranchingScheme::child_tmp(
             node.last_bin_item_number_of_copies = parent.last_bin_item_number_of_copies;
             ItemPos item_copy = node.last_bin_item_number_of_copies[trapezoid_set.item_type_id];
             node.last_bin_resource_consumption = parent.last_bin_resource_consumption;
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
                 double previous_consumption = node.last_bin_resource_consumption[resource_id];
                 node.last_bin_resource_consumption[resource_id]
-                    += resource.item_consumption(trapezoid_set.item_type_id, item_copy);
+                    += schedule_consumption(schedule, item_copy);
                 if (resource.penalize
                         && node.last_bin_resource_consumption[resource_id] > resource.capacity
                         && previous_consumption <= resource.capacity) {
@@ -1967,21 +1973,27 @@ void BranchingScheme::insertion_trapezoid_set(
     if (bin_type.number_of_resources() > 0) {
         if (new_bin_direction == Direction::Any) {  // Same bin.
             ItemPos item_copy = parent->last_bin_item_number_of_copies[trapezoid_set.item_type_id];
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
                 if (resource.penalize)
                     continue;
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
                 double consumption = parent->last_bin_resource_consumption[resource_id]
-                    + resource.item_consumption(trapezoid_set.item_type_id, item_copy);
+                    + schedule_consumption(schedule, item_copy);
                 if (consumption > resource.capacity * PSTOL)
                     return;
             }
         } else {  // New bin.
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
                 if (resource.penalize)
                     continue;
-                double consumption = resource.item_consumption(trapezoid_set.item_type_id, 0);
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
+                double consumption = schedule_consumption(schedule, 0);
                 if (consumption > resource.capacity * PSTOL)
                     return;
             }

--- a/src/onedimensional/instance.cpp
+++ b/src/onedimensional/instance.cpp
@@ -357,16 +357,12 @@ void Instance::write_json(
                     json_resource["penalty"] = resource.penalty;
                 }
                 nlohmann::json json_consumptions = nlohmann::json::array();
-                const std::vector<std::vector<double>>& consumptions
-                    = resource.item_consumptions;
-                for (ItemTypeId item_type_id = 0;
-                        item_type_id < (ItemTypeId)consumptions.size();
-                        ++item_type_id) {
-                    const std::vector<double>& schedule = consumptions[item_type_id];
+                for (const std::pair<ItemTypeId, std::vector<double>>& entry: resource.item_consumptions) {
+                    const std::vector<double>& schedule = entry.second;
                     if (schedule.empty())
                         continue;
                     nlohmann::json json_consumption;
-                    json_consumption["item_type_id"] = item_type_id;
+                    json_consumption["item_type_id"] = entry.first;
                     if (schedule.size() == 1) {
                         json_consumption["consumption"] = schedule[0];
                     } else {

--- a/src/onedimensional/instance_builder.cpp
+++ b/src/onedimensional/instance_builder.cpp
@@ -1,6 +1,7 @@
 #include "packingsolver/onedimensional/instance_builder.hpp"
 
 #include "optimizationtools/utils/utils.hpp"
+#include "optimizationtools/containers/indexed_set.hpp"
 
 using namespace packingsolver;
 using namespace packingsolver::onedimensional;
@@ -112,8 +113,7 @@ void InstanceBuilder::add_resource_consumption(
         BinTypeId bin_type_id,
         ResourceId resource_id,
         ItemTypeId item_type_id,
-        ItemPos item_copy,
-        double consumption)
+        const std::vector<double>& schedule)
 {
     if (bin_type_id < 0 || bin_type_id >= (BinTypeId)instance_.bin_types_.size()) {
         throw std::invalid_argument(
@@ -131,20 +131,11 @@ void InstanceBuilder::add_resource_consumption(
                 "resource_id: " + std::to_string(resource_id) + "; "
                 "bin_type.resources.size(): " + std::to_string(bin_type.resources.size()) + ".");
     }
-    if (item_copy < 0) {
-        throw std::invalid_argument(
-                FUNC_SIGNATURE + ": "
-                "invalid 'item_copy'; "
-                "item_copy: " + std::to_string(item_copy) + ".");
-    }
 
-    std::vector<std::vector<double>>& item_consumptions = bin_type.resources[resource_id].item_consumptions;
-    if (item_type_id >= (ItemTypeId)item_consumptions.size())
-        item_consumptions.resize(item_type_id + 1);
-    std::vector<double>& schedule = item_consumptions[item_type_id];
-    if (item_copy >= (ItemPos)schedule.size())
-        schedule.resize(item_copy + 1, 0.0);
-    schedule[item_copy] = consumption;
+    // May be called at most once per (item type, resource) pair (checked,
+    // and thrown on otherwise, in 'build' below) - no search needed, just
+    // append.
+    bin_type.resources[resource_id].item_consumptions.push_back({item_type_id, schedule});
 }
 
 BinTypeId InstanceBuilder::add_bin_type(
@@ -411,24 +402,15 @@ ItemTypeId InstanceBuilder::add_item_type(
         if (sub_bin_type_id == -1)
             continue;
         const BinType& original_bin_type = original_instance.bin_type(original_bin_type_id);
-        for (ResourceId resource_id = 0;
-                resource_id < original_bin_type.number_of_resources();
-                ++resource_id) {
-            const std::vector<std::vector<double>>& item_consumptions
-                = original_bin_type.resource(resource_id).item_consumptions;
-            if (original_item_type_id >= (ItemTypeId)item_consumptions.size())
-                continue;
-            const std::vector<double>& schedule = item_consumptions[original_item_type_id];
-            for (ItemPos item_copy = 0;
-                    item_copy < (ItemPos)schedule.size();
-                    ++item_copy) {
-                add_resource_consumption(
-                        sub_bin_type_id,
-                        resource_id,
-                        item_type_id,
-                        item_copy,
-                        schedule[item_copy]);
-            }
+        for (const ItemResourceConsumption& consumption: item_type.resources[original_bin_type_id]) {
+            const std::vector<double>& schedule
+                = original_bin_type.resource(consumption.resource_id)
+                    .item_consumptions[consumption.consumption_pos].second;
+            add_resource_consumption(
+                    sub_bin_type_id,
+                    consumption.resource_id,
+                    item_type_id,
+                    schedule);
         }
     }
     // Record this item type's side of every precedence it is involved in
@@ -780,16 +762,11 @@ void InstanceBuilder::read(
                             // the end of the schedule repeats its last
                             // entry); see 'Resource::item_consumptions'.
                             std::vector<double> schedule = json_consumption["consumption_schedule"];
-                            for (ItemPos item_copy = 0;
-                                    item_copy < (ItemPos)schedule.size();
-                                    ++item_copy) {
-                                add_resource_consumption(
-                                        bin_type_id,
-                                        resource_id,
-                                        item_type_id,
-                                        item_copy,
-                                        schedule[item_copy]);
-                            }
+                            add_resource_consumption(
+                                    bin_type_id,
+                                    resource_id,
+                                    item_type_id,
+                                    schedule);
                         } else {
                             // Uniform consumption, regardless of how many
                             // copies are already packed.
@@ -798,8 +775,7 @@ void InstanceBuilder::read(
                                     bin_type_id,
                                     resource_id,
                                     item_type_id,
-                                    0,
-                                    consumption);
+                                    {consumption});
                         }
                     }
                 }
@@ -950,12 +926,13 @@ Instance InstanceBuilder::build()
         }
     }
 
-    // Compute item_type.resource_ids (see its own doc comment).
+    // Compute item_type.resources (see its own doc comment).
     for (ItemTypeId item_type_id = 0;
             item_type_id < instance_.number_of_item_types();
             ++item_type_id) {
-        instance_.item_types_[item_type_id].resource_ids.resize(instance_.number_of_bin_types());
+        instance_.item_types_[item_type_id].resources.resize(instance_.number_of_bin_types());
     }
+    optimizationtools::IndexedSet seen_item_type_ids(instance_.number_of_item_types());
     for (BinTypeId bin_type_id = 0;
             bin_type_id < instance_.number_of_bin_types();
             ++bin_type_id) {
@@ -964,12 +941,24 @@ Instance InstanceBuilder::build()
                 resource_id < bin_type.number_of_resources();
                 ++resource_id) {
             const Resource& resource = bin_type.resource(resource_id);
-            for (ItemTypeId item_type_id = 0;
-                    item_type_id < (ItemTypeId)resource.item_consumptions.size();
-                    ++item_type_id) {
-                if (!resource.item_consumptions[item_type_id].empty()) {
-                    instance_.item_types_[item_type_id].resource_ids[bin_type_id]
-                        .push_back(resource_id);
+            seen_item_type_ids.clear();
+            for (std::size_t consumption_pos = 0;
+                    consumption_pos < resource.item_consumptions.size();
+                    ++consumption_pos) {
+                const std::pair<ItemTypeId, std::vector<double>>& entry
+                    = resource.item_consumptions[consumption_pos];
+                if (!seen_item_type_ids.add(entry.first)) {
+                    throw std::invalid_argument(
+                            FUNC_SIGNATURE + ": "
+                            "resource " + std::to_string(resource_id) + " of bin type " +
+                            std::to_string(bin_type_id) + " has more than one consumption "
+                            "entry for item type " + std::to_string(entry.first) + "; "
+                            "'add_resource_consumption' may only be called once per "
+                            "(item type, resource) pair.");
+                }
+                if (!entry.second.empty()) {
+                    instance_.item_types_[entry.first].resources[bin_type_id]
+                        .push_back({resource_id, consumption_pos});
                 }
             }
         }

--- a/src/onedimensional/milp_assignment.cpp
+++ b/src/onedimensional/milp_assignment.cpp
@@ -419,27 +419,30 @@ void add_penalize_resource_constraints(
     }
     ItemPos threshold = (ItemPos)rounded_capacity + 1;
 
-    // Every (item type, copy) unit the resource involves, flattened.
+    // Every (item type, copy) unit the resource involves, flattened. Only
+    // ever visits item types this resource actually has a schedule for
+    // (see 'Resource::item_consumptions''s own doc comment), not every
+    // item type in the instance.
     std::vector<std::pair<ItemTypeId, ItemPos>> resource_units;
-    for (ItemTypeId item_type_id = 0;
-            item_type_id < instance.number_of_item_types();
-            ++item_type_id) {
-        if (resource.item_consumption(item_type_id, 0) == 0.0)
+    for (const std::pair<ItemTypeId, std::vector<double>>& entry: resource.item_consumptions) {
+        ItemTypeId item_type_id = entry.first;
+        const std::vector<double>& schedule = entry.second;
+        if (schedule_consumption(schedule, 0) == 0.0)
             continue;
         // Validate the 'threshold_schedule(N)' shape: N ones then a single
         // trailing 0 - anything else (e.g. an uncapped uniform consumption,
         // or a non-0/1 value) is not expressible as 0/1 "unit" presence.
         // Bounded by the item type's own total copies: no valid schedule
         // needs to cap beyond that, and an uncapped (all-1) schedule would
-        // otherwise make this scan run forever ('item_consumption' repeats
-        // a schedule's last entry for every copy past its end).
+        // otherwise make this scan run forever ('schedule_consumption'
+        // repeats a schedule's last entry for every copy past its end).
         ItemPos copies_bound = instance.item_type(item_type_id).copies;
         ItemPos item_type_threshold = 0;
         while (item_type_threshold <= copies_bound
-                && resource.item_consumption(item_type_id, item_type_threshold) == 1.0) {
+                && schedule_consumption(schedule, item_type_threshold) == 1.0) {
             ++item_type_threshold;
         }
-        if (resource.item_consumption(item_type_id, item_type_threshold) != 0.0) {
+        if (schedule_consumption(schedule, item_type_threshold) != 0.0) {
             throw std::invalid_argument(
                     FUNC_SIGNATURE + ": "
                     "'penalize' resource " + std::to_string(resource_id) + " of bin type " +
@@ -920,15 +923,26 @@ MilpModel build_milp_model(
                     ++bin_instance_pos) {
                 // Initialize new row.
                 milp_model.model.constraints_starts.push_back(milp_model.model.elements_variables.size());
-                // Add row elements.
-                for (ItemTypeId item_type_id = 0;
-                        item_type_id < instance.number_of_item_types();
-                        ++item_type_id) {
+                // Add row elements. Only ever visits item types this
+                // resource actually has a schedule for (see
+                // 'Resource::item_consumptions''s own doc comment) rather
+                // than every item type in the instance: a resource
+                // generated as a combinatorial cut typically only
+                // involves a handful of them, so this row would otherwise
+                // pay for a full scan of every other, entirely unrelated
+                // item type for nothing.
+                for (const std::pair<ItemTypeId, std::vector<double>>& entry: resource.item_consumptions) {
+                    ItemTypeId item_type_id = entry.first;
                     if (milp_model.x[item_type_id][bin_type_id].empty())
+                        continue;
+                    const std::vector<double>& schedule = entry.second;
+                    if (schedule.empty())
                         continue;
                     const std::vector<int>& slots = milp_model.x[item_type_id][bin_type_id][bin_instance_pos];
                     for (ItemPos copy = 0; copy < (ItemPos)slots.size(); ++copy) {
-                        double consumption = resource.item_consumption(item_type_id, copy);
+                        double consumption = (copy < (ItemPos)schedule.size())?
+                            schedule[copy]:
+                            schedule.back();
                         if (consumption == 0.0)
                             continue;
                         milp_model.model.elements_variables.push_back(slots[copy]);

--- a/src/onedimensional/solution.cpp
+++ b/src/onedimensional/solution.cpp
@@ -65,12 +65,14 @@ void Solution::update_indicators(
         }
 
         // Update bin.resource_consumption.
-        for (ResourceId resource_id: item_type.resource_ids[bin.bin_type_id]) {
+        for (const ItemResourceConsumption& consumption: item_type.resources[bin.bin_type_id]) {
+            ResourceId resource_id = consumption.resource_id;
             const Resource& resource = bin_type.resource(resource_id);
+            const std::vector<double>& schedule = resource.item_consumptions[consumption.consumption_pos].second;
             double previous_consumption = bin.resource_consumption[resource_id];
             bin.resource_consumption[resource_id]
-                += resource.item_consumption(
-                        item.item_type_id,
+                += schedule_consumption(
+                        schedule,
                         item_type_copies_in_bin[item.item_type_id]);
             if (bin.resource_consumption[resource_id] > resource.capacity) {
                 if (resource.penalize) {

--- a/src/onedimensional/tree_search.cpp
+++ b/src/onedimensional/tree_search.cpp
@@ -100,9 +100,12 @@ BranchingScheme::Node BranchingScheme::child_tmp(
         if (bin_type.number_of_resources() > 0) {
             node.last_bin_item_number_of_copies.assign(instance().number_of_item_types(), 0);
             node.last_bin_resource_consumption.assign(bin_type.number_of_resources(), 0.0);
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
-                double consumption = resource.item_consumption(insertion.item_type_id, 0);
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
+                double consumption = schedule_consumption(schedule, 0);
                 node.last_bin_resource_consumption[resource_id] = consumption;
                 // The bin is empty before this insertion, so any crossing here
                 // is necessarily the first one.
@@ -127,11 +130,14 @@ BranchingScheme::Node BranchingScheme::child_tmp(
             node.last_bin_item_number_of_copies = parent.last_bin_item_number_of_copies;
             ItemPos item_copy = node.last_bin_item_number_of_copies[insertion.item_type_id];
             node.last_bin_resource_consumption = parent.last_bin_resource_consumption;
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
                 double previous_consumption = node.last_bin_resource_consumption[resource_id];
                 node.last_bin_resource_consumption[resource_id]
-                    += resource.item_consumption(insertion.item_type_id, item_copy);
+                    += schedule_consumption(schedule, item_copy);
                 if (resource.penalize
                         && node.last_bin_resource_consumption[resource_id] > resource.capacity
                         && previous_consumption <= resource.capacity) {
@@ -229,12 +235,15 @@ void BranchingScheme::insertion_item_same_bin(
     // when the bin type has no resources (see 'child_tmp').
     if (bin_type.number_of_resources() > 0) {
         ItemPos item_copy = parent->last_bin_item_number_of_copies[item_type_id];
-        for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+        for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+            ResourceId resource_id = item_resource_consumption.resource_id;
             const Resource& resource = bin_type.resource(resource_id);
             if (resource.penalize)
                 continue;
+            const std::vector<double>& schedule
+                = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
             double consumption = parent->last_bin_resource_consumption[resource_id]
-                + resource.item_consumption(item_type_id, item_copy);
+                + schedule_consumption(schedule, item_copy);
             if (consumption > resource.capacity * PSTOL)
                 return;
         }
@@ -265,11 +274,14 @@ void BranchingScheme::insertion_item_new_bin(
     // the new bin). 'penalize' resources never block an insertion (see
     // 'Resource::penalize'); the corresponding penalty is applied to
     // 'node.profit' in 'child_tmp' instead.
-    for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+    for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+        ResourceId resource_id = item_resource_consumption.resource_id;
         const Resource& resource = bin_type.resource(resource_id);
         if (resource.penalize)
             continue;
-        double consumption = resource.item_consumption(item_type_id, 0);
+        const std::vector<double>& schedule
+            = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
+        double consumption = schedule_consumption(schedule, 0);
         if (consumption > resource.capacity * PSTOL)
             return;
     }

--- a/src/rectangle/benders_decomposition.cpp
+++ b/src/rectangle/benders_decomposition.cpp
@@ -602,16 +602,11 @@ void add_cut_as_resource(
     ResourceId resource_id = master_instance_builder.add_bin_type_resource(
             master_bin_type_id, cut.capacity);
     for (const std::pair<ItemTypeId, std::vector<double>>& entry: cut.consumption) {
-        for (ItemPos item_copy = 0;
-                item_copy < (ItemPos)entry.second.size();
-                ++item_copy) {
-            master_instance_builder.add_resource_consumption(
-                    master_bin_type_id,
-                    resource_id,
-                    entry.first,
-                    item_copy,
-                    entry.second[item_copy]);
-        }
+        master_instance_builder.add_resource_consumption(
+                master_bin_type_id,
+                resource_id,
+                entry.first,
+                entry.second);
     }
 }
 
@@ -669,20 +664,12 @@ onedimensional::Instance build_master_instance(
                     resource.capacity,
                     resource.penalize,
                     resource.penalty);
-            for (ItemTypeId item_type_id = 0;
-                    item_type_id < (ItemTypeId)resource.item_consumptions.size();
-                    ++item_type_id) {
-                const std::vector<double>& schedule = resource.item_consumptions[item_type_id];
-                for (ItemPos item_copy = 0;
-                        item_copy < (ItemPos)schedule.size();
-                        ++item_copy) {
-                    master_instance_builder.add_resource_consumption(
-                            master_bin_type_id,
-                            master_resource_id,
-                            item_type_id,
-                            item_copy,
-                            schedule[item_copy]);
-                }
+            for (const std::pair<ItemTypeId, std::vector<double>>& entry: resource.item_consumptions) {
+                master_instance_builder.add_resource_consumption(
+                        master_bin_type_id,
+                        master_resource_id,
+                        entry.first,
+                        entry.second);
             }
         }
     }

--- a/src/rectangle/block.cpp
+++ b/src/rectangle/block.cpp
@@ -126,7 +126,7 @@ std::vector<std::pair<ItemTypeId, ItemPos>> merge_item_copies(
  * Prefix sums of each item type's consumption schedule, for each resource it
  * touches - see 'compute_resource_consumption_prefix_sums' in
  * 'algorithms/common.hpp'. Indexed [item_type_id][resource_id]; only entries
- * for resources actually in 'item_type.resource_ids[bin_type_id]' are
+ * for resources actually in 'item_type.resources[bin_type_id]' are
  * populated (every other entry stays a default-constructed empty vector,
  * never read - see 'compute_resource_consumption').
  */
@@ -141,9 +141,12 @@ std::vector<std::vector<std::vector<double>>> compute_resource_consumption_prefi
             ++item_type_id) {
         const ItemType& item_type = instance.item_type(item_type_id);
         prefix_sums[item_type_id].resize(bin_type.number_of_resources());
-        for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
-            prefix_sums[item_type_id][resource_id] = compute_resource_consumption_prefix_sums(
-                    bin_type.resource(resource_id), item_type_id);
+        for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+            const std::vector<double>& schedule
+                = bin_type.resource(item_resource_consumption.resource_id)
+                    .item_consumptions[item_resource_consumption.consumption_pos].second;
+            prefix_sums[item_type_id][item_resource_consumption.resource_id]
+                = compute_resource_consumption_prefix_sums(schedule);
         }
     }
     return prefix_sums;
@@ -169,10 +172,10 @@ std::vector<double> compute_resource_consumption(
         ItemTypeId item_type_id = item_copy.first;
         ItemPos count = item_copy.second;
         const ItemType& item_type = instance.item_type(item_type_id);
-        for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
-            const Resource& resource = bin_type.resource(resource_id);
+        for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+            ResourceId resource_id = item_resource_consumption.resource_id;
             consumption[resource_id] += sum_item_consumption(
-                    resource, item_type_id, prefix_sums[item_type_id][resource_id], count);
+                    prefix_sums[item_type_id][resource_id], count);
         }
     }
     return consumption;

--- a/src/rectangle/instance.cpp
+++ b/src/rectangle/instance.cpp
@@ -685,14 +685,12 @@ void Instance::write_json(
                 json_resource["penalize"] = resource.penalize;
                 json_resource["penalty"] = resource.penalty;
                 json_resource["consumptions"] = nlohmann::json::array();
-                for (ItemTypeId item_type_id = 0;
-                        item_type_id < (ItemTypeId)resource.item_consumptions.size();
-                        ++item_type_id) {
-                    const std::vector<double>& schedule = resource.item_consumptions[item_type_id];
+                for (const std::pair<ItemTypeId, std::vector<double>>& entry: resource.item_consumptions) {
+                    const std::vector<double>& schedule = entry.second;
                     if (schedule.empty())
                         continue;
                     nlohmann::json json_consumption;
-                    json_consumption["item_type_id"] = item_type_id;
+                    json_consumption["item_type_id"] = entry.first;
                     if (schedule.size() == 1) {
                         json_consumption["consumption"] = schedule[0];
                     } else {

--- a/src/rectangle/instance_builder.cpp
+++ b/src/rectangle/instance_builder.cpp
@@ -1,6 +1,7 @@
 #include "packingsolver/rectangle/instance_builder.hpp"
 
 #include "optimizationtools/utils/utils.hpp"
+#include "optimizationtools/containers/indexed_set.hpp"
 
 using namespace packingsolver;
 using namespace packingsolver::rectangle;
@@ -200,8 +201,7 @@ void InstanceBuilder::add_resource_consumption(
         BinTypeId bin_type_id,
         ResourceId resource_id,
         ItemTypeId item_type_id,
-        ItemPos item_copy,
-        double consumption)
+        const std::vector<double>& schedule)
 {
     if (bin_type_id < 0 || bin_type_id >= (BinTypeId)instance_.bin_types_.size()) {
         throw std::invalid_argument(
@@ -219,20 +219,11 @@ void InstanceBuilder::add_resource_consumption(
                 "resource_id: " + std::to_string(resource_id) + "; "
                 "bin_type.resources.size(): " + std::to_string(bin_type.resources.size()) + ".");
     }
-    if (item_copy < 0) {
-        throw std::invalid_argument(
-                FUNC_SIGNATURE + ": "
-                "invalid 'item_copy'; "
-                "item_copy: " + std::to_string(item_copy) + ".");
-    }
 
-    std::vector<std::vector<double>>& item_consumptions = bin_type.resources[resource_id].item_consumptions;
-    if (item_type_id >= (ItemTypeId)item_consumptions.size())
-        item_consumptions.resize(item_type_id + 1);
-    std::vector<double>& schedule = item_consumptions[item_type_id];
-    if (item_copy >= (ItemPos)schedule.size())
-        schedule.resize(item_copy + 1, 0.0);
-    schedule[item_copy] = consumption;
+    // May be called at most once per (item type, resource) pair (checked,
+    // and thrown on otherwise, in 'build' below) - no search needed, just
+    // append.
+    bin_type.resources[resource_id].item_consumptions.push_back({item_type_id, schedule});
 }
 
 BinTypeId InstanceBuilder::add_bin_type(
@@ -503,24 +494,15 @@ ItemTypeId InstanceBuilder::add_item_type(
         if (sub_bin_type_id == -1)
             continue;
         const BinType& original_bin_type = original_instance.bin_type(original_bin_type_id);
-        for (ResourceId resource_id = 0;
-                resource_id < original_bin_type.number_of_resources();
-                ++resource_id) {
-            const std::vector<std::vector<double>>& item_consumptions
-                = original_bin_type.resource(resource_id).item_consumptions;
-            if (original_item_type_id >= (ItemTypeId)item_consumptions.size())
-                continue;
-            const std::vector<double>& schedule = item_consumptions[original_item_type_id];
-            for (ItemPos item_copy = 0;
-                    item_copy < (ItemPos)schedule.size();
-                    ++item_copy) {
-                add_resource_consumption(
-                        sub_bin_type_id,
-                        resource_id,
-                        item_type_id,
-                        item_copy,
-                        schedule[item_copy]);
-            }
+        for (const ItemResourceConsumption& consumption: item_type.resources[original_bin_type_id]) {
+            const std::vector<double>& schedule
+                = original_bin_type.resource(consumption.resource_id)
+                    .item_consumptions[consumption.consumption_pos].second;
+            add_resource_consumption(
+                    sub_bin_type_id,
+                    consumption.resource_id,
+                    item_type_id,
+                    schedule);
         }
     }
     return item_type_id;
@@ -1009,16 +991,11 @@ void InstanceBuilder::read(
                             // the end of the schedule repeats its last
                             // entry); see 'Resource::item_consumptions'.
                             std::vector<double> schedule = json_consumption["consumption_schedule"];
-                            for (ItemPos item_copy = 0;
-                                    item_copy < (ItemPos)schedule.size();
-                                    ++item_copy) {
-                                add_resource_consumption(
-                                        bin_type_id,
-                                        resource_id,
-                                        item_type_id,
-                                        item_copy,
-                                        schedule[item_copy]);
-                            }
+                            add_resource_consumption(
+                                    bin_type_id,
+                                    resource_id,
+                                    item_type_id,
+                                    schedule);
                         } else {
                             // Uniform consumption, regardless of how many
                             // copies are already packed.
@@ -1027,8 +1004,7 @@ void InstanceBuilder::read(
                                     bin_type_id,
                                     resource_id,
                                     item_type_id,
-                                    0,
-                                    consumption);
+                                    {consumption});
                         }
                     }
                 }
@@ -1175,12 +1151,13 @@ Instance InstanceBuilder::build()
         }
     }
 
-    // Compute item_type.resource_ids (see its own doc comment).
+    // Compute item_type.resources (see its own doc comment).
     for (ItemTypeId item_type_id = 0;
             item_type_id < instance_.number_of_item_types();
             ++item_type_id) {
-        instance_.item_types_[item_type_id].resource_ids.resize(instance_.number_of_bin_types());
+        instance_.item_types_[item_type_id].resources.resize(instance_.number_of_bin_types());
     }
+    optimizationtools::IndexedSet seen_item_type_ids(instance_.number_of_item_types());
     for (BinTypeId bin_type_id = 0;
             bin_type_id < instance_.number_of_bin_types();
             ++bin_type_id) {
@@ -1189,12 +1166,24 @@ Instance InstanceBuilder::build()
                 resource_id < bin_type.number_of_resources();
                 ++resource_id) {
             const Resource& resource = bin_type.resource(resource_id);
-            for (ItemTypeId item_type_id = 0;
-                    item_type_id < (ItemTypeId)resource.item_consumptions.size();
-                    ++item_type_id) {
-                if (!resource.item_consumptions[item_type_id].empty()) {
-                    instance_.item_types_[item_type_id].resource_ids[bin_type_id]
-                        .push_back(resource_id);
+            seen_item_type_ids.clear();
+            for (std::size_t consumption_pos = 0;
+                    consumption_pos < resource.item_consumptions.size();
+                    ++consumption_pos) {
+                const std::pair<ItemTypeId, std::vector<double>>& entry
+                    = resource.item_consumptions[consumption_pos];
+                if (!seen_item_type_ids.add(entry.first)) {
+                    throw std::invalid_argument(
+                            FUNC_SIGNATURE + ": "
+                            "resource " + std::to_string(resource_id) + " of bin type " +
+                            std::to_string(bin_type_id) + " has more than one consumption "
+                            "entry for item type " + std::to_string(entry.first) + "; "
+                            "'add_resource_consumption' may only be called once per "
+                            "(item type, resource) pair.");
+                }
+                if (!entry.second.empty()) {
+                    instance_.item_types_[entry.first].resources[bin_type_id]
+                        .push_back({resource_id, consumption_pos});
                 }
             }
         }

--- a/src/rectangle/instance_flipper.cpp
+++ b/src/rectangle/instance_flipper.cpp
@@ -100,20 +100,12 @@ Instance InstanceFlipper::flip(const Instance& instance)
                 resource_id < bin_type.number_of_resources();
                 ++resource_id) {
             const Resource& resource = bin_type.resource(resource_id);
-            for (ItemTypeId item_type_id = 0;
-                    item_type_id < (ItemTypeId)resource.item_consumptions.size();
-                    ++item_type_id) {
-                const std::vector<double>& schedule = resource.item_consumptions[item_type_id];
-                for (ItemPos item_copy = 0;
-                        item_copy < (ItemPos)schedule.size();
-                        ++item_copy) {
-                    flipped_instance_builder.add_resource_consumption(
-                            bin_type_id,
-                            resource_id,
-                            item_type_id,
-                            item_copy,
-                            schedule[item_copy]);
-                }
+            for (const std::pair<ItemTypeId, std::vector<double>>& entry: resource.item_consumptions) {
+                flipped_instance_builder.add_resource_consumption(
+                        bin_type_id,
+                        resource_id,
+                        entry.first,
+                        entry.second);
             }
         }
     }

--- a/src/rectangle/onedimentional_contiguity/milp.cpp
+++ b/src/rectangle/onedimentional_contiguity/milp.cpp
@@ -131,18 +131,18 @@ void packingsolver::rectangle::onedimentional_contiguity::add_resource_constrain
             // flattened - same validation/extraction as
             // 'onedimensional::add_penalize_resource_constraints'.
             std::vector<std::pair<ItemTypeId, ItemPos>> resource_units;
-            for (ItemTypeId item_type_id = 0;
-                    item_type_id < instance.number_of_item_types();
-                    ++item_type_id) {
-                if (resource.item_consumption(item_type_id, 0) == 0.0)
+            for (const std::pair<ItemTypeId, std::vector<double>>& entry: resource.item_consumptions) {
+                ItemTypeId item_type_id = entry.first;
+                const std::vector<double>& schedule = entry.second;
+                if (schedule_consumption(schedule, 0) == 0.0)
                     continue;
                 ItemPos copies_bound = instance.item_type(item_type_id).copies;
                 ItemPos threshold = 0;
                 while (threshold <= copies_bound
-                        && resource.item_consumption(item_type_id, threshold) == 1.0) {
+                        && schedule_consumption(schedule, threshold) == 1.0) {
                     ++threshold;
                 }
-                if (resource.item_consumption(item_type_id, threshold) != 0.0)
+                if (schedule_consumption(schedule, threshold) != 0.0)
                     throw std::invalid_argument(FUNC_SIGNATURE);
                 for (ItemPos copy = 0; copy < threshold; ++copy)
                     resource_units.push_back({item_type_id, copy});
@@ -191,15 +191,18 @@ void packingsolver::rectangle::onedimentional_contiguity::add_resource_constrain
                 }
             }
         } else {
-            // Hard-capacity resource.
+            // Hard-capacity resource. Only ever visits item types this
+            // resource actually has a schedule for (see
+            // 'Resource::item_consumptions''s own doc comment), not every
+            // item type in the instance.
             model.constraints_starts.push_back((int)model.elements_variables.size());
-            for (ItemTypeId item_type_id = 0;
-                    item_type_id < instance.number_of_item_types();
-                    ++item_type_id) {
+            for (const std::pair<ItemTypeId, std::vector<double>>& entry: resource.item_consumptions) {
+                ItemTypeId item_type_id = entry.first;
+                const std::vector<double>& schedule = entry.second;
                 const std::vector<std::vector<size_t>>& unit_candidates_by_copy
                     = candidates_by_item_type_and_copy[item_type_id];
                 for (ItemPos copy = 0; copy < (ItemPos)unit_candidates_by_copy.size(); ++copy) {
-                    double consumption = resource.item_consumption(item_type_id, copy);
+                    double consumption = schedule_consumption(schedule, copy);
                     if (consumption == 0.0)
                         continue;
                     for (size_t candidate_id: unit_candidates_by_copy[copy]) {

--- a/src/rectangle/onedimentional_contiguity/tree_search.cpp
+++ b/src/rectangle/onedimentional_contiguity/tree_search.cpp
@@ -81,11 +81,14 @@ const std::vector<BranchingScheme::Insertion>& BranchingScheme::insertions(
         // Hard-capacity resources ('penalize' ones never block an
         // insertion - the corresponding penalty is applied to 'profit' in
         // 'child_tmp' instead).
-        for (ResourceId resource_id: item_type.resource_ids[0]) {
+        for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[0]) {
+            ResourceId resource_id = item_resource_consumption.resource_id;
             const Resource& resource = bin_type.resource(resource_id);
             if (resource.penalize)
                 continue;
-            double consumption = resource.item_consumption(item_type_id, copy);
+            const std::vector<double>& schedule
+                = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
+            double consumption = schedule_consumption(schedule, copy);
             if (parent->resource_consumption[resource_id] + consumption > resource.capacity * PSTOL) {
                 ok = false;
                 break;
@@ -152,10 +155,13 @@ BranchingScheme::Node BranchingScheme::child_tmp(
         // 'insertions' above), but the first time its consumption crosses
         // 'capacity', 'penalty' is subtracted from 'profit'.
         const BinType& bin_type = instance_.bin_type(0);
-        for (ResourceId resource_id: item_type.resource_ids[0]) {
+        for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[0]) {
+            ResourceId resource_id = item_resource_consumption.resource_id;
             const Resource& resource = bin_type.resource(resource_id);
             double previous_consumption = node.resource_consumption[resource_id];
-            double consumption = resource.item_consumption(candidate.item_type_id, candidate.copy);
+            const std::vector<double>& schedule
+                = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
+            double consumption = schedule_consumption(schedule, candidate.copy);
             node.resource_consumption[resource_id] += consumption;
             if (resource.penalize
                     && node.resource_consumption[resource_id] > resource.capacity

--- a/src/rectangle/reduction.cpp
+++ b/src/rectangle/reduction.cpp
@@ -1220,6 +1220,31 @@ BinPos Reduction::reserved_bin_count() const
     return number_of_dedicated_bins() + (full_span_items_.empty()? 0: 1);
 }
 
+namespace
+{
+
+/**
+ * The consumption schedule 'item_type' has for 'resource_id' in bin type
+ * 'bin_type_id' of 'bin_type' (see 'ItemType::resources'), or 'nullptr'
+ * if it has none there. A linear scan over 'item_type.resources[bin_type_id]'
+ * - typically tiny, how many resources a single item type is involved in -
+ * not a search through the resource's own (potentially larger) item list.
+ */
+const std::vector<double>* find_item_type_schedule(
+        const ItemType& item_type,
+        BinTypeId bin_type_id,
+        const BinType& bin_type,
+        ResourceId resource_id)
+{
+    for (const ItemResourceConsumption& entry: item_type.resources[bin_type_id]) {
+        if (entry.resource_id == resource_id)
+            return &bin_type.resource(resource_id).item_consumptions[entry.consumption_pos].second;
+    }
+    return nullptr;
+}
+
+}
+
 bool Reduction::items_mergeable(
         const std::vector<ReductionItemType>& reduction_item_types,
         ItemTypeId item_type_id_1,
@@ -1272,14 +1297,14 @@ bool Reduction::items_mergeable(
         for (ResourceId resource_id = 0;
                 resource_id < bin_type.number_of_resources();
                 ++resource_id) {
-            const std::vector<std::vector<double>>& item_consumptions
-                = bin_type.resource(resource_id).item_consumptions;
+            const std::vector<double>* schedule_1_ptr
+                = find_item_type_schedule(original_item_type_1, bin_type_id, bin_type, resource_id);
+            const std::vector<double>* schedule_2_ptr
+                = find_item_type_schedule(original_item_type_2, bin_type_id, bin_type, resource_id);
             const std::vector<double>& schedule_1
-                = (item_type_id_1 < (ItemTypeId)item_consumptions.size())?
-                    item_consumptions[item_type_id_1]: empty_schedule;
+                = (schedule_1_ptr != nullptr)? *schedule_1_ptr: empty_schedule;
             const std::vector<double>& schedule_2
-                = (item_type_id_2 < (ItemTypeId)item_consumptions.size())?
-                    item_consumptions[item_type_id_2]: empty_schedule;
+                = (schedule_2_ptr != nullptr)? *schedule_2_ptr: empty_schedule;
             if (schedule_1 != schedule_2)
                 return false;
         }
@@ -1443,10 +1468,9 @@ double min_or_zero(const std::vector<double>& schedule)
  * (geometric, weight, any one resource) holds.
  */
 bool items_incompatible(
-        ItemTypeId item_type_id_1,
         const ItemType& item_type_1,
-        ItemTypeId item_type_id_2,
         const ItemType& item_type_2,
+        BinTypeId bin_type_id,
         const BinType& bin_type)
 {
     bool geometrically_incompatible =
@@ -1484,14 +1508,15 @@ bool items_incompatible(
         // combined contribution from one occurrence of each already
         // exceeds capacity, a guaranteed overflow regardless of which
         // copy index either one actually ends up placed at.
-        const std::vector<std::vector<double>>& item_consumptions = resource.item_consumptions;
         static const std::vector<double> empty_schedule;
+        const std::vector<double>* schedule_1_ptr
+            = find_item_type_schedule(item_type_1, bin_type_id, bin_type, resource_id);
+        const std::vector<double>* schedule_2_ptr
+            = find_item_type_schedule(item_type_2, bin_type_id, bin_type, resource_id);
         const std::vector<double>& schedule_1
-            = (item_type_id_1 < (ItemTypeId)item_consumptions.size())?
-                item_consumptions[item_type_id_1]: empty_schedule;
+            = (schedule_1_ptr != nullptr)? *schedule_1_ptr: empty_schedule;
         const std::vector<double>& schedule_2
-            = (item_type_id_2 < (ItemTypeId)item_consumptions.size())?
-                item_consumptions[item_type_id_2]: empty_schedule;
+            = (schedule_2_ptr != nullptr)? *schedule_2_ptr: empty_schedule;
         if (min_or_zero(schedule_1) + min_or_zero(schedule_2) > resource.capacity)
             return true;
     }
@@ -1544,15 +1569,15 @@ bool Reduction::item_type_dominates(
         for (ResourceId resource_id = 0;
                 resource_id < bin_type.number_of_resources();
                 ++resource_id) {
-            const std::vector<std::vector<double>>& item_consumptions
-                = bin_type.resource(resource_id).item_consumptions;
             static const std::vector<double> empty_schedule;
+            const std::vector<double>* schedule_a_ptr
+                = find_item_type_schedule(item_a, bin_type_id, bin_type, resource_id);
+            const std::vector<double>* schedule_b_ptr
+                = find_item_type_schedule(item_b, bin_type_id, bin_type, resource_id);
             const std::vector<double>& schedule_a
-                = (item_type_id_a < (ItemTypeId)item_consumptions.size())?
-                    item_consumptions[item_type_id_a]: empty_schedule;
+                = (schedule_a_ptr != nullptr)? *schedule_a_ptr: empty_schedule;
             const std::vector<double>& schedule_b
-                = (item_type_id_b < (ItemTypeId)item_consumptions.size())?
-                    item_consumptions[item_type_id_b]: empty_schedule;
+                = (schedule_b_ptr != nullptr)? *schedule_b_ptr: empty_schedule;
             if (max_or_zero(schedule_a) > min_or_zero(schedule_b))
                 return false;
         }
@@ -1583,8 +1608,9 @@ bool Reduction::items_provably_incompatible(
         if (!eligible_1 || !eligible_2)
             continue;
         if (!items_incompatible(
-                item_type_id_1, item_type_1,
-                item_type_id_2, item_type_2,
+                item_type_1,
+                item_type_2,
+                bin_type_id,
                 original_instance_->bin_type(bin_type_id)))
             return false;
     }
@@ -1919,24 +1945,15 @@ Instance Reduction::reduction_to_instance(
             if (original_to_reduced_bin_type_id[bin_type_id] == -1)
                 continue;
             const BinType& original_bin_type = original_instance_->bin_type(bin_type_id);
-            for (ResourceId resource_id = 0;
-                    resource_id < original_bin_type.number_of_resources();
-                    ++resource_id) {
-                const std::vector<std::vector<double>>& item_consumptions
-                    = original_bin_type.resource(resource_id).item_consumptions;
-                if (item_type_id >= (ItemTypeId)item_consumptions.size())
-                    continue;
-                const std::vector<double>& schedule = item_consumptions[item_type_id];
-                for (ItemPos item_copy = 0;
-                        item_copy < (ItemPos)schedule.size();
-                        ++item_copy) {
-                    instance_builder.add_resource_consumption(
-                            original_to_reduced_bin_type_id[bin_type_id],
-                            resource_id,
-                            new_item_type_id,
-                            item_copy,
-                            schedule[item_copy]);
-                }
+            for (const ItemResourceConsumption& consumption: original_item_type.resources[bin_type_id]) {
+                const std::vector<double>& schedule
+                    = original_bin_type.resource(consumption.resource_id)
+                        .item_consumptions[consumption.consumption_pos].second;
+                instance_builder.add_resource_consumption(
+                        original_to_reduced_bin_type_id[bin_type_id],
+                        consumption.resource_id,
+                        new_item_type_id,
+                        schedule);
             }
         }
         reduced_copy_origins_.push_back(std::move(copy_origins));

--- a/src/rectangle/solution.cpp
+++ b/src/rectangle/solution.cpp
@@ -52,12 +52,14 @@ void Solution::update_indicators(
         this->item_copies_[solution_item.item_type_id] += bin.copies;
 
         // Update bin.resource_consumption.
-        for (ResourceId resource_id: item_type.resource_ids[bin.bin_type_id]) {
+        for (const ItemResourceConsumption& consumption: item_type.resources[bin.bin_type_id]) {
+            ResourceId resource_id = consumption.resource_id;
             const Resource& resource = bin_type.resource(resource_id);
+            const std::vector<double>& schedule = resource.item_consumptions[consumption.consumption_pos].second;
             double previous_consumption = bin.resource_consumption[resource_id];
             bin.resource_consumption[resource_id]
-                += resource.item_consumption(
-                        solution_item.item_type_id,
+                += schedule_consumption(
+                        schedule,
                         item_type_copies_in_bin[solution_item.item_type_id]);
             if (bin.resource_consumption[resource_id] > resource.capacity) {
                 if (resource.penalize) {

--- a/src/rectangle/tree_search.cpp
+++ b/src/rectangle/tree_search.cpp
@@ -348,9 +348,12 @@ BranchingScheme::Node BranchingScheme::child_tmp(
         if (insertion.new_bin > 0) {  // New bin.
             node.last_bin_item_number_of_copies.assign(instance.number_of_item_types(), 0);
             node.last_bin_resource_consumption.assign(bin_type.number_of_resources(), 0.0);
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
-                double consumption = resource.item_consumption(insertion.item_type_id, 0);
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
+                double consumption = schedule_consumption(schedule, 0);
                 node.last_bin_resource_consumption[resource_id] = consumption;
                 // The bin is empty before this insertion, so any crossing here
                 // is necessarily the first one.
@@ -362,11 +365,14 @@ BranchingScheme::Node BranchingScheme::child_tmp(
             node.last_bin_item_number_of_copies = parent.last_bin_item_number_of_copies;
             ItemPos item_copy = node.last_bin_item_number_of_copies[insertion.item_type_id];
             node.last_bin_resource_consumption = parent.last_bin_resource_consumption;
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
                 double previous_consumption = node.last_bin_resource_consumption[resource_id];
                 node.last_bin_resource_consumption[resource_id]
-                    += resource.item_consumption(insertion.item_type_id, item_copy);
+                    += schedule_consumption(schedule, item_copy);
                 if (resource.penalize
                         && node.last_bin_resource_consumption[resource_id] > resource.capacity
                         && previous_consumption <= resource.capacity) {
@@ -882,21 +888,27 @@ void BranchingScheme::insertion_item(
     if (bin_type.number_of_resources() > 0) {
         if (new_bin == 0) {
             ItemPos item_copy = parent->last_bin_item_number_of_copies[item_type_id];
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
                 if (resource.penalize)
                     continue;
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
                 double consumption = parent->last_bin_resource_consumption[resource_id]
-                    + resource.item_consumption(item_type_id, item_copy);
+                    + schedule_consumption(schedule, item_copy);
                 if (consumption > resource.capacity * PSTOL)
                     return;
             }
         } else {
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
                 if (resource.penalize)
                     continue;
-                double consumption = resource.item_consumption(item_type_id, 0);
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
+                double consumption = schedule_consumption(schedule, 0);
                 if (consumption > resource.capacity * PSTOL)
                     return;
             }

--- a/src/rectangleguillotine/instance.cpp
+++ b/src/rectangleguillotine/instance.cpp
@@ -461,14 +461,12 @@ void Instance::write_json(
                 json_resource["penalize"] = resource.penalize;
                 json_resource["penalty"] = resource.penalty;
                 json_resource["consumptions"] = nlohmann::json::array();
-                for (ItemTypeId item_type_id = 0;
-                        item_type_id < (ItemTypeId)resource.item_consumptions.size();
-                        ++item_type_id) {
-                    const std::vector<double>& schedule = resource.item_consumptions[item_type_id];
+                for (const std::pair<ItemTypeId, std::vector<double>>& entry: resource.item_consumptions) {
+                    const std::vector<double>& schedule = entry.second;
                     if (schedule.empty())
                         continue;
                     nlohmann::json json_consumption;
-                    json_consumption["item_type_id"] = item_type_id;
+                    json_consumption["item_type_id"] = entry.first;
                     if (schedule.size() == 1) {
                         json_consumption["consumption"] = schedule[0];
                     } else {

--- a/src/rectangleguillotine/instance_builder.cpp
+++ b/src/rectangleguillotine/instance_builder.cpp
@@ -1,6 +1,7 @@
 #include "packingsolver/rectangleguillotine/instance_builder.hpp"
 
 #include "optimizationtools/utils/utils.hpp"
+#include "optimizationtools/containers/indexed_set.hpp"
 
 using namespace packingsolver;
 using namespace packingsolver::rectangleguillotine;
@@ -369,8 +370,7 @@ void InstanceBuilder::add_resource_consumption(
         BinTypeId bin_type_id,
         ResourceId resource_id,
         ItemTypeId item_type_id,
-        ItemPos item_copy,
-        double consumption)
+        const std::vector<double>& schedule)
 {
     if (bin_type_id < 0 || bin_type_id >= (BinTypeId)instance_.bin_types_.size()) {
         throw std::invalid_argument(
@@ -388,20 +388,11 @@ void InstanceBuilder::add_resource_consumption(
                 "resource_id: " + std::to_string(resource_id) + "; "
                 "bin_type.resources.size(): " + std::to_string(bin_type.resources.size()) + ".");
     }
-    if (item_copy < 0) {
-        throw std::invalid_argument(
-                FUNC_SIGNATURE + ": "
-                "invalid 'item_copy'; "
-                "item_copy: " + std::to_string(item_copy) + ".");
-    }
 
-    std::vector<std::vector<double>>& item_consumptions = bin_type.resources[resource_id].item_consumptions;
-    if (item_type_id >= (ItemTypeId)item_consumptions.size())
-        item_consumptions.resize(item_type_id + 1);
-    std::vector<double>& schedule = item_consumptions[item_type_id];
-    if (item_copy >= (ItemPos)schedule.size())
-        schedule.resize(item_copy + 1, 0.0);
-    schedule[item_copy] = consumption;
+    // May be called at most once per (item type, resource) pair (checked,
+    // and thrown on otherwise, in 'build' below) - no search needed, just
+    // append.
+    bin_type.resources[resource_id].item_consumptions.push_back({item_type_id, schedule});
 }
 
 BinTypeId InstanceBuilder::add_bin_type(
@@ -620,24 +611,15 @@ ItemTypeId InstanceBuilder::add_item_type(
         if (sub_bin_type_id == -1)
             continue;
         const BinType& original_bin_type = original_instance.bin_type(original_bin_type_id);
-        for (ResourceId resource_id = 0;
-                resource_id < original_bin_type.number_of_resources();
-                ++resource_id) {
-            const std::vector<std::vector<double>>& item_consumptions
-                = original_bin_type.resource(resource_id).item_consumptions;
-            if (original_item_type_id >= (ItemTypeId)item_consumptions.size())
-                continue;
-            const std::vector<double>& schedule = item_consumptions[original_item_type_id];
-            for (ItemPos item_copy = 0;
-                    item_copy < (ItemPos)schedule.size();
-                    ++item_copy) {
-                add_resource_consumption(
-                        sub_bin_type_id,
-                        resource_id,
-                        item_type_id,
-                        item_copy,
-                        schedule[item_copy]);
-            }
+        for (const ItemResourceConsumption& consumption: item_type.resources[original_bin_type_id]) {
+            const std::vector<double>& schedule
+                = original_bin_type.resource(consumption.resource_id)
+                    .item_consumptions[consumption.consumption_pos].second;
+            add_resource_consumption(
+                    sub_bin_type_id,
+                    consumption.resource_id,
+                    item_type_id,
+                    schedule);
         }
     }
     return item_type_id;
@@ -1254,16 +1236,11 @@ void InstanceBuilder::read(
                             // the end of the schedule repeats its last
                             // entry); see 'Resource::item_consumptions'.
                             std::vector<double> schedule = json_consumption["consumption_schedule"];
-                            for (ItemPos item_copy = 0;
-                                    item_copy < (ItemPos)schedule.size();
-                                    ++item_copy) {
-                                add_resource_consumption(
-                                        bin_type_id,
-                                        resource_id,
-                                        item_type_id,
-                                        item_copy,
-                                        schedule[item_copy]);
-                            }
+                            add_resource_consumption(
+                                    bin_type_id,
+                                    resource_id,
+                                    item_type_id,
+                                    schedule);
                         } else {
                             // Uniform consumption, regardless of how many
                             // copies are already packed.
@@ -1272,8 +1249,7 @@ void InstanceBuilder::read(
                                     bin_type_id,
                                     resource_id,
                                     item_type_id,
-                                    0,
-                                    consumption);
+                                    {consumption});
                         }
                     }
                 }
@@ -1495,12 +1471,13 @@ Instance InstanceBuilder::build()
         instance_.number_of_defects_ += bin_type.defects.size();
     }
 
-    // Compute item_type.resource_ids (see its own doc comment).
+    // Compute item_type.resources (see its own doc comment).
     for (ItemTypeId item_type_id = 0;
             item_type_id < instance_.number_of_item_types();
             ++item_type_id) {
-        instance_.item_types_[item_type_id].resource_ids.resize(instance_.number_of_bin_types());
+        instance_.item_types_[item_type_id].resources.resize(instance_.number_of_bin_types());
     }
+    optimizationtools::IndexedSet seen_item_type_ids(instance_.number_of_item_types());
     for (BinTypeId bin_type_id = 0;
             bin_type_id < instance_.number_of_bin_types();
             ++bin_type_id) {
@@ -1509,12 +1486,24 @@ Instance InstanceBuilder::build()
                 resource_id < bin_type.number_of_resources();
                 ++resource_id) {
             const Resource& resource = bin_type.resource(resource_id);
-            for (ItemTypeId item_type_id = 0;
-                    item_type_id < (ItemTypeId)resource.item_consumptions.size();
-                    ++item_type_id) {
-                if (!resource.item_consumptions[item_type_id].empty()) {
-                    instance_.item_types_[item_type_id].resource_ids[bin_type_id]
-                        .push_back(resource_id);
+            seen_item_type_ids.clear();
+            for (std::size_t consumption_pos = 0;
+                    consumption_pos < resource.item_consumptions.size();
+                    ++consumption_pos) {
+                const std::pair<ItemTypeId, std::vector<double>>& entry
+                    = resource.item_consumptions[consumption_pos];
+                if (!seen_item_type_ids.add(entry.first)) {
+                    throw std::invalid_argument(
+                            FUNC_SIGNATURE + ": "
+                            "resource " + std::to_string(resource_id) + " of bin type " +
+                            std::to_string(bin_type_id) + " has more than one consumption "
+                            "entry for item type " + std::to_string(entry.first) + "; "
+                            "'add_resource_consumption' may only be called once per "
+                            "(item type, resource) pair.");
+                }
+                if (!entry.second.empty()) {
+                    instance_.item_types_[entry.first].resources[bin_type_id]
+                        .push_back({resource_id, consumption_pos});
                 }
             }
         }

--- a/src/rectangleguillotine/instance_flipper.cpp
+++ b/src/rectangleguillotine/instance_flipper.cpp
@@ -91,20 +91,12 @@ Instance InstanceFlipper::flip(const Instance& instance)
                 resource_id < bin_type.number_of_resources();
                 ++resource_id) {
             const Resource& resource = bin_type.resource(resource_id);
-            for (ItemTypeId item_type_id = 0;
-                    item_type_id < (ItemTypeId)resource.item_consumptions.size();
-                    ++item_type_id) {
-                const std::vector<double>& schedule = resource.item_consumptions[item_type_id];
-                for (ItemPos item_copy = 0;
-                        item_copy < (ItemPos)schedule.size();
-                        ++item_copy) {
-                    flipped_instance_builder.add_resource_consumption(
-                            bin_type_id,
-                            resource_id,
-                            item_type_id,
-                            item_copy,
-                            schedule[item_copy]);
-                }
+            for (const std::pair<ItemTypeId, std::vector<double>>& entry: resource.item_consumptions) {
+                flipped_instance_builder.add_resource_consumption(
+                        bin_type_id,
+                        resource_id,
+                        entry.first,
+                        entry.second);
             }
         }
     }

--- a/src/rectangleguillotine/solution.cpp
+++ b/src/rectangleguillotine/solution.cpp
@@ -92,12 +92,14 @@ void Solution::update_indicators(
 
             // Update bin.resource_consumption.
             const ItemType& item_type = instance().item_type(node.item_type_id);
-            for (ResourceId resource_id: item_type.resource_ids[bin.bin_type_id]) {
+            for (const ItemResourceConsumption& consumption: item_type.resources[bin.bin_type_id]) {
+                ResourceId resource_id = consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
+                const std::vector<double>& schedule = resource.item_consumptions[consumption.consumption_pos].second;
                 double previous_consumption = bin.resource_consumption[resource_id];
                 bin.resource_consumption[resource_id]
-                    += resource.item_consumption(
-                            node.item_type_id,
+                    += schedule_consumption(
+                            schedule,
                             item_type_copies_in_bin[node.item_type_id]);
                 if (bin.resource_consumption[resource_id] > resource.capacity) {
                     if (resource.penalize) {

--- a/src/rectangleguillotine/tree_search.cpp
+++ b/src/rectangleguillotine/tree_search.cpp
@@ -535,11 +535,14 @@ BranchingScheme::Node BranchingScheme::child_tmp(
                 continue;
             const ItemType& item_type = instance.item_type(item_type_id);
             ItemPos item_copy = node.last_bin_item_number_of_copies[item_type_id];
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
                 double previous_consumption = node.last_bin_resource_consumption[resource_id];
                 node.last_bin_resource_consumption[resource_id]
-                    += resource.item_consumption(item_type_id, item_copy);
+                    += schedule_consumption(schedule, item_copy);
                 if (resource.penalize
                         && node.last_bin_resource_consumption[resource_id] > resource.capacity
                         && previous_consumption <= resource.capacity) {
@@ -1846,11 +1849,14 @@ void BranchingScheme::update(
                 continue;
             const ItemType& item_type = instance.item_type(item_type_id);
             ItemPos item_copy = item_number_of_copies[item_type_id];
-            for (ResourceId resource_id: item_type.resource_ids[bin_type_id]) {
+            for (const ItemResourceConsumption& item_resource_consumption: item_type.resources[bin_type_id]) {
+                ResourceId resource_id = item_resource_consumption.resource_id;
                 const Resource& resource = bin_type.resource(resource_id);
                 if (resource.penalize)
                     continue;
-                resource_consumption[resource_id] += resource.item_consumption(item_type_id, item_copy);
+                const std::vector<double>& schedule
+                    = resource.item_consumptions[item_resource_consumption.consumption_pos].second;
+                resource_consumption[resource_id] += schedule_consumption(schedule, item_copy);
                 if (resource_consumption[resource_id] > resource.capacity * PSTOL)
                     return;
             }

--- a/test/onedimensional/onedimensional_test.cpp
+++ b/test/onedimensional/onedimensional_test.cpp
@@ -8,6 +8,30 @@
 using namespace packingsolver::onedimensional;
 namespace fs = boost::filesystem;
 
+namespace
+{
+
+/**
+ * Test-only helper: the consumption of the 'copy'-th (0-indexed) unit of
+ * 'item_type_id' in 'resource' - a linear scan over
+ * 'Resource::item_consumptions', fine here since this is not a hot path
+ * (see that field's own doc comment for why production code instead looks
+ * this up in O(1) via 'ItemType::resources').
+ */
+double item_consumption_for_test(
+        const packingsolver::Resource& resource,
+        packingsolver::ItemTypeId item_type_id,
+        packingsolver::ItemPos copy)
+{
+    for (const auto& entry: resource.item_consumptions) {
+        if (entry.first == item_type_id)
+            return packingsolver::schedule_consumption(entry.second, copy);
+    }
+    return 0.0;
+}
+
+}
+
 TEST(OneDimensional, BinCopies)
 {
     InstanceBuilder instance_builder;
@@ -31,7 +55,7 @@ TEST(OneDimensional, ResourceConsumptionCopiedFromOriginalInstance)
     packingsolver::BinTypeId bin_type_id = instance_builder.add_bin_type(100);
     packingsolver::ResourceId resource_id = instance_builder.add_bin_type_resource(bin_type_id, 10);
     packingsolver::ItemTypeId item_type_id = instance_builder.add_item_type(10);
-    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, 0, 5);
+    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, {5.0});
     const Instance instance = instance_builder.build();
 
     InstanceBuilder sub_instance_builder;
@@ -41,7 +65,7 @@ TEST(OneDimensional, ResourceConsumptionCopiedFromOriginalInstance)
 
     EXPECT_EQ(sub_instance.bin_type(sub_bin_type_id).number_of_resources(), 1);
     EXPECT_EQ(
-            sub_instance.bin_type(sub_bin_type_id).resource(0).item_consumption(sub_item_type_id, 0),
+            item_consumption_for_test(sub_instance.bin_type(sub_bin_type_id).resource(0), sub_item_type_id, 0),
             5.0);
 }
 
@@ -89,7 +113,7 @@ TEST(OneDimensional, WriteJsonRoundTripWithResource)
     packingsolver::ResourceId resource_id = instance_builder.add_bin_type_resource(bin_type_id, 10);
     packingsolver::ItemTypeId item_type_id = instance_builder.add_item_type(10);
     instance_builder.set_item_type_copies(item_type_id, 3);
-    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, 0, 5);
+    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, {5.0});
     const Instance instance = instance_builder.build();
 
     fs::path path = fs::temp_directory_path() / fs::unique_path();
@@ -106,7 +130,7 @@ TEST(OneDimensional, WriteJsonRoundTripWithResource)
     ASSERT_EQ(read_instance.number_of_bin_types(), 1);
     EXPECT_EQ(read_instance.bin_type(0).number_of_resources(), 1);
     EXPECT_EQ(read_instance.bin_type(0).resource(0).capacity, 10.0);
-    EXPECT_EQ(read_instance.bin_type(0).resource(0).item_consumption(0, 0), 5.0);
+    EXPECT_EQ(item_consumption_for_test(read_instance.bin_type(0).resource(0), 0, 0), 5.0);
 }
 
 TEST(OneDimensional, WriteCsvThrowsOnResource)

--- a/test/rectangle/benders_decomposition_contiguity_test.cpp
+++ b/test/rectangle/benders_decomposition_contiguity_test.cpp
@@ -69,9 +69,7 @@ TEST(RectangleBendersDecompositionContiguity, UnsupportedPenalizeResourceCapacit
     ResourceId resource_id = instance_builder.add_bin_type_resource(bin_type_id, 2.0, true, 100.0);
     ItemTypeId item_type_id = instance_builder.add_item_type(5, 5, true);
     instance_builder.set_item_type_copies(item_type_id, 2);
-    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, 0, 1.0);
-    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, 1, 1.0);
-    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, 2, 0.0);
+    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, {1.0, 1.0, 0.0});
     Instance instance = instance_builder.build();
 
     BendersDecompositionContiguityParameters parameters;
@@ -93,7 +91,7 @@ TEST(RectangleBendersDecompositionContiguity, UnsupportedPenalizeResourceSchedul
     ResourceId resource_id = instance_builder.add_bin_type_resource(bin_type_id, 1.0, true, 100.0);
     ItemTypeId item_type_id = instance_builder.add_item_type(5, 5, true);
     instance_builder.set_item_type_copies(item_type_id, 2);
-    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, 0, 1.0);
+    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, {1.0});
     Instance instance = instance_builder.build();
 
     BendersDecompositionContiguityParameters parameters;

--- a/test/rectangleguillotine/resource_test.cpp
+++ b/test/rectangleguillotine/resource_test.cpp
@@ -22,7 +22,7 @@ TEST(RectangleGuillotineResourceTest, HardResourceForcesExtraBins)
     packingsolver::ResourceId resource_id = instance_builder.add_bin_type_resource(bin_type_id, 1.0, false, 0.0);
     packingsolver::ItemTypeId item_type_id = instance_builder.add_item_type(5, 5);
     instance_builder.set_item_type_copies(item_type_id, 3);
-    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, 0, 1.0);
+    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, {1.0});
     Instance instance = instance_builder.build();
 
     OptimizeParameters parameters;
@@ -54,7 +54,7 @@ TEST(RectangleGuillotineResourceTest, PenalizeResourceDiscouragesCrossing)
     packingsolver::ItemTypeId item_type_id = instance_builder.add_item_type(5, 5);
     instance_builder.set_item_type_profit(item_type_id, 10);
     instance_builder.set_item_type_copies(item_type_id, 2);
-    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, 0, 1.0);
+    instance_builder.add_resource_consumption(bin_type_id, resource_id, item_type_id, {1.0});
     Instance instance = instance_builder.build();
 
     OptimizeParameters parameters;


### PR DESCRIPTION
## Summary
- `Resource::item_consumptions` was a dense `[item_type_id]`-indexed vector, even though a resource generated as a combinatorial cut (no-good, pairwise- or triplet-incompatibility) typically only involves a handful of item types. Every consumer that iterated it - most notably `InstanceBuilder::build()`'s resource computation and `milp_assignment.cpp`'s resource-capacity constraint builder - paid for that density regardless (this is what rectangle's Benders decomposition rebuilds from scratch every iteration).
- Switched it to a list of `(item_type_id, schedule)` pairs, and updated every consumer across every problem type (rectangle, rectangleguillotine, irregular, box, onedimensional). On a synthetic instance with 2000 item types and 5000 resources of 3 item types each, `InstanceBuilder::build()` alone drops from ~105ms to ~4ms, and the gap widens with item type count.
- Each item type now carries, per bin type, the resources it has a non-zero consumption for together with the position of its own entry in that resource's `item_consumptions` (`ItemType::resources`, see `ItemResourceConsumption`) - computed once in `InstanceBuilder::build()` via a reusable `optimizationtools::IndexedSet` (also used to enforce that `add_resource_consumption` is only ever called once per (item type, resource) pair, throwing otherwise) - so every item-perspective consumer (tree search, solution indicator updates, block generation, reduction) reaches a resource's schedule in O(1).
- `InstanceBuilder::add_resource_consumption` now takes a whole per-copy schedule at once, letting every caller that already has one in hand (cut application, copying resource consumption from another instance) set it in a single call instead of one per copy.

## Test plan
- [x] Full test suites pass locally: rectangle (138), rectangleguillotine (285), irregular (54), box (12), onedimensional (37), boxstacks (4)