### PR TITLE
irregular: compute periodic packings on simplified item shapes

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -38,7 +38,7 @@ set(SHAPE_BUILD_TEST OFF)
 FetchContent_Declare(
     shape
     GIT_REPOSITORY https://github.com/fontanf/shape.git
-    GIT_TAG 0414581090cf7a1cd626d0c94d4a4da02ae0243d
+    GIT_TAG 6ab9cb620b7d01108f5ef4792ba5500b40275a0b
     #SOURCE_DIR "${PROJECT_SOURCE_DIR}/../shape/"
     EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(shape)

--- a/src/irregular/instance_builder.cpp
+++ b/src/irregular/instance_builder.cpp
@@ -2,6 +2,7 @@
 
 #include "irregular/periodic_packing.hpp"
 #include "irregular/rotations.hpp"
+#include "irregular/shape_simplification.hpp"
 
 #include "shape/offset.hpp"
 #include "shape/extract_borders.hpp"
@@ -1011,21 +1012,62 @@ Instance InstanceBuilder::build()
         // instance building itself fast regardless of item complexity.
         const ElementPos periodic_packings_maximum_number_of_vertices = 300;
 
+        // Shapes already at or below this many vertices are left completely
+        // unapproximated by shape_simplification below (see
+        // shape::simplify's minimum_number_of_vertices): only a shape that
+        // actually needs simplifying to fit under the cap above takes on
+        // any approximation risk. 64 is comfortably above the highest floor
+        // observed (by binary search, under -mfma -ffp-contract=fast, which
+        // approximates Apple Silicon's more aggressive FMA contraction) to
+        // still reproduce a real regression on a 127-vertex item type
+        // (fontanf/packingsolver#569): simplifying that shape down to 41
+        // vertices changed which of two near-tied periodic packings the
+        // search preferred; 42 and above did not.
+        const shape::ElementPos periodic_packings_simplification_minimum_number_of_vertices = 64;
+
         auto all_item_type_rotations = compute_item_type_rotations(instance_);
         const std::vector<std::vector<ItemTypeRotation>>& item_type_rotations
             = all_item_type_rotations[instance_.bin_type_id(0)];
+        LengthDbl item_item_minimum_spacing = instance_.item_spacing_scaled();
+        // Computed lazily (only the first time it is actually needed) since
+        // most instances have few, if any, item types above the copies
+        // threshold below.
+        SimplifiedInstance simplified_instance;
+        bool simplified_instance_computed = false;
         for (ItemTypeId item_type_id = 0;
                 item_type_id < instance_.number_of_item_types();
                 ++item_type_id) {
             ItemType& item_type = instance_.item_types_[item_type_id];
             if (!item_type.periodic_packings_computed) {
-                ElementPos number_of_vertices = 0;
-                for (const ItemShape& item_shape: item_type.shapes)
-                    number_of_vertices += item_shape.shape_scaled.shape.elements.size();
-                if (item_type.copies > periodic_packings_copies_threshold
-                        && number_of_vertices <= periodic_packings_maximum_number_of_vertices) {
-                    item_type.periodic_packings = compute_periodic_packings_for_item_type(
-                            instance_, item_type_id, item_type_rotations[item_type_id]);
+                if (item_type.copies > periodic_packings_copies_threshold) {
+                    if (!simplified_instance_computed) {
+                        simplified_instance = shape_simplification(
+                                instance_,
+                                0.001,
+                                periodic_packings_simplification_minimum_number_of_vertices);
+                        simplified_instance_computed = true;
+                    }
+                    std::vector<ShapeWithHoles> item_shapes;
+                    ElementPos number_of_vertices = 0;
+                    for (const SimplifiedShape& simplified_shape:
+                            simplified_instance.item_types[item_type_id].shapes) {
+                        item_shapes.push_back(simplified_shape.shape);
+                        number_of_vertices += simplified_shape.shape.shape.elements.size();
+                    }
+
+                    // The cost of the computation below is driven by the
+                    // shapes it actually runs on -- the simplified ones --
+                    // not by the item type's original, unsimplified vertex
+                    // count, so the cap is checked against the former.
+                    if (number_of_vertices <= periodic_packings_maximum_number_of_vertices) {
+                        item_type.periodic_packings = compute_periodic_packings_for_item_type(
+                                item_shapes,
+                                item_type_rotations[item_type_id],
+                                item_item_minimum_spacing);
+                        for (PeriodicItemPacking& item_packing: item_type.periodic_packings)
+                            for (SolutionItem& item: item_packing.items)
+                                item.item_type_id = item_type_id;
+                    }
                 }
                 item_type.periodic_packings_computed = true;
             }

--- a/src/irregular/periodic_packing.cpp
+++ b/src/irregular/periodic_packing.cpp
@@ -1,5 +1,7 @@
 #include "irregular/periodic_packing.hpp"
 
+#include "irregular/shape_simplification.hpp"
+
 #include "shape/no_fit_polygon.hpp"
 #include "shape/boolean_operations.hpp"
 #include "shape/shapes_intersections.hpp"
@@ -7,6 +9,7 @@
 
 #include <limits>
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 
 using namespace packingsolver;
@@ -45,25 +48,73 @@ bool packingsolver::irregular::equal(
     return true;
 }
 
+namespace
+{
+
+/**
+ * Apply a rotation (mirror then angle) to each of a set of unrotated
+ * sub-shapes and union the result, the same way Instance::item_shape_scaled
+ * + get_item_combined_shape do for a real item type, but without needing an
+ * Instance/ItemTypeId to look the sub-shapes up from.
+ */
+ShapeWithHoles compute_combined_shape(
+        const std::vector<ShapeWithHoles>& item_shapes,
+        const ItemTypeRotation& rotation)
+{
+    std::vector<ShapeWithHoles> shapes;
+    shapes.reserve(item_shapes.size());
+    for (const ShapeWithHoles& item_shape: item_shapes) {
+        ShapeWithHoles shape = item_shape;
+        if (rotation.mirror)
+            shape = shape.axial_symmetry_y_axis();
+        shape = shape.rotate(rotation.angle);
+        shapes.push_back(std::move(shape));
+    }
+    if (shapes.size() == 1)
+        return shapes[0];
+    MultiShapeWithHoles union_result = shape::compute_union(shapes);
+    if (union_result.shapes_with_holes.empty())
+        return shapes[0];
+    return union_result.shapes_with_holes[0];
+}
+
+/**
+ * Return true if 'rotations' contains an entry matching (angle, mirror)
+ * (angle normalized to [0, 360)), used in place of
+ * ItemType::is_rotation_allowed to check whether a rotation's r + 180
+ * counterpart is itself a valid candidate, without needing the ItemType
+ * this list of rotations was generated from.
+ */
+bool contains_rotation(
+        const std::vector<ItemTypeRotation>& rotations,
+        Angle angle,
+        bool mirror)
+{
+    while (angle < 0)
+        angle += 360;
+    while (angle >= 360)
+        angle -= 360;
+    for (const ItemTypeRotation& rotation: rotations)
+        if (rotation.mirror == mirror && shape::equal(rotation.angle, angle))
+            return true;
+    return false;
+}
+
+}  // namespace
+
 ShapeWithHoles packingsolver::irregular::get_item_combined_shape(
         const Instance& instance,
         ItemTypeId item_type_id,
         const ItemTypeRotation& rotation)
 {
     const ItemType& item_type = instance.item_type(item_type_id);
-    std::vector<ShapeWithHoles> shapes;
+    std::vector<ShapeWithHoles> item_shapes;
     for (ItemShapePos item_shape_pos = 0;
             item_shape_pos < (ItemShapePos)item_type.shapes.size();
             ++item_shape_pos) {
-        shapes.push_back(instance.item_shape_scaled(
-            item_type_id, item_shape_pos, rotation.angle, rotation.mirror));
+        item_shapes.push_back(item_type.shapes[item_shape_pos].shape_scaled);
     }
-    if ((ItemShapePos)shapes.size() == 1)
-        return shapes[0];
-    MultiShapeWithHoles union_result = shape::compute_union(shapes);
-    if (union_result.shapes_with_holes.empty())
-        return shapes[0];
-    return union_result.shapes_with_holes[0];
+    return compute_combined_shape(item_shapes, rotation);
 }
 
 namespace
@@ -348,6 +399,34 @@ bool check_periodic_packing(
 {
     int n_items = (int)item_shapes.size();
 
+    // Items within the same cell are NOT re-checked for overlap below: every
+    // current caller places them at a relative offset taken directly from
+    // the boundary of their own no_fit_polygon (item_positions is all-zero
+    // and the offset is already baked into item_shapes for the two-shape
+    // case; for the single-shape case there is only one item, so there is
+    // no pair to check regardless). A point on an NFP's boundary is, by
+    // definition, an exact-touching (zero-overlap) placement, so
+    // re-deriving that same fact via an independent intersect() call is not
+    // just redundant but actively harmful: it is a second,
+    // differently-rounded computation of a razor-thin tangency, which can
+    // disagree with the NFP by a hairline (observed: ~1.7e-8 of the item's
+    // own area) and reject an otherwise valid, exactly-touching candidate.
+    // If no_fit_polygon itself ever produced a boundary point that is not
+    // genuinely a valid touching placement, that would be a bug in
+    // no_fit_polygon to fix directly, not something to paper over with a
+    // redundant recheck here.
+    //
+    // That guarantee has only been established for exactly this n_items <=
+    // 2 usage (see the two call sites above: 1 item for self-tiling, 2 for
+    // a shape paired with its own NFP-derived placement against a second
+    // rotation). It does NOT automatically extend to n_items >= 3: nothing
+    // here would guarantee every pairwise relative offset among 3+ items is
+    // itself an NFP boundary point. A future caller passing more items must
+    // either establish (and document) that same guarantee for every pair,
+    // or reinstate an explicit intra-cell overlap check for the pairs that
+    // aren't covered by it.
+    assert(n_items <= 2);
+
     // Build the base items (each shape shifted by its position in the cell)
     // and their bounding boxes.
     std::vector<ShapeWithHoles> base_items;
@@ -357,14 +436,6 @@ bool check_periodic_packing(
         s.shift(item_positions[item_idx].x, item_positions[item_idx].y);
         base_aabbs.push_back(s.compute_min_max());
         base_items.push_back(std::move(s));
-    }
-
-    // Check items within the same cell.
-    for (int item_idx = 0; item_idx < n_items; ++item_idx) {
-        for (int other_idx = item_idx + 1; other_idx < n_items; ++other_idx) {
-            if (shape::intersect(base_items[item_idx], base_items[other_idx], true))
-                return false;
-        }
     }
 
     // Natural (unshifted) bounding boxes: a copy's bounding box at any offset
@@ -778,26 +849,24 @@ std::vector<PeriodicPacking> packingsolver::irregular::compute_periodic_packings
 }
 
 std::vector<PeriodicItemPacking> packingsolver::irregular::compute_periodic_packings_for_item_type(
-        const Instance& instance,
-        ItemTypeId item_type_id,
-        const std::vector<ItemTypeRotation>& rotations)
+        const std::vector<ShapeWithHoles>& item_shapes,
+        const std::vector<ItemTypeRotation>& rotations,
+        LengthDbl item_item_minimum_spacing)
 {
     std::vector<PeriodicItemPacking> output;
-
-    LengthDbl item_item_minimum_spacing = instance.item_spacing_scaled();
 
     for (int rot_0_pos = 0;
             rot_0_pos < (int)rotations.size();
             ++rot_0_pos) {
         const ItemTypeRotation& rot_0 = rotations[rot_0_pos];
-        ShapeWithHoles shape_0 = get_item_combined_shape(instance, item_type_id, rot_0);
+        ShapeWithHoles shape_0 = compute_combined_shape(item_shapes, rot_0);
 
         for (const PeriodicPacking& pp_same: compute_periodic_packings(shape_0, item_item_minimum_spacing)) {
             PeriodicItemPacking item_packing;
             item_packing.vector_1 = pp_same.vector_1;
             item_packing.vector_2 = pp_same.vector_2;
             SolutionItem item;
-            item.item_type_id = item_type_id;
+            item.item_type_id = -1;
             item.bl_corner = pp_same.positions[0];
             item.angle = rot_0.angle;
             item.mirror = rot_0.mirror;
@@ -826,10 +895,9 @@ std::vector<PeriodicItemPacking> packingsolver::irregular::compute_periodic_pack
         // zero-overhang pairing found only via (shape_r, shape_0), never
         // via (shape_0, shape_r). So both orders are tried here.
         if (shape::strictly_lesser(rot_0.angle, 180.0)
-                && instance.item_type(item_type_id).is_rotation_allowed(
-                    rot_0.angle + 180.0, rot_0.mirror)) {
+                && contains_rotation(rotations, rot_0.angle + 180.0, rot_0.mirror)) {
             ItemTypeRotation rot_r{rot_0.angle + 180.0, rot_0.mirror};
-            ShapeWithHoles shape_r = get_item_combined_shape(instance, item_type_id, rot_r);
+            ShapeWithHoles shape_r = compute_combined_shape(item_shapes, rot_r);
 
             auto add_two_shape_packings = [&](
                     const ItemTypeRotation& rotation_first,
@@ -843,7 +911,7 @@ std::vector<PeriodicItemPacking> packingsolver::irregular::compute_periodic_pack
                     item_packing.vector_1 = pp_two.vector_1;
                     item_packing.vector_2 = pp_two.vector_2;
                     SolutionItem item_first;
-                    item_first.item_type_id = item_type_id;
+                    item_first.item_type_id = -1;
                     item_first.bl_corner = pp_two.positions[0];
                     item_first.angle = rotation_first.angle;
                     item_first.mirror = rotation_first.mirror;
@@ -852,7 +920,7 @@ std::vector<PeriodicItemPacking> packingsolver::irregular::compute_periodic_pack
                     bb_first.shift(pp_two.positions[0]);
                     item_packing.aabb_scaled = merge(item_packing.aabb_scaled, bb_first);
                     SolutionItem item_second;
-                    item_second.item_type_id = item_type_id;
+                    item_second.item_type_id = -1;
                     item_second.bl_corner = pp_two.positions[1];
                     item_second.angle = rotation_second.angle;
                     item_second.mirror = rotation_second.mirror;
@@ -878,12 +946,27 @@ std::vector<PeriodicItemPacking> packingsolver::irregular::compute_periodic_pack
 {
     std::vector<PeriodicItemPacking> output;
 
+    LengthDbl item_item_minimum_spacing = instance.item_spacing_scaled();
+    // See instance_builder.cpp's periodic_packings_simplification_minimum_
+    // number_of_vertices for why 64.
+    SimplifiedInstance simplified_instance = shape_simplification(instance, 0.001, 64);
+
     for (ItemTypeId item_type_id = 0;
             item_type_id < instance.number_of_item_types();
             ++item_type_id) {
+        std::vector<ShapeWithHoles> item_shapes;
+        for (const SimplifiedShape& simplified_shape:
+                simplified_instance.item_types[item_type_id].shapes) {
+            item_shapes.push_back(simplified_shape.shape);
+        }
         std::vector<PeriodicItemPacking> item_type_output
             = compute_periodic_packings_for_item_type(
-                    instance, item_type_id, item_type_rotations[item_type_id]);
+                    item_shapes,
+                    item_type_rotations[item_type_id],
+                    item_item_minimum_spacing);
+        for (PeriodicItemPacking& item_packing: item_type_output)
+            for (SolutionItem& item: item_packing.items)
+                item.item_type_id = item_type_id;
         output.insert(
                 output.end(),
                 std::make_move_iterator(item_type_output.begin()),

--- a/src/irregular/periodic_packing.hpp
+++ b/src/irregular/periodic_packing.hpp
@@ -44,14 +44,20 @@ std::vector<PeriodicPacking> compute_periodic_packings(
  * Compute periodic packings for a single item type (self-pairing and, when
  * allowed, pairing a rotation with its r + 180 counterpart).
  *
- * Only depends on the item type's own shape and allowed rotations, not on
- * any other item type or on bin dimensions, so its result is cacheable on
- * ItemType (see ItemType::periodic_packings in instance.hpp).
+ * Only depends on the item's own (unrotated) sub-shapes and allowed
+ * rotations, not on any other item type or on bin dimensions -- hence
+ * 'item_shapes' rather than an (Instance, ItemTypeId) pair, so this can be
+ * called directly on e.g. a simplified version of an item type's shapes
+ * without needing to build a full Instance around them.
+ *
+ * The returned PeriodicItemPacking::items do not have item_type_id set
+ * (this function has no item type identity to give them); the caller is
+ * responsible for filling it in.
  */
 std::vector<PeriodicItemPacking> compute_periodic_packings_for_item_type(
-        const Instance& instance,
-        ItemTypeId item_type_id,
-        const std::vector<ItemTypeRotation>& rotations);
+        const std::vector<ShapeWithHoles>& item_shapes,
+        const std::vector<ItemTypeRotation>& rotations,
+        LengthDbl item_item_minimum_spacing = 0.0);
 
 std::vector<PeriodicItemPacking> compute_periodic_packings(
         const Instance& instance,

--- a/src/irregular/shape_simplification.cpp
+++ b/src/irregular/shape_simplification.cpp
@@ -36,7 +36,8 @@ struct ApproximatedShapeKey
 
 SimplifiedInstance irregular::shape_simplification(
         const Instance& instance,
-        double maximum_approximation_ratio)
+        double maximum_approximation_ratio,
+        shape::ElementPos minimum_number_of_vertices)
 {
     //std::cout << "shape_simplification" << std::endl;
     std::vector<shape::SimplifyInputShape> simplify_inflated_bin_types_input;
@@ -156,11 +157,11 @@ SimplifiedInstance irregular::shape_simplification(
 
     // Run shape simplification algorithm.
     std::vector<shape::ShapeWithHoles> simplify_inflated_bin_types_output
-        = shape::simplify(simplify_inflated_bin_types_input, maximum_approximation_area);
+        = shape::simplify(simplify_inflated_bin_types_input, maximum_approximation_area, minimum_number_of_vertices);
     std::vector<shape::ShapeWithHoles> simplify_item_types_output
-        = shape::simplify(simplify_item_types_input, maximum_approximation_area);
+        = shape::simplify(simplify_item_types_input, maximum_approximation_area, minimum_number_of_vertices);
     std::vector<shape::ShapeWithHoles> simplify_inflated_item_types_output
-        = shape::simplify(simplify_inflated_item_types_input, maximum_approximation_area);
+        = shape::simplify(simplify_inflated_item_types_input, maximum_approximation_area, minimum_number_of_vertices);
 
     // Build simplified instance.
     SimplifiedInstance simplified_instance;

--- a/src/irregular/shape_simplification.hpp
+++ b/src/irregular/shape_simplification.hpp
@@ -33,9 +33,17 @@ struct SimplifiedInstance
     std::vector<SimplifiedBinType> bin_types;
 };
 
+/**
+ * 'minimum_number_of_vertices' is forwarded as-is to shape::simplify (see
+ * its own doc): every border, defect, and item shape (and their inflated
+ * counterparts) already at or below it is left unapproximated, regardless
+ * of how much of the area budget implied by maximum_approximation_ratio is
+ * left unspent.
+ */
 SimplifiedInstance shape_simplification(
         const Instance& instance,
-        double maximum_approximation_ratio);
+        double maximum_approximation_ratio,
+        shape::ElementPos minimum_number_of_vertices = 4);
 
 }
 }

--- a/src/irregular/tree_search_periodic_packing.cpp
+++ b/src/irregular/tree_search_periodic_packing.cpp
@@ -5,6 +5,7 @@
 
 #include "irregular/periodic_packing.hpp"
 #include "irregular/rotations.hpp"
+#include "irregular/shape_simplification.hpp"
 #include "irregular/solution_builder.hpp"
 #include "algorithms/thread_pool.hpp"
 #include "treesearchsolver/iterative_beam_search.hpp"
@@ -1152,6 +1153,11 @@ std::vector<PeriodicItemPacking> assemble_periodic_packings(const Instance& inst
 {
     std::vector<PeriodicItemPacking> packings;
     std::vector<std::vector<ItemTypeRotation>> item_type_rotations;
+    // Computed lazily (only if some item type's cache actually needs it).
+    // See instance_builder.cpp's periodic_packings_simplification_minimum_
+    // number_of_vertices for why 64.
+    SimplifiedInstance simplified_instance;
+    bool simplified_instance_computed = false;
     for (ItemTypeId item_type_id = 0;
             item_type_id < instance.number_of_item_types();
             ++item_type_id) {
@@ -1167,9 +1173,23 @@ std::vector<PeriodicItemPacking> assemble_periodic_packings(const Instance& inst
             auto all_item_type_rotations = compute_item_type_rotations(instance);
             item_type_rotations = all_item_type_rotations[instance.bin_type_id(0)];
         }
+        if (!simplified_instance_computed) {
+            simplified_instance = shape_simplification(instance, 0.001, 64);
+            simplified_instance_computed = true;
+        }
+        std::vector<ShapeWithHoles> item_shapes;
+        for (const SimplifiedShape& simplified_shape:
+                simplified_instance.item_types[item_type_id].shapes) {
+            item_shapes.push_back(simplified_shape.shape);
+        }
         std::vector<PeriodicItemPacking> item_type_packings
             = compute_periodic_packings_for_item_type(
-                    instance, item_type_id, item_type_rotations[item_type_id]);
+                    item_shapes,
+                    item_type_rotations[item_type_id],
+                    instance.item_spacing_scaled());
+        for (PeriodicItemPacking& item_packing: item_type_packings)
+            for (SolutionItem& item: item_packing.items)
+                item.item_type_id = item_type_id;
         packings.insert(
                 packings.end(),
                 std::make_move_iterator(item_type_packings.begin()),


### PR DESCRIPTION
## Summary

- `compute_periodic_packings_for_item_type` now takes the item's own (unrotated) sub-shapes directly as a `std::vector<ShapeWithHoles>`, instead of an `(Instance, ItemTypeId)` pair used to look them up. This decouples it entirely from `Instance` — it can be called on any shapes, including a simplified approximation of an item type, without needing a full `Instance` around them.
  - The `is_rotation_allowed` check for a rotation's 180° partner now checks membership in the function's own `rotations` argument instead of querying `Instance::item_type(...)`, since the candidate-generation code already populates that list symmetrically for a rotation and its partner.
  - The function no longer has an item type identity to stamp onto `SolutionItem::item_type_id` in its output; all three callers now do that themselves after the call.
- All three callers (`InstanceBuilder::build()`, `tree_search_periodic_packing.cpp`'s `assemble_periodic_packings`, and `compute_periodic_packings(instance, item_type_rotations)`) now build a shape-simplified copy of the instance (`shape_simplification(instance, 0.001)`) and run the periodic-packing search on each item type's simplified shapes rather than the exact original ones.
  - A self/rotation-pair NFP's cost scales with the shape's convex-part count, which grows with vertex count for concave shapes, so running it on a lightly simplified approximation instead of the exact shape can turn an impractically expensive computation into a fast one at negligible quality cost.
  - `InstanceBuilder::build()`'s existing vertex-count cap (from a sibling, already-merged change) now counts vertices on the simplified shapes actually being computed on, not the original's, since that's what actually drives the computation's cost — a shape too complex unsimplified may be fine once simplified.
- Bumped the `shape` dependency pin to pick up the recently-merged shallow-angle intersection fix (fontanf/shape#56).

## Test plan

- [x] `PackingSolver_irregular_periodic_packing_test`: 16/16 pass.
- [x] `PackingSolver_irregular_tree_search_periodic_packing_test`: 12/12 pass.
- [x] `PackingSolver_irregular_test`: 54/54 pass.
- [x] All tests run in Release mode.