### PR TITLE
irregular: bump shape dependency to fix inflate() segfault (#563)

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -38,7 +38,7 @@ set(SHAPE_BUILD_TEST OFF)
 FetchContent_Declare(
     shape
     GIT_REPOSITORY https://github.com/fontanf/shape.git
-    GIT_TAG 1e57508f8f9a194891e0343c84a1a255f62f0e40
+    GIT_TAG 8280d870a207f50063343c6eaecbb70e39845944
     #SOURCE_DIR "${PROJECT_SOURCE_DIR}/../shape/"
     EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(shape)


### PR DESCRIPTION
## Summary

- Bumps the `shape` dependency to [fontanf/shape@8280d87](https://github.com/fontanf/shape/commit/8280d870a207f50063343c6eaecbb70e39845944), which fixes `Shape::find_point_strictly_inside` returning a point outside the shape in some cases (a horizontal edge running along the ray, or a reflex vertex the ray happens to pass through, could sit between two genuine crossings without being one itself, so the midpoint the function returned could land exactly on that feature instead of in the shape's interior).
- That bug was the root cause of the segfault reported in #563: `inflate()` building the offset outline of an item shape with a corner-fillet arc calls `compute_union()` on the pieces, which needs to bridge a touching hole via a boolean `Difference`, whose result-face classification calls `find_point_strictly_inside()`. The bad probe point caused the only valid face to be silently dropped, and `inflate()` then dereferenced the resulting empty face list unchecked, segfaulting instead of raising an error.

Fixes #563.

## Test plan

- [x] Rebuilt `packingsolver_irregular` against the new `shape` commit and reran the exact crashing command from #563 (the attached `instance.json`, `item_item_minimum_spacing: 10`) — runs to completion instead of segfaulting.
- [x] `shape`'s own test suite (463 tests, including new regressions for this exact bug) passes against the bumped commit.