### PR TITLE
algorithms: let the feasibility callback return cuts alongside its verdict

### DIFF
--- a/include/packingsolver/algorithms/common.hpp
+++ b/include/packingsolver/algorithms/common.hpp
@@ -322,6 +322,29 @@ struct Resource
 };
 
 /**
+ * Result of a domain's 'FeasibilityCallback' invocation (see each domain's
+ * own 'instance.hpp' for the callback itself).
+ *
+ * 'resources' lets the callback hand back its own reason for an infeasible
+ * verdict, expressed as one or more combinatorial cuts (see 'Resource'),
+ * instead of only a bare 'true'/'false' - so that whichever algorithm owns
+ * the callback (e.g. a caller re-solving the same instance repeatedly, one
+ * cut at a time) can accumulate and reuse them itself, rather than
+ * re-deriving the same infeasibility from scratch on a later call. Empty
+ * when 'feasible' is 'true', or when the callback has no cut to offer for
+ * an infeasible verdict (a plain 'false', same as before this field
+ * existed, is still a completely valid result).
+ */
+struct FeasibilityCallbackResult
+{
+    /** 'false' marks the solution the callback was given as infeasible. */
+    bool feasible = true;
+
+    /** Cuts the callback derived while proving 'feasible == false', if any. */
+    std::vector<Resource> resources;
+};
+
+/**
  * One of a bin type's resources a given item type has a non-zero
  * consumption for, together with the position of that item type's own
  * entry in the resource's own (sparse) 'Resource::item_consumptions' list

--- a/include/packingsolver/box/instance.hpp
+++ b/include/packingsolver/box/instance.hpp
@@ -267,9 +267,9 @@ class Solution;
  * User-provided feasibility callback.
  *
  * Called on a fully-built Solution in addition to the built-in feasibility
- * checks; returning 'false' marks the solution as infeasible.
+ * checks; see 'FeasibilityCallbackResult' for what it may return.
  */
-using FeasibilityCallback = std::function<bool(const Solution&)>;
+using FeasibilityCallback = std::function<FeasibilityCallbackResult(const Solution&)>;
 
 /**
  * Instance class for a problem of type "box".
@@ -444,7 +444,7 @@ private:
     Parameters parameters_;
 
     /** User-provided feasibility callback. */
-    FeasibilityCallback feasibility_callback_ = [](const Solution&) { return true; };
+    FeasibilityCallback feasibility_callback_ = [](const Solution&) { return FeasibilityCallbackResult(); };
 
     /** Bin types. */
     std::vector<BinType> bin_types_;

--- a/include/packingsolver/box/solution.hpp
+++ b/include/packingsolver/box/solution.hpp
@@ -109,6 +109,9 @@ public:
     /** Feasibility according to the user feasibility callback. */
     inline bool callback_feasible() const { return callback_feasible_; }
 
+    /** Cuts the feasibility callback returned, if any - see 'FeasibilityCallbackResult'. */
+    inline const std::vector<Resource>& callback_resources() const { return callback_resources_; }
+
     /** Overall feasibility. */
     inline bool feasible() const { return feasible_; }
 
@@ -272,6 +275,9 @@ private:
 
     /** Feasibility according to the user feasibility callback. */
     bool callback_feasible_ = true;
+
+    /** Cuts the feasibility callback returned, if any - see 'FeasibilityCallbackResult'. */
+    std::vector<Resource> callback_resources_;
 
     /** Overall feasibility. */
     bool feasible_ = true;

--- a/include/packingsolver/boxstacks/instance.hpp
+++ b/include/packingsolver/boxstacks/instance.hpp
@@ -344,9 +344,9 @@ class Solution;
  * User-provided feasibility callback.
  *
  * Called on a fully-built Solution in addition to the built-in feasibility
- * checks; returning 'false' marks the solution as infeasible.
+ * checks; see 'FeasibilityCallbackResult' for what it may return.
  */
-using FeasibilityCallback = std::function<bool(const Solution&)>;
+using FeasibilityCallback = std::function<FeasibilityCallbackResult(const Solution&)>;
 
 /**
  * Instance class for a problem of type "boxstacks".
@@ -496,7 +496,7 @@ private:
     Parameters parameters_;
 
     /** User-provided feasibility callback. */
-    FeasibilityCallback feasibility_callback_ = [](const Solution&) { return true; };
+    FeasibilityCallback feasibility_callback_ = [](const Solution&) { return FeasibilityCallbackResult(); };
 
     /** Bin types. */
     std::vector<BinType> bin_types_;

