### PR TITLE
irregular: bump shape dependency to fix convex partition segfault (#558)

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -38,7 +38,7 @@ set(SHAPE_BUILD_TEST OFF)
 FetchContent_Declare(
     shape
     GIT_REPOSITORY https://github.com/fontanf/shape.git
-    GIT_TAG 8280d870a207f50063343c6eaecbb70e39845944
+    GIT_TAG 0414581090cf7a1cd626d0c94d4a4da02ae0243d
     #SOURCE_DIR "${PROJECT_SOURCE_DIR}/../shape/"
     EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(shape)


### PR DESCRIPTION
## Summary

- Bumps the `shape` dependency to [fontanf/shape@0414581](https://github.com/fontanf/shape/commit/0414581090cf7a1cd626d0c94d4a4da02ae0243d), which fixes `compute_convex_partition` emitting a degenerate, zero-area part when `trapezoidation()` collapses one side of a trapezoid to a point (two sweep events landing at exactly the same coordinate). `is_convex()` has no well-defined answer for such a part (a zero-length edge has no tangent direction) and correctly reports `false`, but nothing filtered it out before it could reach a caller.
- That was crashing `packingsolver_irregular` on real production data — test case 2 of 3 attached to #558: computing a no-fit polygon against such a degenerate part throws (`"orbiting_shape is not convex"`) instead of the solver treating it as a normal, if oddly-shaped, item.

This addresses test case 2 only. Test cases 1 and 3 in #558 hit a separate, unrelated issue (convex decomposition producing too many parts, a performance problem rather than a crash) still to be looked into — not closing #558 yet.

## Test plan

- [x] Rebuilt `packingsolver_irregular` against the new `shape` commit and reran the exact crashing command from #558's second test case (`AutoNestParam11.json`) — places all 80/80 items instead of throwing.
- [x] `shape`'s own test suite (465 tests, including new regressions for this exact bug using the real item shapes from #558) passes against the bumped commit.