### PR TITLE
irregular: cap eager periodic-packing precomputation by shape complexity

### DIFF
--- a/src/irregular/instance_builder.cpp
+++ b/src/irregular/instance_builder.cpp
@@ -997,6 +997,20 @@ Instance InstanceBuilder::build()
         // compute_periodic_blocks_for_item_type is later called on it.
         const ItemPos periodic_packings_copies_threshold = 16;
 
+        // Even above that copies threshold, a shape with too many vertices
+        // makes this precomputation itself prohibitively expensive: its
+        // cost is driven by the number of convex parts the shape decomposes
+        // into (each pairwise convex-convex NFP, and the final union over
+        // all of them, adds up), and a highly concave shape's part count
+        // grows with its vertex count. Benchmarked against real production
+        // data (fontanf/packingsolver#558): a self-NFP already took ~22s at
+        // 442 vertices (115 convex parts) and didn't finish in two minutes
+        // at 4068 vertices (1070 parts), against ~1s at 151 vertices (47
+        // parts); this cap sits just below where cost starts climbing
+        // steeply, trading a possibly-missed periodic packing for keeping
+        // instance building itself fast regardless of item complexity.
+        const ElementPos periodic_packings_maximum_number_of_vertices = 300;
+
         auto all_item_type_rotations = compute_item_type_rotations(instance_);
         const std::vector<std::vector<ItemTypeRotation>>& item_type_rotations
             = all_item_type_rotations[instance_.bin_type_id(0)];
@@ -1005,7 +1019,11 @@ Instance InstanceBuilder::build()
                 ++item_type_id) {
             ItemType& item_type = instance_.item_types_[item_type_id];
             if (!item_type.periodic_packings_computed) {
-                if (item_type.copies > periodic_packings_copies_threshold) {
+                ElementPos number_of_vertices = 0;
+                for (const ItemShape& item_shape: item_type.shapes)
+                    number_of_vertices += item_shape.shape_scaled.shape.elements.size();
+                if (item_type.copies > periodic_packings_copies_threshold
+                        && number_of_vertices <= periodic_packings_maximum_number_of_vertices) {
                     item_type.periodic_packings = compute_periodic_packings_for_item_type(
                             instance_, item_type_id, item_type_rotations[item_type_id]);
                 }


### PR DESCRIPTION
## Summary

- `InstanceBuilder::build()` already skipped eager periodic-packing precomputation for item types below a copies threshold, since a self-NFP can be expensive (close to quadratic in the shape's vertex count for highly concave shapes) — but the threshold only looked at copy count, not shape complexity. For a shape with many vertices, the cost is prohibitive regardless of copy count.
- Benchmarked against real production data (#558): a self-NFP already took ~22s at 442 vertices (115 convex parts) and hadn't finished in two minutes at 4068 vertices (1070 parts), against ~1s at 151 vertices (47 parts).
- Add a vertex-count cap alongside the existing copies threshold, sitting just below where cost starts climbing steeply: above it, periodic packing is skipped and the item type falls back to plain AABB-grid blocks, same as it already did below the copies threshold.

This fixes the hang in test cases 1 and 3 of #558 (both single- or few-item-type instances with several thousand vertices each).

A separate, unrelated issue remains in those same test cases: the regular (non-periodic) tree search's `BranchingScheme::children()` can itself take tens of seconds for a single node on a shape this complex, without checking the time limit mid-call. Not addressed here — will be a follow-up PR.

## Test plan

- [x] Reproduced the hang directly against the raw item shape from #558's test case 1 (`no_fit_polygon(shape, shape)`: 1070 convex parts, still running after 2 minutes).
- [x] Rebuilt `packingsolver_irregular` with the fix and reran the exact command from #558's test case 1 — instance building now completes instantly instead of hanging before any output.