--- a/include/packingsolver/boxstacks/solution.hpp
+++ b/include/packingsolver/boxstacks/solution.hpp
@@ -152,6 +152,9 @@ public:
     /** Feasibility according to the user feasibility callback. */
     inline bool callback_feasible() const { return callback_feasible_; }
 
+    /** Cuts the feasibility callback returned, if any - see 'FeasibilityCallbackResult'. */
+    inline const std::vector<Resource>& callback_resources() const { return callback_resources_; }
+
     /*
      * Getters: bins
      */
@@ -344,6 +347,9 @@ private:
 
     /** Feasibility according to the user feasibility callback. */
     bool callback_feasible_ = true;
+
+    /** Cuts the feasibility callback returned, if any - see 'FeasibilityCallbackResult'. */
+    std::vector<Resource> callback_resources_;
 
     /** Overall feasibility. */
     bool feasible_ = true;

--- a/include/packingsolver/irregular/instance.hpp
+++ b/include/packingsolver/irregular/instance.hpp
@@ -383,9 +383,9 @@ class Solution;
  * User-provided feasibility callback.
  *
  * Called on a fully-built Solution in addition to the built-in feasibility
- * checks; returning 'false' marks the solution as infeasible.
+ * checks; see 'FeasibilityCallbackResult' for what it may return.
  */
-using FeasibilityCallback = std::function<bool(const Solution&)>;
+using FeasibilityCallback = std::function<FeasibilityCallbackResult(const Solution&)>;
 
 /**
  * Instance class for a problem of type "irregular".
@@ -591,7 +591,7 @@ private:
     Parameters parameters_;
 
     /** User-provided feasibility callback. */
-    FeasibilityCallback feasibility_callback_ = [](const Solution&) { return true; };
+    FeasibilityCallback feasibility_callback_ = [](const Solution&) { return FeasibilityCallbackResult(); };
 
     /** Bin types. */
     std::vector<BinType> bin_types_;

--- a/include/packingsolver/irregular/solution.hpp
+++ b/include/packingsolver/irregular/solution.hpp
@@ -96,6 +96,9 @@ public:
     /** Feasibility according to the user feasibility callback. */
     inline bool callback_feasible() const { return callback_feasible_; }
 
+    /** Cuts the feasibility callback returned, if any - see 'FeasibilityCallbackResult'. */
+    inline const std::vector<Resource>& callback_resources() const { return callback_resources_; }
+
     /** Overall feasibility. */
     inline bool feasible() const { return feasible_; }
 
@@ -262,6 +265,9 @@ private:
 
     /** Feasibility according to the user feasibility callback. */
     bool callback_feasible_ = true;
+
+    /** Cuts the feasibility callback returned, if any - see 'FeasibilityCallbackResult'. */
+    std::vector<Resource> callback_resources_;
 
     /** Overall feasibility. */
     bool feasible_ = true;

--- a/include/packingsolver/onedimensional/instance.hpp
+++ b/include/packingsolver/onedimensional/instance.hpp
@@ -208,9 +208,9 @@ class Solution;
  * User-provided feasibility callback.
  *
  * Called on a fully-built Solution in addition to the built-in feasibility
- * checks; returning 'false' marks the solution as infeasible.
+ * checks; see 'FeasibilityCallbackResult' for what it may return.
  */
-using FeasibilityCallback = std::function<bool(const Solution&)>;
+using FeasibilityCallback = std::function<FeasibilityCallbackResult(const Solution&)>;
 
 /**
  * Instance class for a problem of type "onedimensional".
@@ -356,7 +356,7 @@ private:
     Parameters parameters_;
 
     /** User-provided feasibility callback. */
-    FeasibilityCallback feasibility_callback_ = [](const Solution&) { return true; };
+    FeasibilityCallback feasibility_callback_ = [](const Solution&) { return FeasibilityCallbackResult(); };
 
     /** Bin types. */
     std::vector<BinType> bin_types_;

--- a/include/packingsolver/onedimensional/solution.hpp
+++ b/include/packingsolver/onedimensional/solution.hpp
@@ -112,6 +112,9 @@ public:
     /** Feasibility according to the user feasibility callback. */
     inline bool callback_feasible() const { return callback_feasible_; }
 
+    /** Cuts the feasibility callback returned, if any - see 'FeasibilityCallbackResult'. */
+    inline const std::vector<Resource>& callback_resources() const { return callback_resources_; }
+
     /** Return 'true' iff the solution satisfies the bin length capacity constraint. */
     inline bool capacity_feasible() const { return capacity_feasible_; }
 
