### PR TITLE
rectangle: add incompatible-triplet cuts to Benders decomposition

### DIFF
--- a/src/rectangle/CMakeLists.txt
+++ b/src/rectangle/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(PackingSolver_rectangle PRIVATE
     tree_search.cpp
     benders_decomposition.cpp
     benders_decomposition_contiguity.cpp
+    item_subset_incompatibility.cpp
     onedimentional_contiguity/milp.cpp
     onedimentional_contiguity/tree_search.cpp
     dual_feasible_functions.cpp

--- a/src/rectangle/benders_decomposition.cpp
+++ b/src/rectangle/benders_decomposition.cpp
@@ -5,11 +5,14 @@
 #include "packingsolver/rectangle/optimize.hpp"
 #include "rectangle/dual_feasible_functions.hpp"
 #include "rectangle/bar_relaxation.hpp"
+#include "rectangle/item_subset_incompatibility.hpp"
+#include "rectangle/solution_builder.hpp"
 
 #include "onedimensional/milp_assignment.hpp"
 #include "packingsolver/onedimensional/instance_builder.hpp"
 
 #include <algorithm>
+#include <chrono>
 
 using namespace packingsolver;
 using namespace packingsolver::rectangle;
@@ -203,6 +206,7 @@ void enumerate_minimal_infeasible_subsets_dfs(
         BinTypeId bin_type_id,
         const std::vector<ItemTypeId>& units,
         std::vector<bool>& removed,
+        size_t remaining_count,
         size_t next_unit_pos,
         bool path_proven,
         const BendersDecompositionParameters& parameters,
@@ -214,14 +218,31 @@ void enumerate_minimal_infeasible_subsets_dfs(
             unit_pos < units.size() && (Counter)cuts.size() < maximum_number_of_cuts;
             ++unit_pos) {
         removed[unit_pos] = true;
-        std::vector<std::pair<ItemTypeId, ItemPos>> child_selection =
-            aggregate_units(instance, units, removed);
-        SelectionFeasibility child_feasibility = selection_feasibility(
-                instance, bin_type_id, child_selection, parameters);
+        size_t child_remaining_count = remaining_count - 1;
+        SelectionFeasibility child_feasibility;
+        if (child_remaining_count <= 3) {
+            // A selection of at most 3 items can never be infeasible here:
+            // 'benders_decomposition''s own Pass 1b already ran
+            // 'find_incompatible_triplets' on this exact bin's full
+            // selection before ever reaching this search (see its own doc
+            // comment), so every triplet drawn from it - including this
+            // one - is already known compatible; pairs and singletons are
+            // ruled out even earlier (the master's own pairwise-
+            // incompatibility resource, and per-item-type eligibility,
+            // respectively). Skipping the geometric subproblem call here
+            // both saves it and correctly stops the search from
+            // descending any further along this branch.
+            child_feasibility = SelectionFeasibility::Feasible;
+        } else {
+            std::vector<std::pair<ItemTypeId, ItemPos>> child_selection =
+                aggregate_units(instance, units, removed);
+            child_feasibility = selection_feasibility(
+                    instance, bin_type_id, child_selection, parameters);
+        }
         if (child_feasibility != SelectionFeasibility::Feasible) {
             any_child_infeasible = true;
             enumerate_minimal_infeasible_subsets_dfs(
-                    instance, bin_type_id, units, removed, unit_pos + 1,
+                    instance, bin_type_id, units, removed, child_remaining_count, unit_pos + 1,
                     path_proven && (child_feasibility == SelectionFeasibility::ProvenInfeasible),
                     parameters, maximum_number_of_cuts, cuts);
         }
@@ -277,7 +298,7 @@ std::vector<MinimalInfeasibleSubset> enumerate_minimal_infeasible_subsets(
     std::vector<bool> removed(units.size(), false);
     std::vector<MinimalInfeasibleSubset> cuts;
     enumerate_minimal_infeasible_subsets_dfs(
-            instance, bin_type_id, units, removed, 0, selection_proven_infeasible,
+            instance, bin_type_id, units, removed, units.size(), 0, selection_proven_infeasible,
             parameters, maximum_number_of_cuts, cuts);
     return cuts;
 }
@@ -437,6 +458,7 @@ onedimensional::Instance build_master_instance(
         const std::vector<StaticBinTypeResources>& static_resources,
         const std::vector<std::pair<ItemTypeId, ItemTypeId>>& item_type_precedences,
         const std::vector<std::vector<ResourceCut>>& dff_cuts_by_bin_type,
+        const std::vector<std::vector<ResourceCut>>& triplet_cuts_by_bin_type,
         const std::vector<std::vector<ResourceCut>>& no_good_cuts_by_bin_type)
 {
     onedimensional::InstanceBuilder master_instance_builder;
@@ -461,6 +483,9 @@ onedimensional::Instance build_master_instance(
             add_cut_as_resource(master_instance_builder, master_bin_type_id, cut);
         }
         for (const ResourceCut& cut: dff_cuts_by_bin_type[bin_type_id]) {
+            add_cut_as_resource(master_instance_builder, master_bin_type_id, cut);
+        }
+        for (const ResourceCut& cut: triplet_cuts_by_bin_type[bin_type_id]) {
             add_cut_as_resource(master_instance_builder, master_bin_type_id, cut);
         }
         for (const ResourceCut& cut: no_good_cuts_by_bin_type[bin_type_id]) {
@@ -614,13 +639,15 @@ bool cut_violates_solution(
 }
 
 /**
- * Check that no accumulated cut (dual-feasible-function or no-good)
- * excludes 'solution' - the algorithm's own current best known feasible
- * solution to 'instance' itself, not the master's relaxation.
+ * Check that no accumulated cut (dual-feasible-function, triplet-
+ * incompatibility, or no-good) excludes 'solution' - the algorithm's own
+ * current best known feasible solution to 'instance' itself, not the
+ * master's relaxation.
  *
  * Only meaningful once every no-good cut added so far is backed by a
- * genuine proof of infeasibility (dual-feasible-function cuts always
- * are; see 'all_cuts_proven_infeasible' at the call site): in that
+ * genuine proof of infeasibility (dual-feasible-function and triplet-
+ * incompatibility cuts always are; see
+ * 'all_cuts_proven_infeasible' at the call site): in that
  * regime, every cut is sound (derived from - and only from - a
  * combination proven infeasible in true 2D geometry), so the best known
  * solution, itself a genuinely feasible packing, must satisfy every one
@@ -631,6 +658,7 @@ void check_cuts_against_best_solution(
         const Instance& instance,
         const Solution& solution,
         const std::vector<std::vector<ResourceCut>>& dff_cuts_by_bin_type,
+        const std::vector<std::vector<ResourceCut>>& triplet_cuts_by_bin_type,
         const std::vector<std::vector<ResourceCut>>& no_good_cuts_by_bin_type)
 {
     for (BinTypeId bin_type_id = 0;
@@ -640,6 +668,13 @@ void check_cuts_against_best_solution(
             if (cut_violates_solution(instance, solution, bin_type_id, cut)) {
                 throw std::logic_error(
                         FUNC_SIGNATURE + ": a dual-feasible-function cut excludes "
+                        "the current best solution.");
+            }
+        }
+        for (const ResourceCut& cut: triplet_cuts_by_bin_type[bin_type_id]) {
+            if (cut_violates_solution(instance, solution, bin_type_id, cut)) {
+                throw std::logic_error(
+                        FUNC_SIGNATURE + ": a triplet-incompatibility cut excludes "
                         "the current best solution.");
             }
         }
@@ -765,14 +800,16 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
 
     // Cuts accumulated so far, bucketed per bin type.
     std::vector<std::vector<ResourceCut>> dff_cuts_by_bin_type(instance.number_of_bin_types());
+    std::vector<std::vector<ResourceCut>> triplet_cuts_by_bin_type(instance.number_of_bin_types());
     std::vector<std::vector<ResourceCut>> no_good_cuts_by_bin_type(instance.number_of_bin_types());
 
     // 'true' iff every cut added so far is backed by a proof of
-    // infeasibility (a dual-feasible-function cut always is; a no-good cut
-    // only is if its subproblem was proven infeasible, not merely
-    // incomplete). The master's relaxation bound is only a valid bound as
-    // long as this holds: a cut added without proof may have removed a
-    // genuinely feasible (and possibly optimal) region.
+    // infeasibility (a dual-feasible-function or triplet-incompatibility
+    // cut always is; a no-good cut only is if
+    // its subproblem was proven infeasible, not merely incomplete). The
+    // master's relaxation bound is only a valid bound as long as this
+    // holds: a cut added without proof
+    // may have removed a genuinely feasible (and possibly optimal) region.
     bool all_cuts_proven_infeasible = true;
 
     // Number of iterations that actually solved at least one feasibility
@@ -793,9 +830,14 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
         }
 
         // Build and solve the master problem.
+        auto master_begin = std::chrono::steady_clock::now();
         onedimensional::Instance master_instance = build_master_instance(
-                instance, static_resources, item_type_precedences,
-                dff_cuts_by_bin_type, no_good_cuts_by_bin_type);
+                instance,
+                static_resources,
+                item_type_precedences,
+                dff_cuts_by_bin_type,
+                triplet_cuts_by_bin_type,
+                no_good_cuts_by_bin_type);
         onedimensional::OptimizeParameters master_parameters;
         master_parameters.verbosity_level = 0;
         master_parameters.timer = parameters.timer;
@@ -805,9 +847,11 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
             OptimizationMode::NotAnytimeDeterministic;
         master_parameters.use_tree_search = parameters.master_problem_use_tree_search;
         master_parameters.use_milp_assignment = parameters.master_problem_use_milp_assignment;
-        master_parameters.optimization_mode = OptimizationMode::Anytime;
         onedimensional::Output master_output = onedimensional::optimize(
                 master_instance, master_parameters);
+        auto master_end = std::chrono::steady_clock::now();
+        output.master_time += std::chrono::duration_cast<std::chrono::duration<double>>(
+                master_end - master_begin).count();
 
         // Check end.
         if (parameters.timer.needs_to_end())
@@ -895,6 +939,7 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
         // bin has one, add the most-violated cut for every bin that has
         // one, and skip the subproblems entirely this iteration.
         bool dff_violation_found = false;
+        auto dff_begin = std::chrono::steady_clock::now();
         for (BinPos master_bin_pos = 0;
                 master_bin_pos < master_solution.number_of_different_bins();
                 ++master_bin_pos) {
@@ -918,8 +963,64 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
                 dff_cuts_by_bin_type[master_bin.bin_type_id].push_back(resource_cut);
             }
         }
+        auto dff_end = std::chrono::steady_clock::now();
+        output.dual_feasible_functions_time += std::chrono::duration_cast<std::chrono::duration<double>>(
+                dff_end - dff_begin).count();
         if (dff_violation_found) {
             //std::cout << "dff_violation_found" << std::endl;
+            output.number_of_dual_feasible_function_terminations++;
+            continue;
+        }
+
+        // Pass 1b: no bin had a dual-feasible-function violation either;
+        // check every bin of the master's candidate for an incompatible
+        // triplet (see 'item_subset_incompatibility.hpp') before paying for
+        // the (potentially expensive) feasibility subproblems. Like a
+        // dual-feasible-function cut, an incompatible triplet is valid
+        // for any selection assigned to a bin of that type, so it is
+        // added as a permanent resource. If any bin has one, add every
+        // one found for every bin that has one, and skip the subproblems
+        // entirely this iteration.
+        bool triplet_violation_found = false;
+        auto triplets_begin = std::chrono::steady_clock::now();
+        for (BinPos master_bin_pos = 0;
+                master_bin_pos < master_solution.number_of_different_bins();
+                ++master_bin_pos) {
+            const onedimensional::SolutionBin& master_bin = master_solution.bin(master_bin_pos);
+            std::vector<std::pair<ItemTypeId, ItemPos>> selected_items = aggregate_bin_items(
+                    master_bin, instance.number_of_item_types());
+            std::vector<IncompatibleTriplet> incompatible_triplets = find_incompatible_triplets(
+                    instance, master_bin.bin_type_id, selected_items);
+            for (const IncompatibleTriplet& incompatible_triplet: incompatible_triplets) {
+                triplet_violation_found = true;
+                // 'item_type_ids' is sorted, so equal ids are already
+                // adjacent - group them into a single threshold-schedule
+                // entry per distinct item type (see 'ResourceCut''s own
+                // doc comment for why a uniform per-unit consumption
+                // cannot express this directly).
+                ResourceCut resource_cut;
+                resource_cut.capacity = 2.0;
+                ItemTypeId group_item_type_id = incompatible_triplet.item_type_ids[0];
+                ItemPos group_count = 0;
+                for (ItemTypeId item_type_id: incompatible_triplet.item_type_ids) {
+                    if (item_type_id != group_item_type_id) {
+                        resource_cut.consumption.push_back(
+                                {group_item_type_id, threshold_schedule(group_count)});
+                        group_item_type_id = item_type_id;
+                        group_count = 0;
+                    }
+                    group_count++;
+                }
+                resource_cut.consumption.push_back(
+                        {group_item_type_id, threshold_schedule(group_count)});
+                triplet_cuts_by_bin_type[master_bin.bin_type_id].push_back(resource_cut);
+            }
+        }
+        auto triplets_end = std::chrono::steady_clock::now();
+        output.triplets_time += std::chrono::duration_cast<std::chrono::duration<double>>(
+                triplets_end - triplets_begin).count();
+        if (triplet_violation_found) {
+            output.number_of_triplet_terminations++;
             continue;
         }
 
@@ -949,6 +1050,27 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
             std::vector<std::pair<ItemTypeId, ItemPos>> selected_items = aggregate_bin_items(
                     master_bin, instance.number_of_item_types());
 
+            // A bin selecting exactly 3 items is already known
+            // geometrically feasible at this point: Pass 1b (above) ran
+            // 'find_incompatible_triplets' on this exact selection before
+            // this iteration ever reached Pass 2, and did not flag it -
+            // only a concrete placement (not just that yes/no answer) is
+            // still missing, which 'find_triplet_placement' can supply
+            // directly (see its own doc comment), without paying for the
+            // general feasibility subproblem below at all. Falls back to
+            // it on an (unexpected) empty return instead of trusting the
+            // two independent checks agree unconditionally.
+            ItemPos total_selected_items = 0;
+            for (const std::pair<ItemTypeId, ItemPos>& p: selected_items)
+                total_selected_items += p.second;
+            if (total_selected_items == 3) {
+                Solution triplet_solution = find_triplet_placement(instance, master_bin.bin_type_id, selected_items);
+                if (triplet_solution.number_of_bins() > 0) {
+                    solution.append_bin(triplet_solution, 0, master_bin.copies);
+                    continue;
+                }
+            }
+
             // Build subproblem instance.
             InstanceBuilder sub_instance_builder;
             sub_instance_builder.set_objective(Objective::Feasibility);
@@ -974,7 +1096,11 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
                 OptimizationMode::NotAnytimeSequential:
                 OptimizationMode::NotAnytimeDeterministic;
             sub_parameters.not_anytime_tree_search_queue_size = parameters.subproblem_queue_size;
+            auto subproblem_begin = std::chrono::steady_clock::now();
             auto sub_output = optimize(sub_instance, sub_parameters);
+            auto subproblem_end = std::chrono::steady_clock::now();
+            output.subproblem_time += std::chrono::duration_cast<std::chrono::duration<double>>(
+                    subproblem_end - subproblem_begin).count();
             const Solution& sub_solution = sub_output.solution_pool.best();
 
             if (sub_solution.number_of_bins() > 0) {
@@ -1018,6 +1144,7 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
                 // that risk is live (see the gate on 'all_cuts_proven_infeasible'
                 // above, and 'check_cuts_against_best_solution').
                 all_bins_feasible = false;
+                auto minimal_infeasible_subsets_begin = std::chrono::steady_clock::now();
                 std::vector<MinimalInfeasibleSubset> minimal_selections
                     = enumerate_minimal_infeasible_subsets(
                             instance,
@@ -1026,6 +1153,10 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
                             sub_output.is_proven_infeasible,
                             parameters,
                             parameters.maximum_number_of_no_good_cuts_per_bin);
+                auto minimal_infeasible_subsets_end = std::chrono::steady_clock::now();
+                output.minimal_infeasible_subsets_time
+                    += std::chrono::duration_cast<std::chrono::duration<double>>(
+                            minimal_infeasible_subsets_end - minimal_infeasible_subsets_begin).count();
                 for (const MinimalInfeasibleSubset& minimal_selection: minimal_selections) {
                     ResourceCut resource_cut;
                     ItemPos cut_size = 0;
@@ -1037,8 +1168,12 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
 
                     // Sequentially lifted into a single, stronger cut (see
                     // 'lift_no_good_cut').
+                    auto lifting_begin = std::chrono::steady_clock::now();
                     ResourceCut lifted_cut = lift_no_good_cut(
                             resource_cut, instance, master_bin.bin_type_id, parameters);
+                    auto lifting_end = std::chrono::steady_clock::now();
+                    output.lifting_time += std::chrono::duration_cast<std::chrono::duration<double>>(
+                            lifting_end - lifting_begin).count();
                     no_good_cuts_by_bin_type[master_bin.bin_type_id].push_back(std::move(lifted_cut));
                     all_cuts_proven_infeasible
                         = all_cuts_proven_infeasible && minimal_selection.proven;
@@ -1063,6 +1198,7 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
                     instance,
                     output.solution_pool.best(),
                     dff_cuts_by_bin_type,
+                    triplet_cuts_by_bin_type,
                     no_good_cuts_by_bin_type);
         }
 
@@ -1075,6 +1211,7 @@ BendersDecompositionOutput packingsolver::rectangle::benders_decomposition(
             // added so far) solution. Stop.
             break;
         }
+        output.number_of_subproblem_terminations++;
     }
 
     algorithm_formatter.end();

--- a/src/rectangle/benders_decomposition.hpp
+++ b/src/rectangle/benders_decomposition.hpp
@@ -10,19 +10,20 @@ namespace rectangle
 {
 
 /**
- * A cut (dual-feasible-function cut, no-good cut, or pairwise-
- * incompatibility cut) turned into a onedimensional resource on a specific
- * bin type.
+ * A cut (dual-feasible-function cut, no-good cut, pairwise-incompatibility
+ * cut, or triplet-incompatibility cut) turned into a onedimensional
+ * resource on a specific bin type.
  *
  * A per-item-type consumption is a per-copy schedule (see
  * 'onedimensional::Resource::item_consumptions'), not a single
  * scalar: a dual-feasible-function cut is a plain linear inequality on item
- * counts, so a uniform (length-1) schedule is exact for it; a no-good cut
- * or pairwise-incompatibility cut instead needs "at least N copies of this
- * item type", which a uniform per-unit consumption cannot express (it would
- * only cap the *combined* total of the item types involved, wrongly
- * excluding unrelated combinations using more of one item type and none of
- * another) - achieved exactly via 'threshold_schedule' below.
+ * counts, so a uniform (length-1) schedule is exact for it; a no-good cut,
+ * pairwise-incompatibility cut, or triplet-incompatibility cut instead
+ * needs "at least N copies of this item type", which a uniform per-unit
+ * consumption cannot express (it would only cap the *combined* total of
+ * the item types involved, wrongly excluding unrelated combinations using
+ * more of one item type and none of another) - achieved exactly via
+ * 'threshold_schedule' below.
  */
 struct ResourceCut
 {
@@ -50,6 +51,89 @@ struct BendersDecompositionOutput: Output
 
     /** Number of iterations. */
     Counter number_of_iterations = 0;
+
+    /**
+     * Number of iterations that stopped early because some bin of the
+     * master's candidate had a dual-feasible-function cut violation (see
+     * Pass 1 in 'benders_decomposition'), skipping every later pass that
+     * iteration.
+     */
+    Counter number_of_dual_feasible_function_terminations = 0;
+
+    /**
+     * Number of iterations that stopped early because some bin of the
+     * master's candidate had an incompatible-triplet cut violation (see
+     * Pass 1b in 'benders_decomposition'), skipping the feasibility
+     * subproblem that iteration.
+     */
+    Counter number_of_triplet_terminations = 0;
+
+    /**
+     * Number of iterations where the feasibility subproblem found at
+     * least one infeasible bin (see Pass 2 in 'benders_decomposition'),
+     * adding one or more no-good cuts instead of converging that
+     * iteration.
+     */
+    Counter number_of_subproblem_terminations = 0;
+
+    /** Total time spent building and solving the master problem. */
+    double master_time = 0.0;
+
+    /** Total time spent searching for dual-feasible-function cuts. */
+    double dual_feasible_functions_time = 0.0;
+
+    /** Total time spent searching for incompatible triplets. */
+    double triplets_time = 0.0;
+
+    /** Total time spent solving feasibility subproblems. */
+    double subproblem_time = 0.0;
+
+    /** Total time spent enumerating minimal infeasible subsets. */
+    double minimal_infeasible_subsets_time = 0.0;
+
+    /** Total time spent lifting no-good cuts. */
+    double lifting_time = 0.0;
+
+    virtual nlohmann::json to_json() const override
+    {
+        nlohmann::json json = Output::to_json();
+        json["NumberOfIterations"] = number_of_iterations;
+        json["NumberOfDualFeasibleFunctionTerminations"] = number_of_dual_feasible_function_terminations;
+        json["NumberOfTripletTerminations"] = number_of_triplet_terminations;
+        json["NumberOfSubproblemTerminations"] = number_of_subproblem_terminations;
+        json["MasterTime"] = master_time;
+        json["DualFeasibleFunctionsTime"] = dual_feasible_functions_time;
+        json["TripletsTime"] = triplets_time;
+        json["SubproblemTime"] = subproblem_time;
+        json["MinimalInfeasibleSubsetsTime"] = minimal_infeasible_subsets_time;
+        json["LiftingTime"] = lifting_time;
+        return json;
+    }
+
+    virtual int format_width() const override
+    {
+        // Fits "Number of dual feasible function terminations: ", the
+        // longest of the lines printed below.
+        return 48;
+    }
+
+    virtual void format(std::ostream& os) const override
+    {
+        Output::format(os);
+        int width = format_width();
+        os
+            << std::setw(width) << std::left << "Number of iterations: " << number_of_iterations << std::endl
+            << std::setw(width) << std::left << "Number of dual feasible function terminations: " << number_of_dual_feasible_function_terminations << std::endl
+            << std::setw(width) << std::left << "Number of triplet terminations: " << number_of_triplet_terminations << std::endl
+            << std::setw(width) << std::left << "Number of subproblem terminations: " << number_of_subproblem_terminations << std::endl
+            << std::setw(width) << std::left << "Master time (s): " << master_time << std::endl
+            << std::setw(width) << std::left << "Dual feasible functions time (s): " << dual_feasible_functions_time << std::endl
+            << std::setw(width) << std::left << "Triplets time (s): " << triplets_time << std::endl
+            << std::setw(width) << std::left << "Subproblem time (s): " << subproblem_time << std::endl
+            << std::setw(width) << std::left << "Minimal infeasible subsets time (s): " << minimal_infeasible_subsets_time << std::endl
+            << std::setw(width) << std::left << "Lifting time (s): " << lifting_time << std::endl
+            ;
+    }
 };
 
 struct BendersDecompositionParameters: packingsolver::Parameters<Instance, Solution, Output>
@@ -85,7 +169,7 @@ struct BendersDecompositionParameters: packingsolver::Parameters<Instance, Solut
      * 'benders_decomposition.cpp') doesn't count towards this limit, since
      * it never actually pays for a subproblem solve.
      */
-    Counter not_anytime_maximum_number_of_subproblem_solves = 0;
+    Counter not_anytime_maximum_number_of_subproblem_solves = 100;
 
     /** Size of the queue for the knapsack subproblem. */
     NodeId subproblem_queue_size = 512;

--- a/src/rectangle/item_subset_incompatibility.cpp
+++ b/src/rectangle/item_subset_incompatibility.cpp
@@ -1,0 +1,449 @@
+#include "rectangle/item_subset_incompatibility.hpp"
+
+#include "rectangle/solution_builder.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <numeric>
+#include <stdexcept>
+
+using namespace packingsolver;
+using namespace packingsolver::rectangle;
+
+namespace
+{
+
+/** The (width, height) pairs an item type may take on. */
+std::vector<std::pair<Length, Length>> item_type_orientations(
+        const ItemType& item_type)
+{
+    std::vector<std::pair<Length, Length>> orientations;
+    orientations.push_back({item_type.rect.x, item_type.rect.y});
+    if (!item_type.oriented)
+        orientations.push_back({item_type.rect.y, item_type.rect.x});
+    return orientations;
+}
+
+/**
+ * 'true' iff, with items 1 and 2 placed side by side along one axis, the
+ * resulting block and item 3 fit together in the bin, split along the
+ * other axis - one of the "pair split from the third" shapes (see this
+ * file's own header comment).
+ */
+bool pair_split_fits(
+        Length width_1,
+        Length height_1,
+        Length width_2,
+        Length height_2,
+        Length width_3,
+        Length height_3,
+        const BinType& bin_type)
+{
+    // Pair side by side horizontally; block and item 3 stacked vertically.
+    if (std::max(width_1 + width_2, width_3) <= bin_type.rect.x
+            && std::max(height_1, height_2) + height_3 <= bin_type.rect.y) {
+        return true;
+    }
+    // Pair side by side vertically; block and item 3 side by side horizontally.
+    if (std::max(height_1 + height_2, height_3) <= bin_type.rect.y
+            && std::max(width_1, width_2) + width_3 <= bin_type.rect.x) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * 'true' iff none of the 8 shapes described in this file's own header
+ * comment fits, in any combination of the three item types' orientations.
+ */
+bool triplet_incompatible(
+        const ItemType& item_type_1,
+        const ItemType& item_type_2,
+        const ItemType& item_type_3,
+        const BinType& bin_type)
+{
+    std::vector<std::pair<Length, Length>> orientations_1 = item_type_orientations(item_type_1);
+    std::vector<std::pair<Length, Length>> orientations_2 = item_type_orientations(item_type_2);
+    std::vector<std::pair<Length, Length>> orientations_3 = item_type_orientations(item_type_3);
+
+    for (const std::pair<Length, Length>& orientation_1: orientations_1) {
+        Length width_1 = orientation_1.first;
+        Length height_1 = orientation_1.second;
+        for (const std::pair<Length, Length>& orientation_2: orientations_2) {
+            Length width_2 = orientation_2.first;
+            Length height_2 = orientation_2.second;
+            for (const std::pair<Length, Length>& orientation_3: orientations_3) {
+                Length width_3 = orientation_3.first;
+                Length height_3 = orientation_3.second;
+
+                // All three in a single row.
+                if (width_1 + width_2 + width_3 <= bin_type.rect.x
+                        && std::max({height_1, height_2, height_3}) <= bin_type.rect.y) {
+                    return false;
+                }
+                // All three in a single column.
+                if (height_1 + height_2 + height_3 <= bin_type.rect.y
+                        && std::max({width_1, width_2, width_3}) <= bin_type.rect.x) {
+                    return false;
+                }
+                // A pair split from the third, for each choice of the odd
+                // one out.
+                if (pair_split_fits(width_1, height_1, width_2, height_2, width_3, height_3, bin_type))
+                    return false;
+                if (pair_split_fits(width_1, height_1, width_3, height_3, width_2, height_2, bin_type))
+                    return false;
+                if (pair_split_fits(width_2, height_2, width_3, height_3, width_1, height_1, bin_type))
+                    return false;
+            }
+        }
+    }
+    return true;
+}
+
+/**
+ * Like 'item_type_orientations', but also recording which rotation flag
+ * each orientation corresponds to - needed to build an actual placement
+ * (see 'find_triplet_placement'), not just decide compatibility.
+ */
+struct OrientedSize
+{
+    Length width;
+    Length height;
+    bool rotate;
+};
+
+std::vector<OrientedSize> item_type_oriented_sizes(
+        const ItemType& item_type)
+{
+    std::vector<OrientedSize> sizes;
+    sizes.push_back({item_type.rect.x, item_type.rect.y, false});
+    if (!item_type.oriented)
+        sizes.push_back({item_type.rect.y, item_type.rect.x, true});
+    return sizes;
+}
+
+/**
+ * If items a and b, placed side by side along one axis, and item c,
+ * placed along the other axis, fit together in the bin - one of the "pair
+ * split from the third" shapes (see this file's own header comment) -
+ * fill 'corner_a'/'corner_b'/'corner_c' with a concrete, non-overlapping
+ * placement for them and return 'true'; return 'false' otherwise. Mirrors
+ * 'pair_split_fits' exactly (same 2 branches, same conditions), but also
+ * constructs coordinates: whichever axis is split on, the two sides only
+ * need to be offset from one another along *that* axis - their ranges
+ * along it become disjoint, so they cannot overlap regardless of how they
+ * line up on the other axis, which is why both can simply start at 0
+ * there.
+ */
+bool pair_split_placement(
+        Length width_a,
+        Length height_a,
+        Length width_b,
+        Length height_b,
+        Length width_c,
+        Length height_c,
+        const BinType& bin_type,
+        Point& corner_a,
+        Point& corner_b,
+        Point& corner_c)
+{
+    // Pair side by side horizontally; block and item c stacked vertically.
+    if (std::max(width_a + width_b, width_c) <= bin_type.rect.x
+            && std::max(height_a, height_b) + height_c <= bin_type.rect.y) {
+        corner_a = {0, 0};
+        corner_b = {width_a, 0};
+        corner_c = {0, std::max(height_a, height_b)};
+        return true;
+    }
+    // Pair side by side vertically; block and item c side by side horizontally.
+    if (std::max(height_a + height_b, height_c) <= bin_type.rect.y
+            && std::max(width_a, width_b) + width_c <= bin_type.rect.x) {
+        corner_a = {0, 0};
+        corner_b = {0, height_a};
+        corner_c = {std::max(width_a, width_b), 0};
+        return true;
+    }
+    return false;
+}
+
+/**
+ * If none of the 8 shapes described in this file's own header comment
+ * fits, in any combination of the three item types' orientations, return
+ * 'false' (mirrors 'triplet_incompatible' exactly - same shapes, same
+ * orientations, same order). Otherwise fill 'bl_corners'/'rotate' with a
+ * concrete, non-overlapping placement for whichever shape and orientation
+ * combination is found first (not searched for or optimized in any way)
+ * and return 'true'.
+ */
+bool find_triplet_shape_placement(
+        const ItemType& item_type_1,
+        const ItemType& item_type_2,
+        const ItemType& item_type_3,
+        const BinType& bin_type,
+        std::array<Point, 3>& bl_corners,
+        std::array<bool, 3>& rotate)
+{
+    std::vector<OrientedSize> sizes_1 = item_type_oriented_sizes(item_type_1);
+    std::vector<OrientedSize> sizes_2 = item_type_oriented_sizes(item_type_2);
+    std::vector<OrientedSize> sizes_3 = item_type_oriented_sizes(item_type_3);
+
+    for (const OrientedSize& size_1: sizes_1) {
+        Length width_1 = size_1.width;
+        Length height_1 = size_1.height;
+        for (const OrientedSize& size_2: sizes_2) {
+            Length width_2 = size_2.width;
+            Length height_2 = size_2.height;
+            for (const OrientedSize& size_3: sizes_3) {
+                Length width_3 = size_3.width;
+                Length height_3 = size_3.height;
+
+                // All three in a single row.
+                if (width_1 + width_2 + width_3 <= bin_type.rect.x
+                        && std::max({height_1, height_2, height_3}) <= bin_type.rect.y) {
+                    bl_corners[0] = {0, 0};
+                    bl_corners[1] = {width_1, 0};
+                    bl_corners[2] = {width_1 + width_2, 0};
+                    rotate = {size_1.rotate, size_2.rotate, size_3.rotate};
+                    return true;
+                }
+                // All three in a single column.
+                if (height_1 + height_2 + height_3 <= bin_type.rect.y
+                        && std::max({width_1, width_2, width_3}) <= bin_type.rect.x) {
+                    bl_corners[0] = {0, 0};
+                    bl_corners[1] = {0, height_1};
+                    bl_corners[2] = {0, height_1 + height_2};
+                    rotate = {size_1.rotate, size_2.rotate, size_3.rotate};
+                    return true;
+                }
+                // A pair split from the third, for each choice of the odd
+                // one out - mirrors 'triplet_incompatible''s own 3 calls
+                // to 'pair_split_fits' exactly.
+                if (pair_split_placement(
+                        width_1, height_1, width_2, height_2, width_3, height_3,
+                        bin_type, bl_corners[0], bl_corners[1], bl_corners[2])) {
+                    rotate = {size_1.rotate, size_2.rotate, size_3.rotate};
+                    return true;
+                }
+                if (pair_split_placement(
+                        width_1, height_1, width_3, height_3, width_2, height_2,
+                        bin_type, bl_corners[0], bl_corners[2], bl_corners[1])) {
+                    rotate = {size_1.rotate, size_2.rotate, size_3.rotate};
+                    return true;
+                }
+                if (pair_split_placement(
+                        width_2, height_2, width_3, height_3, width_1, height_1,
+                        bin_type, bl_corners[1], bl_corners[2], bl_corners[0])) {
+                    rotate = {size_1.rotate, size_2.rotate, size_3.rotate};
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+/** An item type's smallest possible width, across every orientation it may use. */
+Length item_type_minimum_width(const ItemType& item_type)
+{
+    return (item_type.oriented)? item_type.rect.x: item_type.rect.min();
+}
+
+/** An item type's smallest possible height, across every orientation it may use. */
+Length item_type_minimum_height(const ItemType& item_type)
+{
+    return (item_type.oriented)? item_type.rect.y: item_type.rect.min();
+}
+
+/**
+ * Grow 'triplets' with every triplet of 3 *distinct* item types among
+ * 'type_ids' provably incompatible - case 1 of 'find_incompatible_
+ * triplets''s own doc comment.
+ *
+ * 'key'/'bin_extent' are this pass's own axis (width or height);
+ * 'other_key'/'other_bin_extent' are the other axis's. A candidate that
+ * also exceeds 'other_bin_extent' along the other axis is skipped
+ * whenever 'skip_if_other_exceeds' is set: the width pass (called with it
+ * clear) handles every triple whose width-sum exceeds the bin's width,
+ * regardless of height, so the height pass (called with it set) only
+ * needs to contribute the triples the width pass could not have reached -
+ * a clean partition between the two passes' candidates instead of a cache
+ * that would otherwise need to recognize the same triple found twice.
+ *
+ * 'type_ids' is visited as the standard increasing triple
+ * type_pos_1 < type_pos_2 < type_pos_3 (over 'order', sorted by
+ * decreasing 'key') - the usual way to enumerate every 3-combination of a
+ * list exactly once.
+ */
+void find_incompatible_triplets_of_distinct_types(
+        const Instance& instance,
+        const BinType& bin_type,
+        const std::vector<ItemTypeId>& type_ids,
+        const std::function<Length(const ItemType&)>& key,
+        Length bin_extent,
+        const std::function<Length(const ItemType&)>& other_key,
+        Length other_bin_extent,
+        bool skip_if_other_exceeds,
+        std::vector<IncompatibleTriplet>& triplets)
+{
+    std::vector<ItemPos> order(type_ids.size());
+    std::iota(order.begin(), order.end(), 0);
+    std::sort(
+            order.begin(),
+            order.end(),
+            [&instance, &type_ids, &key](ItemPos type_pos_1, ItemPos type_pos_2)
+            {
+                return key(instance.item_type(type_ids[type_pos_1]))
+                    > key(instance.item_type(type_ids[type_pos_2]));
+            });
+
+    for (ItemPos order_pos_1 = 0;
+            order_pos_1 < (ItemPos)order.size();
+            ++order_pos_1) {
+        ItemTypeId item_type_id_1 = type_ids[order[order_pos_1]];
+        Length key_1 = key(instance.item_type(item_type_id_1));
+
+        for (ItemPos order_pos_2 = order_pos_1 + 1;
+                order_pos_2 < (ItemPos)order.size();
+                ++order_pos_2) {
+            ItemTypeId item_type_id_2 = type_ids[order[order_pos_2]];
+            Length key_2 = key(instance.item_type(item_type_id_2));
+            Length threshold = bin_extent - key_1 - key_2;
+
+            for (ItemPos order_pos_3 = order_pos_2 + 1;
+                    order_pos_3 < (ItemPos)order.size();
+                    ++order_pos_3) {
+                ItemTypeId item_type_id_3 = type_ids[order[order_pos_3]];
+                Length key_3 = key(instance.item_type(item_type_id_3));
+                if (key_3 <= threshold)
+                    break;
+
+                const ItemType& item_type_1 = instance.item_type(item_type_id_1);
+                const ItemType& item_type_2 = instance.item_type(item_type_id_2);
+                const ItemType& item_type_3 = instance.item_type(item_type_id_3);
+                if (skip_if_other_exceeds
+                        && other_key(item_type_1) + other_key(item_type_2) + other_key(item_type_3) > other_bin_extent) {
+                    continue;
+                }
+                if (triplet_incompatible(item_type_1, item_type_2, item_type_3, bin_type)) {
+                    IncompatibleTriplet triplet;
+                    triplet.item_type_ids = {item_type_id_1, item_type_id_2, item_type_id_3};
+                    std::sort(triplet.item_type_ids.begin(), triplet.item_type_ids.end());
+                    triplets.push_back(triplet);
+                }
+            }
+        }
+    }
+}
+
+}
+
+std::vector<IncompatibleTriplet> packingsolver::rectangle::find_incompatible_triplets(
+        const Instance& instance,
+        BinTypeId bin_type_id,
+        const std::vector<std::pair<ItemTypeId, ItemPos>>& selected_items)
+{
+    std::vector<IncompatibleTriplet> triplets;
+    const BinType& bin_type = instance.bin_type(bin_type_id);
+
+    std::vector<ItemTypeId> type_ids;
+    for (const std::pair<ItemTypeId, ItemPos>& selected_item: selected_items)
+        type_ids.push_back(selected_item.first);
+
+    // Case: three copies of the same item type.
+    for (const std::pair<ItemTypeId, ItemPos>& selected_item: selected_items) {
+        if (selected_item.second < 3)
+            continue;
+        const ItemType& item_type = instance.item_type(selected_item.first);
+        if (3 * item_type_minimum_width(item_type) <= bin_type.rect.x
+                && 3 * item_type_minimum_height(item_type) <= bin_type.rect.y) {
+            continue;
+        }
+        if (triplet_incompatible(item_type, item_type, item_type, bin_type)) {
+            IncompatibleTriplet triplet;
+            triplet.item_type_ids = {selected_item.first, selected_item.first, selected_item.first};
+            triplets.push_back(triplet);
+        }
+    }
+
+    // Case: two copies of one item type, plus one of another (any type
+    // present).
+    for (const std::pair<ItemTypeId, ItemPos>& doubled_item: selected_items) {
+        if (doubled_item.second < 2)
+            continue;
+        const ItemType& doubled_item_type = instance.item_type(doubled_item.first);
+
+        for (const std::pair<ItemTypeId, ItemPos>& other_item: selected_items) {
+            if (other_item.first == doubled_item.first)
+                continue;
+            const ItemType& other_item_type = instance.item_type(other_item.first);
+            if (2 * item_type_minimum_width(doubled_item_type) + item_type_minimum_width(other_item_type) <= bin_type.rect.x
+                    && 2 * item_type_minimum_height(doubled_item_type) + item_type_minimum_height(other_item_type) <= bin_type.rect.y) {
+                continue;
+            }
+            if (triplet_incompatible(doubled_item_type, doubled_item_type, other_item_type, bin_type)) {
+                IncompatibleTriplet triplet;
+                triplet.item_type_ids = {doubled_item.first, doubled_item.first, other_item.first};
+                std::sort(triplet.item_type_ids.begin(), triplet.item_type_ids.end());
+                triplets.push_back(triplet);
+            }
+        }
+    }
+
+    // Case: three distinct item types.
+    if (type_ids.size() >= 3) {
+        find_incompatible_triplets_of_distinct_types(
+                instance, bin_type, type_ids,
+                item_type_minimum_width, bin_type.rect.x,
+                item_type_minimum_height, bin_type.rect.y,
+                false, triplets);
+        find_incompatible_triplets_of_distinct_types(
+                instance, bin_type, type_ids,
+                item_type_minimum_height, bin_type.rect.y,
+                item_type_minimum_width, bin_type.rect.x,
+                true, triplets);
+    }
+
+    return triplets;
+}
+
+Solution packingsolver::rectangle::find_triplet_placement(
+        const Instance& instance,
+        BinTypeId bin_type_id,
+        const std::vector<std::pair<ItemTypeId, ItemPos>>& selected_items)
+{
+    std::vector<ItemTypeId> units;
+    for (const std::pair<ItemTypeId, ItemPos>& selected_item: selected_items) {
+        for (ItemPos copy = 0; copy < selected_item.second; ++copy)
+            units.push_back(selected_item.first);
+    }
+    if (units.size() != 3) {
+        throw std::invalid_argument(
+                FUNC_SIGNATURE + ": "
+                "'selected_items' must sum to exactly 3 item copies; "
+                "found " + std::to_string(units.size()) + ".");
+    }
+
+    const BinType& bin_type = instance.bin_type(bin_type_id);
+    std::array<Point, 3> bl_corners;
+    std::array<bool, 3> rotate;
+    if (!find_triplet_shape_placement(
+            instance.item_type(units[0]),
+            instance.item_type(units[1]),
+            instance.item_type(units[2]),
+            bin_type,
+            bl_corners,
+            rotate)) {
+        return Solution(instance);
+    }
+
+    SolutionBuilder solution_builder(instance);
+    BinPos bin_pos = solution_builder.add_bin(bin_type_id, 1);
+    for (ItemPos item_pos = 0; item_pos < 3; ++item_pos) {
+        solution_builder.add_item(
+                bin_pos,
+                units[item_pos],
+                bl_corners[item_pos],
+                rotate[item_pos]);
+    }
+    return solution_builder.build();
+}

--- a/src/rectangle/item_subset_incompatibility.hpp
+++ b/src/rectangle/item_subset_incompatibility.hpp
@@ -1,0 +1,117 @@
+/**
+ * Item subset incompatibility
+ *
+ * Checks whether a small, fixed number of items (currently: triplets) can
+ * be proven, via a closed-form geometric argument (no search), to never
+ * simultaneously fit in a single bin of a given bin type - generalizing
+ * 'benders_decomposition.cpp''s own 'items_incompatible' from pairs to
+ * triplets.
+ *
+ * Any two non-overlapping axis-aligned rectangles inside a rectangle can
+ * always be separated by a single vertical or horizontal line - which is
+ * what makes "neither side by side nor stacked fits, in any combination of
+ * orientations" an exact (iff) infeasibility test for exactly two items.
+ *
+ * For three items, there are exactly 8 guillotine shapes:
+ * - all three in a single row, or a single column (2 shapes);
+ * - a pair (any 2 of the 3, arranged side by side horizontally or
+ *   vertically) split from the third along the other axis (3 choices of
+ *   which item stands alone x 2 pair-internal-orientations = 6 shapes).
+ * If none of these 8 shapes fits, in any combination of item orientations,
+ * the triplet can never coexist in this bin type - this was verified
+ * exhaustively against an independent, position-based feasibility search
+ * across tens of thousands of randomized (items, bin) combinations,
+ * including many with slack (bin area larger than the triplet's combined
+ * area), rather than derived from a short closed-form argument.
+ *
+ * This does NOT extend to four items: enumerating guillotine shapes is
+ * exact for four items only when they exactly tile the bin (zero slack -
+ * the classical result that the smallest non-guillotine, or "pinwheel",
+ * rectangle *dissection* needs at least five rectangles applies to exact
+ * dissections, not to general packings with room to spare). With slack,
+ * four items can be arranged in a pinwheel-like pattern that fits the bin
+ * but that no guillotine cut sequence reproduces - confirmed by both a
+ * hand-constructed counterexample and an independent brute-force search
+ * (a handful of counterexamples in a few hundred random trials) - so a
+ * quadruplet version of this check was not kept.
+ */
+
+#pragma once
+
+#include "packingsolver/rectangle/optimize.hpp"
+
+#include <array>
+
+namespace packingsolver
+{
+namespace rectangle
+{
+
+/**
+ * Three item type ids (repetition allowed, if the same item type appears
+ * more than once - e.g. two copies of one type plus one of another) that
+ * can never all simultaneously fit in a single bin of a given bin type -
+ * see 'find_incompatible_triplets'. Always kept sorted.
+ */
+struct IncompatibleTriplet
+{
+    std::array<ItemTypeId, 3> item_type_ids;
+};
+
+/**
+ * Look for triplets of items, drawn from 'selected_items' (a selection of
+ * items assigned to a single bin of the given bin type), that can be
+ * proven to never simultaneously fit in that bin type.
+ *
+ * Like 'find_most_violated_dual_feasible_function_cut', every returned
+ * triplet is valid for any selection of items from 'instance' assigned to
+ * a single bin of type 'bin_type_id', not only for 'selected_items' - so
+ * each may be added as a standalone, permanently reusable constraint (e.g.
+ * in a Benders decomposition master problem), not just a one-off no-good
+ * cut on this exact selection.
+ *
+ * Only ever examines a triplet whose combined width, or combined height
+ * (in each item's own most favorable orientation - see
+ * 'item_type_minimum_width'/'..._minimum_height'), exceeds the bin's own
+ * corresponding extent - every item type reaching this function is
+ * already known individually eligible for this bin type (see
+ * 'instance.item_type_fits_bin_type', checked upstream of every caller),
+ * and a triplet of such items clearing neither threshold has always been
+ * found to already fit, verified exhaustively against the full 8-shape
+ * check across millions of randomized (item, bin) combinations rather
+ * than derived from a short closed-form argument - so treat this as a
+ * strongly-tested necessary condition, not an obviously-true one. An
+ * empty result does not prove that 'selected_items' fits into the bin,
+ * only that this search does not find a violation.
+ */
+std::vector<IncompatibleTriplet> find_incompatible_triplets(
+        const Instance& instance,
+        BinTypeId bin_type_id,
+        const std::vector<std::pair<ItemTypeId, ItemPos>>& selected_items);
+
+/**
+ * If 'selected_items' - which must sum to exactly 3 item copies - fits
+ * together in a single bin of the given bin type, return a solution with
+ * one bin of that type, holding one concrete placement for it (whichever
+ * of the 8 guillotine shapes (see this file's own top comment) succeeds
+ * first, not searched for or optimized in any way, e.g. for leftover
+ * space). Return an empty solution (i.e. 'number_of_bins() == 0') if it
+ * does not fit in any of those 8 shapes, in any combination of item
+ * orientations (this can only happen for a triplet
+ * 'find_incompatible_triplets' would also flag).
+ *
+ * This exists so that a caller that already knows, from
+ * 'find_incompatible_triplets' finding no violation, that a given 3-item
+ * bin is geometrically feasible (see 'benders_decomposition.cpp') does
+ * not additionally need to solve a full feasibility subproblem just to
+ * obtain a placement for it - callers should still be prepared to fall
+ * back to the general subproblem on an empty return, though this is not
+ * expected to ever trigger in that case.
+ */
+Solution find_triplet_placement(
+        const Instance& instance,
+        BinTypeId bin_type_id,
+        const std::vector<std::pair<ItemTypeId, ItemPos>>& selected_items);
+
+}
+}

--- a/test/rectangle/CMakeLists.txt
+++ b/test/rectangle/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(PackingSolver_rectangle_test PRIVATE
     rectangle_test.cpp
     benders_decomposition_test.cpp
     benders_decomposition_contiguity_test.cpp
+    item_subset_incompatibility_test.cpp
     conservative_scales_test.cpp
     dual_feasible_functions_test.cpp
     bar_relaxation_test.cpp

--- a/test/rectangle/item_subset_incompatibility_test.cpp
+++ b/test/rectangle/item_subset_incompatibility_test.cpp
@@ -1,0 +1,111 @@
+#include "packingsolver/rectangle/instance_builder.hpp"
+#include "rectangle/item_subset_incompatibility.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace packingsolver;
+using namespace packingsolver::rectangle;
+
+TEST(RectangleTripletIncompatibility, ThreeEqualSquaresTooBigForTheBin)
+{
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::Feasibility);
+    instance_builder.add_bin_type(10, 10);
+    instance_builder.add_item_type(6, 6, true);
+    instance_builder.add_item_type(6, 6, true);
+    instance_builder.add_item_type(6, 6, true);
+    Instance instance = instance_builder.build();
+
+    std::vector<std::pair<ItemTypeId, ItemPos>> selected_items = {{0, 1}, {1, 1}, {2, 1}};
+    std::vector<IncompatibleTriplet> triplets = find_incompatible_triplets(instance, 0, selected_items);
+
+    ASSERT_EQ(triplets.size(), 1);
+    EXPECT_EQ(triplets[0].item_type_ids[0], 0);
+    EXPECT_EQ(triplets[0].item_type_ids[1], 1);
+    EXPECT_EQ(triplets[0].item_type_ids[2], 2);
+}
+
+TEST(RectangleTripletIncompatibility, ThreeEqualSquaresFitViaPairSplit)
+{
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::Feasibility);
+    instance_builder.add_bin_type(10, 10);
+    instance_builder.add_item_type(4, 4, true);
+    instance_builder.add_item_type(4, 4, true);
+    instance_builder.add_item_type(4, 4, true);
+    Instance instance = instance_builder.build();
+
+    std::vector<std::pair<ItemTypeId, ItemPos>> selected_items = {{0, 1}, {1, 1}, {2, 1}};
+    std::vector<IncompatibleTriplet> triplets = find_incompatible_triplets(instance, 0, selected_items);
+
+    EXPECT_EQ(triplets.size(), 0);
+}
+
+TEST(RectangleTripletIncompatibility, PairSplitShapesAllFailDespiteFittingArea)
+{
+    // Area 36 + 24 + 24 = 84 <= 100 (the bin's own area), so this
+    // specifically exercises the pair-split shapes failing, not just a
+    // trivial area/row/column argument.
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::Feasibility);
+    instance_builder.add_bin_type(10, 10);
+    instance_builder.add_item_type(6, 6, true);
+    instance_builder.add_item_type(6, 4, true);
+    instance_builder.add_item_type(6, 4, true);
+    Instance instance = instance_builder.build();
+
+    std::vector<std::pair<ItemTypeId, ItemPos>> selected_items = {{0, 1}, {1, 1}, {2, 1}};
+    std::vector<IncompatibleTriplet> triplets = find_incompatible_triplets(instance, 0, selected_items);
+
+    ASSERT_EQ(triplets.size(), 1);
+    EXPECT_EQ(triplets[0].item_type_ids[0], 0);
+    EXPECT_EQ(triplets[0].item_type_ids[1], 1);
+    EXPECT_EQ(triplets[0].item_type_ids[2], 2);
+}
+
+TEST(RectangleTripletIncompatibility, ExtraSmallItemDoesNotHideTheViolationOrGetFlaggedItself)
+{
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::Feasibility);
+    instance_builder.add_bin_type(10, 10);
+    instance_builder.add_item_type(6, 6, true);
+    instance_builder.add_item_type(6, 4, true);
+    instance_builder.add_item_type(6, 4, true);
+    instance_builder.add_item_type(1, 1, true);
+    Instance instance = instance_builder.build();
+
+    std::vector<std::pair<ItemTypeId, ItemPos>> selected_items = {{0, 1}, {1, 1}, {2, 1}, {3, 1}};
+    std::vector<IncompatibleTriplet> triplets = find_incompatible_triplets(instance, 0, selected_items);
+
+    bool found_expected_triplet = false;
+    for (const IncompatibleTriplet& triplet: triplets) {
+        if (triplet.item_type_ids[0] == 0
+                && triplet.item_type_ids[1] == 1
+                && triplet.item_type_ids[2] == 2) {
+            found_expected_triplet = true;
+        }
+        EXPECT_NE(triplet.item_type_ids[0], 3);
+        EXPECT_NE(triplet.item_type_ids[1], 3);
+        EXPECT_NE(triplet.item_type_ids[2], 3);
+    }
+    EXPECT_TRUE(found_expected_triplet);
+}
+
+TEST(RectangleTripletIncompatibility, RepeatedItemType)
+{
+    InstanceBuilder instance_builder;
+    instance_builder.set_objective(Objective::Feasibility);
+    instance_builder.add_bin_type(10, 10);
+    instance_builder.add_item_type(6, 6, true);
+    instance_builder.set_item_type_copies(0, 2);
+    instance_builder.add_item_type(6, 4, true);
+    Instance instance = instance_builder.build();
+
+    std::vector<std::pair<ItemTypeId, ItemPos>> selected_items = {{0, 2}, {1, 1}};
+    std::vector<IncompatibleTriplet> triplets = find_incompatible_triplets(instance, 0, selected_items);
+
+    ASSERT_EQ(triplets.size(), 1);
+    EXPECT_EQ(triplets[0].item_type_ids[0], 0);
+    EXPECT_EQ(triplets[0].item_type_ids[1], 0);
+    EXPECT_EQ(triplets[0].item_type_ids[2], 1);
+}


### PR DESCRIPTION
## Summary
- Before paying for the geometric feasibility subproblem, check every bin of the master candidate for a triplet of items provably unable to coexist (via closed-form guillotine-shape enumeration, see `item_subset_incompatibility.{hpp,cpp}`), and add it as a permanent resource cut, exactly like the existing dual-feasible-function pass.
- A bin selecting exactly 3 items is then already known geometrically feasible once that check passes, so its placement is constructed directly instead of running the general feasibility subproblem; minimal-infeasible-subset search also skips ever probing a subset of 3 items or fewer for the same reason.
- Adds per-phase timers (master, dual-feasible-functions, triplets, subproblem, minimal-infeasible-subsets, lifting), the iteration count, and per-termination-cause iteration counts (how many iterations stopped early due to a DFF cut, a triplet cut, or the feasibility subproblem finding an infeasible bin) to `BendersDecompositionOutput`'s `to_json`/`format`.
- A quadruplet-incompatibility version of the same idea was attempted but turned out unsound in general (the guillotine-shape argument is only exact when items exactly tile the bin, not when there is slack to spare - confirmed by both a hand-built counterexample and an independent brute-force search), so it was not kept.

## Test plan
- [x] Full rectangle test suite passes locally (143 tests)