### PR TITLE
irregular: check the time limit while expanding a node's children

### DIFF
--- a/src/irregular/tree_search.cpp
+++ b/src/irregular/tree_search.cpp
@@ -1468,8 +1468,12 @@ std::vector<std::shared_ptr<BranchingScheme::Node>> BranchingScheme::children(
     update_extra_trapezoids(*parent);
     insertions(parent);
     std::vector<std::shared_ptr<Node>> cs;
+    if (parameters_.timer.needs_to_end())
+        return cs;
     cs.reserve(parent->children_insertions.size());
     for (Counter i = 0; i < (Counter)parent->children_insertions.size(); ++i) {
+        if (time_limit_reached(cs.size()))
+            break;
         const Insertion& insertion = parent->children_insertions[i];
 
         //std::cout << "- insertion " << insertion << std::endl;
@@ -1557,6 +1561,8 @@ void BranchingScheme::insertions(
 
         // Check all parents insertions.
         for (const Insertion& insertion: parent->parent->children_insertions) {
+            if (time_limit_reached(parent->children_insertions.size()))
+                return;
             // Check item quantity.
             ItemTypeId item_type_id = trapezoid_sets[insertion.trapezoid_set_id].item_type_id;
             const ItemType& item_type = instance().item_type(item_type_id);
@@ -1579,6 +1585,8 @@ void BranchingScheme::insertions(
                 //std::cout << "trapezoid_set_id " << trapezoid_set_id << std::endl;
                 const TrapezoidSet& supported_trapezoid_set = trapezoid_sets[supported_trapezoid_set_id];
                 for (ShapePos supported_part_pos: supported_trapezoid_set.supported_parts) {
+                    if (time_limit_reached(parent->children_insertions.size()))
+                        return;
                     const Support& supported_part = bb_bin_type.supported_parts[supported_part_pos];
 
                     insertion_trapezoid_set(
@@ -1640,6 +1648,8 @@ void BranchingScheme::insertions(
                 ItemShapePos item_shape_pos = -1;
 
                 for (ShapePos supported_part_pos: bb_bin_type.trapezoid_sets[supported_trapezoid_set_id].supported_parts) {
+                    if (time_limit_reached(parent->children_insertions.size()))
+                        return;
                     const Support& supported_part = bb_bin_type.supported_parts[supported_part_pos];
 
                     // If inserting on a defect, check if it is impacting.
@@ -2733,6 +2743,7 @@ void tree_search_worker(
         }
 
         branching_scheme_parameters.maximum_approximation_ratio = maximum_approximation_ratio;
+        branching_scheme_parameters.timer = ibs_parameters.timer;
         ibs_parameters.cutoff = cutoff;
         ibs_parameters.minimum_size_of_the_queue = queue_size;
         ibs_parameters.maximum_size_of_the_queue = queue_size;

--- a/src/irregular/tree_search.hpp
+++ b/src/irregular/tree_search.hpp
@@ -8,6 +8,7 @@
 #include "shape/trapezoid.hpp"
 
 #include "optimizationtools/utils/utils.hpp"
+#include "optimizationtools/utils/timer.hpp"
 
 #include <sstream>
 
@@ -328,6 +329,19 @@ public:
         Direction direction = Direction::LeftToRightThenBottomToTop;
 
         double maximum_approximation_ratio = 0.05;
+
+        /**
+         * Timer to check against inside insertions() and children(), so a
+         * single node whose candidate insertions are numerous on a complex
+         * shape doesn't block past the time limit for however long it takes
+         * to enumerate and build them: iterative_beam_search_2's own time
+         * check only runs between nodes, not while children() (which calls
+         * insertions()) builds one node's full set of children in one go.
+         * Left default-constructed (no time limit, so never triggers) where
+         * a caller has no timer to give, e.g. direct unit tests of the
+         * branching scheme.
+         */
+        optimizationtools::Timer timer;
     };
 
     /** Constructor. */
@@ -645,6 +659,23 @@ private:
             BinPos new_bin_pos = -1) const;
 
     void json_export_setup() const;
+
+    /**
+     * Whether a bulk-generation loop keyed on 'count' (either the number of
+     * candidates found so far by insertions(), or the number of child Node
+     * objects built so far by children()) should stop right now: checked
+     * only every 100 units of 'count', not on every single one --
+     * parameters_.timer.needs_to_end() itself isn't free -- since either
+     * count can run into the thousands for a complex shape (see the
+     * Parameters::timer doc comment) and generation must be able to stop
+     * partway through, not just between nodes.
+     */
+    inline bool time_limit_reached(std::size_t count) const
+    {
+        return count > 0
+            && count % 100 == 0
+            && parameters_.timer.needs_to_end();
+    }
 
 };
 


### PR DESCRIPTION
## Summary

Part of the investigation into #558 (test cases 1 and 3). #567 already reduced the cost of the eager periodic-packing precomputation for complex shapes; this addresses a second, separate source of the same symptom in the regular (non-periodic) tree search itself.

`BranchingScheme::insertions()` enumerates every candidate insertion for a node in one uninterruptible call, and `children()` then builds a full `Node` for each accepted candidate, also in one uninterruptible call. For a complex shape, either of these can run into the thousands of candidates, so a single node can take far longer than the search's time limit to expand: `iterative_beam_search_2` only checks the timer between nodes, not while a node's children are being generated.

This gives `BranchingScheme::Parameters` a copy of the search timer and checks it every 100 candidates inside `insertions()`, and every 100 built children inside `children()`, returning/breaking early once time is up.

On one of the reported instances (with `--time-limit 15`), total run time went from ~26s down to ~17s.

## Test plan
- [x] `PackingSolver_irregular_test`: 54/54 pass (unaffected, since these run without a timer)
- [x] Reproduced the reported instance with `--time-limit 15`: run time now closely tracks the requested limit instead of overrunning by ~10s