@@ -293,6 +296,9 @@ private:
 
     /** Feasibility according to the user feasibility callback. */
     bool callback_feasible_ = true;
+
+    /** Cuts the feasibility callback returned, if any - see 'FeasibilityCallbackResult'. */
+    std::vector<Resource> callback_resources_;
 
     /** 'true' iff the solution is feasible regarding the packing constraints. */
     bool feasible_ = true;

--- a/include/packingsolver/rectangle/instance.hpp
+++ b/include/packingsolver/rectangle/instance.hpp
@@ -325,9 +325,9 @@ class Solution;
  * User-provided feasibility callback.
  *
  * Called on a fully-built Solution in addition to the built-in feasibility
- * checks; returning 'false' marks the solution as infeasible.
+ * checks; see 'FeasibilityCallbackResult' for what it may return.
  */
-using FeasibilityCallback = std::function<bool(const Solution&)>;
+using FeasibilityCallback = std::function<FeasibilityCallbackResult(const Solution&)>;
 
 /**
  * Instance class for a problem of type "rectangle".
@@ -536,7 +536,7 @@ private:
     Parameters parameters_;
 
     /** User-provided feasibility callback. */
-    FeasibilityCallback feasibility_callback_ = [](const Solution&) { return true; };
+    FeasibilityCallback feasibility_callback_ = [](const Solution&) { return FeasibilityCallbackResult(); };
 
     /** Bin types. */
     std::vector<BinType> bin_types_;

--- a/include/packingsolver/rectangle/solution.hpp
+++ b/include/packingsolver/rectangle/solution.hpp
@@ -111,6 +111,9 @@ public:
     /** Feasibility according to the user feasibility callback. */
     inline bool callback_feasible() const { return callback_feasible_; }
 
+    /** Cuts the feasibility callback returned, if any - see 'FeasibilityCallbackResult'. */
+    inline const std::vector<Resource>& callback_resources() const { return callback_resources_; }
+
     /** Overall feasibility. */
     inline bool feasible() const { return feasible_; }
 
@@ -259,6 +262,9 @@ private:
 
     /** Feasibility according to the user feasibility callback. */
     bool callback_feasible_ = true;
+
+    /** Cuts the feasibility callback returned, if any - see 'FeasibilityCallbackResult'. */
+    std::vector<Resource> callback_resources_;
 
     /** Overall feasibility. */
     bool feasible_ = true;

--- a/include/packingsolver/rectangleguillotine/instance.hpp
+++ b/include/packingsolver/rectangleguillotine/instance.hpp
@@ -362,9 +362,9 @@ class Solution;
  * User-provided feasibility callback.
  *
  * Called on a fully-built Solution in addition to the built-in feasibility
- * checks; returning 'false' marks the solution as infeasible.
+ * checks; see 'FeasibilityCallbackResult' for what it may return.
  */
-using FeasibilityCallback = std::function<bool(const Solution&)>;
+using FeasibilityCallback = std::function<FeasibilityCallbackResult(const Solution&)>;
 
 /**
  * Instance class for a problem of type "rectangleguillotine".
@@ -591,7 +591,7 @@ private:
     Parameters parameters_;
 
     /** User-provided feasibility callback. */
-    FeasibilityCallback feasibility_callback_ = [](const Solution&) { return true; };
+    FeasibilityCallback feasibility_callback_ = [](const Solution&) { return FeasibilityCallbackResult(); };
 
     /** Bin types. */
     std::vector<BinType> bin_types_;

--- a/include/packingsolver/rectangleguillotine/solution.hpp
+++ b/include/packingsolver/rectangleguillotine/solution.hpp
@@ -161,6 +161,9 @@ public:
 
     bool callback_feasible() const { return callback_feasible_; }
 
+    /** Cuts the feasibility callback returned, if any - see 'FeasibilityCallbackResult'. */
+    const std::vector<Resource>& callback_resources() const { return callback_resources_; }
+
     bool feasible() const { return feasible_; }
 
     /*
@@ -337,6 +340,9 @@ private:
 
     /** Feasibility according to the user feasibility callback. */
     bool callback_feasible_ = true;
+
+    /** Cuts the feasibility callback returned, if any - see 'FeasibilityCallbackResult'. */
+    std::vector<Resource> callback_resources_;
 
     /** Overall feasibility. */
     bool feasible_ = true;

--- a/src/box/solution.cpp
+++ b/src/box/solution.cpp
@@ -104,7 +104,9 @@ void Solution::update_indicators(
     }
 
     // Feasibility callback.
-    callback_feasible_ = instance().feasibility_callback()(*this);
+    FeasibilityCallbackResult callback_result = instance().feasibility_callback()(*this);
+    callback_feasible_ = callback_result.feasible;
+    callback_resources_ = std::move(callback_result.resources);
     feasible_ = item_copies_feasible_
         && callback_feasible_
         && resource_feasible_

--- a/src/boxstacks/solution.cpp
+++ b/src/boxstacks/solution.cpp
@@ -105,7 +105,9 @@ void Solution::update_indicators(
     }
 
     // Feasibility callback.
-    callback_feasible_ = instance().feasibility_callback()(*this);
+    FeasibilityCallbackResult callback_result = instance().feasibility_callback()(*this);
+    callback_feasible_ = callback_result.feasible;
+    callback_resources_ = std::move(callback_result.resources);
 
     // Aggregate feasibility, recomputed (not accumulated) on every call since
     // the feasibility callback's result is not required to be monotonic as

--- a/src/irregular/solution.cpp
+++ b/src/irregular/solution.cpp
@@ -149,7 +149,9 @@ void Solution::update_indicators(
     }
 
     // Feasibility callback.
-    callback_feasible_ = instance().feasibility_callback()(*this);
+    FeasibilityCallbackResult callback_result = instance().feasibility_callback()(*this);
+    callback_feasible_ = callback_result.feasible;
+    callback_resources_ = std::move(callback_result.resources);
     feasible_ = item_copies_feasible_
         && callback_feasible_
         && resource_feasible_

--- a/src/onedimensional/solution.cpp
+++ b/src/onedimensional/solution.cpp
@@ -160,7 +160,9 @@ void Solution::update_indicators(
     }
 
     // Feasibility callback.
-    callback_feasible_ = instance().feasibility_callback()(*this);
+    FeasibilityCallbackResult callback_result = instance().feasibility_callback()(*this);
+    callback_feasible_ = callback_result.feasible;
+    callback_resources_ = std::move(callback_result.resources);
     feasible_ = capacity_feasible_
         && weight_feasible_
         && stackability_feasible_

--- a/src/rectangle/solution.cpp
+++ b/src/rectangle/solution.cpp
@@ -125,7 +125,9 @@ void Solution::update_indicators(
     }
 
     // Feasibility callback.
-    callback_feasible_ = instance().feasibility_callback()(*this);
+    FeasibilityCallbackResult callback_result = instance().feasibility_callback()(*this);
+    callback_feasible_ = callback_result.feasible;
+    callback_resources_ = std::move(callback_result.resources);
     feasible_ = item_copies_feasible_
         && callback_feasible_
         && resource_feasible_

--- a/src/rectangleguillotine/solution.cpp
+++ b/src/rectangleguillotine/solution.cpp
@@ -452,7 +452,9 @@ void Solution::update_indicators(
     }
 
     // Feasibility callback.
-    callback_feasible_ = instance().feasibility_callback()(*this);
+    FeasibilityCallbackResult callback_result = instance().feasibility_callback()(*this);
+    callback_feasible_ = callback_result.feasible;
+    callback_resources_ = std::move(callback_result.resources);
 
     // Aggregate feasibility flags into the overall feasibility indicator.
     // Recomputed (not accumulated) on every call since the feasibility


### PR DESCRIPTION
## Summary
- Extends `FeasibilityCallback` (currently unused everywhere - defaults to `[](const Solution&){ return true; }` in all six problem types) to return a new `FeasibilityCallbackResult` instead of a plain `bool`.
- `FeasibilityCallbackResult` carries `feasible` (as before) plus `resources`: one or more `Resource` cuts the callback derived while proving an infeasible verdict, if any.
- This lets whichever algorithm owns the callback accumulate and reuse those cuts itself, instead of only learning a bare true/false each call - a building block for solving the rectangle Benders decomposition master problem incrementally (a persistent tree search across iterations) instead of rebuilding it from scratch every iteration. That part is a separate, larger follow-up; this PR is just the signature/plumbing change, with no behavior change.
- Added a `Solution::callback_resources()` getter in all six domains, mirroring the existing `callback_feasible()` getter, populated from the callback result but not consumed anywhere yet.

## Test plan
- [x] Full debug build (`build_debug_claude`, all targets across all 6 domains) compiles cleanly.
- [x] All existing test suites pass under `build_claude` (Release): rectangle (140), rectangleguillotine (285), irregular (54), box (12), boxstacks (7), onedimensional (37).
- [x] Confirmed the only real caller of `set_feasibility_callback` (`src/rectangle/reduction.cpp`) just forwards the callback value unchanged, so it needed no changes.